### PR TITLE
Switch to self-contained `jq4j`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Build and test
         run: mvn -B clean verify
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,9 +18,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Build and test
         run: mvn -B clean verify
 

--- a/h5m-core/pom.xml
+++ b/h5m-core/pom.xml
@@ -79,6 +79,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.roastedroot</groupId>
+            <artifactId>jq4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>io.roastedroot</groupId>
+                <artifactId>jq4j</artifactId>
+                <version>0.0.2</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>2.19.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
             <dependency>
                 <groupId>io.roastedroot</groupId>
                 <artifactId>jq4j</artifactId>
-                <version>999-SNAPSHOT</version>
+                <version>0.0.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
             <dependency>
                 <groupId>io.roastedroot</groupId>
                 <artifactId>jq4j</artifactId>
-                <version>0.0.2</version>
+                <version>999-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Switches `calculateJqValues()` from forking `/usr/bin/jq` via `ProcessBuilder` to using `jq4j`, which runs `jq` as a WASM module inside the JVM.                                                       
                                                            
  - No external `jq` binary required
  - No temp files
  - Removes "Install jq" step from CI workflows

  Existing `NodeServiceTest.calculateJqValues*` tests pass unchanged.