### PR TITLE
fix DAG storage correctness, performance, and robustness issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.settings
+*/target
+*.classpath
+*.project
+*.idea

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/entity/Work.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/entity/Work.java
@@ -4,7 +4,6 @@ import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.*;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Immutable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -16,7 +15,6 @@ import java.util.stream.IntStream;
 )
 @DiscriminatorColumn(name = "type")
 @DiscriminatorValue("node")
-@Immutable
 //cross test comparison could use sourceNodes and not have an activeNode?
 //custom post nodegroup actions could have sourceNodes without activeNode
 
@@ -83,6 +81,8 @@ public class Work  extends PanacheEntity implements Comparable<Work>{
             return false;
         }
         boolean activeNode = this.activeNode !=null && this.activeNode.dependsOn(work.activeNode);
+        // sameValue intentionally over-blocks: any shared source value forces ordering for safety.
+        // This may block unrelated work that happens to share a value — revisit if it causes bottlenecks.
         boolean sameValue = sourceValues.stream().anyMatch(v->work.sourceValues.contains(v));
         boolean dependentValue = sourceValues.stream().anyMatch(sourceValue ->
                 sourceValue.node.dependsOn(work.activeNode) && work.sourceValues.stream().anyMatch(sourceValue::dependsOn)) ;

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -101,7 +101,7 @@ public class NodeService {
     @Transactional
     public List<Node> getDependentNodes(Node n){
         List<Node> rtrn = Node.list("SELECT DISTINCT n FROM Node n JOIN n.sources s WHERE s.id = ?1",n.id);
-        rtrn.forEach(r->r.hashCode());//lazy hack
+        rtrn.forEach(r->r.sources.size()); // force lazy initialization of sources
         return rtrn;
     }
 

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -483,7 +483,7 @@ public class ValueService {
     @Transactional
     public Map<String,Value> getDescendantValueByPath(Value root,Node node){
         List<Value> found = getDescendantValues(root,node);
-        found.forEach(v->{v.hashCode();});//lazy hack
+        found.forEach(v->{ v.sources.size(); }); // force lazy initialization of sources
         return found.stream().collect(Collectors.toMap(Value::getPath,v->v));
     }
 

--- a/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
+++ b/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
@@ -103,5 +103,37 @@ public class NodeTest {
         assertTrue(n1.isCircular(),"n1 should be circular");
     }
 
+    @Test
+    public void dependsOn_deep_dag(){
+        Node first = new JqNode("n0",".");
+        Node prev = first;
+        for(int i = 1; i < 100; i++){
+            Node next = new JqNode("n"+i,".",prev);
+            prev = next;
+        }
+        Node last = prev;
+        assertTrue(last.dependsOn(first),"last node in a 100-deep chain should depend on first");
+        assertFalse(first.dependsOn(last),"first node should not depend on last");
+    }
+
+    @Test
+    public void dependsOn_diamond(){
+        Node a = new JqNode("a",".");
+        Node b = new JqNode("b",".",a);
+        Node c = new JqNode("c",".",a);
+        Node d = new JqNode("d",".",b,c);
+
+        assertTrue(d.dependsOn(a),"d should depend on a through both b and c");
+        assertTrue(d.dependsOn(b),"d should depend on b");
+        assertTrue(d.dependsOn(c),"d should depend on c");
+        assertFalse(a.dependsOn(d),"a should not depend on d");
+        assertFalse(b.dependsOn(c),"b should not depend on c");
+    }
+
+    @Test
+    public void dependsOn_null_source(){
+        Node n1 = new JqNode("n1",".");
+        assertFalse(n1.dependsOn(null),"dependsOn(null) should return false");
+    }
 
 }

--- a/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/ValueTest.java
+++ b/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/ValueTest.java
@@ -1,0 +1,58 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ValueTest {
+
+    private Value value(String name, Value... sources) {
+        Value v = new Value(null, new JqNode(name, "."));
+        v.sources = new ArrayList<>(List.of(sources));
+        return v;
+    }
+
+    @Test
+    public void dependsOn_deep_chain() {
+        Value first = value("v0");
+        Value prev = first;
+        for (int i = 1; i < 100; i++) {
+            Value next = value("v" + i, prev);
+            prev = next;
+        }
+        Value last = prev;
+        assertTrue(last.dependsOn(first), "last value in a 100-deep chain should depend on first");
+        assertFalse(first.dependsOn(last), "first value should not depend on last");
+    }
+
+    @Test
+    public void dependsOn_diamond() {
+        Value a = value("a");
+        Value b = value("b", a);
+        Value c = value("c", a);
+        Value d = value("d", b, c);
+
+        assertTrue(d.dependsOn(a), "d should depend on a through both b and c");
+        assertTrue(d.dependsOn(b), "d should depend on b");
+        assertTrue(d.dependsOn(c), "d should depend on c");
+        assertFalse(a.dependsOn(d), "a should not depend on d");
+        assertFalse(b.dependsOn(c), "b should not depend on c");
+    }
+
+    @Test
+    public void dependsOn_null_source() {
+        Value v = value("v1");
+        assertFalse(v.dependsOn(null), "dependsOn(null) should return false");
+    }
+
+    @Test
+    public void dependsOn_no_sources() {
+        Value a = value("a");
+        Value b = value("b");
+        assertFalse(a.dependsOn(b), "value with no sources should not depend on anything");
+    }
+}

--- a/h5m-core/src/test/java/io/hyperfoil/tools/h5m/queue/KahnDagSortTest.java
+++ b/h5m-core/src/test/java/io/hyperfoil/tools/h5m/queue/KahnDagSortTest.java
@@ -6,8 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class KahnDagSortTest {
 
@@ -50,6 +49,26 @@ public class KahnDagSortTest {
         assertTrue(sorted.indexOf(c) < sorted.indexOf(a),"c should be before a to preserve add order: "+sorted);
         assertTrue(sorted.indexOf(c) < sorted.indexOf(b),"c should be before b to preserve add order: "+sorted);
         assertTrue(sorted.indexOf(b) < sorted.indexOf(a),"b should be before a to preserve add order: "+sorted);
+    }
+
+    @Test
+    public void sort_throws_on_cycle(){
+        Item a = new Item("a");
+        Item b = new Item("b");
+        a.dependencies = new ArrayList<>(List.of(b));
+        b.dependencies = new ArrayList<>(List.of(a));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                KahnDagSort.sort(List.of(a, b), Item::getDependencies));
+    }
+
+    @Test
+    public void sort_throws_on_self_cycle(){
+        Item a = new Item("a");
+        a.dependencies = new ArrayList<>(List.of(a));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                KahnDagSort.sort(List.of(a), Item::getDependencies));
     }
 }
 

--- a/h5m-core/src/test/resources/application.properties
+++ b/h5m-core/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.hibernate-orm.database.generation = drop-and-create


### PR DESCRIPTION
- KahnDagSort: replace PriorityQueue with ArrayDeque in isCircular(), add visited set to prevent infinite loops, throw on cycles in sort() instead of silently accepting, return ArrayList instead of COW list
- Node.dependsOn(): convert recursive DFS to iterative BFS with visited set, preventing StackOverflowError and exponential blowup on diamonds
- Node.hashCode(): remove expensive List.copyOf(sources) allocation
- Value.dependsOn(): add visited set to prevent exponential re-visiting
- Work: remove @Immutable so retryCount mutations persist correctly
- WorkQueue: replace CopyOnWriteArrayList with ArrayList (already under lock), optimize getScore() to short-circuit and use pendingWork set
- Add unique constraints on node_edge and value_edge join tables
- Add tests for cycle detection and BFS edge cases
- Replace hashCode() lazy initialization hacks in NodeService and ValueService with explicit sources.size() calls, since hashCode() no longer accesses the sources collection
- Add test application.properties with drop-and-create schema strategy to prevent stale SQLite columns from breaking tests