### PR TITLE
Replace external jq binary with jackson-jq for in-process filter eval…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Build and test
         run: mvn -B clean verify
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,9 +18,6 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
 
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Build and test
         run: mvn -B clean verify
 

--- a/docs/design/fingerprint-redesign.md
+++ b/docs/design/fingerprint-redesign.md
@@ -90,10 +90,10 @@ public void setFingerprintFilter(String filter) {
 
 **`h5m-core/.../svc/NodeService.java`**
 - Add helper method `evaluateFingerprintFilter(String filter, JsonNode fingerprint)`:
-  - Pipes the fingerprint JSON through `jq --exit-status '<filter>'` via ProcessBuilder
-  - Returns `true` if exit code is 0 (truthy output), `false` if exit code is 1 (falsy) or non-zero
+  - Evaluates the fingerprint JSON through the jq filter expression using jackson-jq (in-process, no external binary)
+  - Returns `true` if the filter produces a truthy output (`true`, non-null, non-empty), `false` otherwise
   - Returns `true` if filter is null/empty (no filter = pass all)
-  - Follows the same ProcessBuilder pattern as `calculateJqValues()` (~line 848)
+  - Uses the same `compileJq()` caching and `JQ_SCOPE` pattern as `calculateJqValues()`
 - Modify `calculateRelativeDifferenceValues()` (~line 287):
   - After getting `fingerprintValues` list, before the loop that processes each fingerprint:
   - Get the filter: `String fpFilter = node.getFingerprintFilter();`

--- a/h5m-core/pom.xml
+++ b/h5m-core/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>JSONata4Java</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.thisptr</groupId>
+            <artifactId>jackson-jq</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.hyperfoil.tools</groupId>
             <artifactId>yaup-core</artifactId>
         </dependency>

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/entity/node/JqNode.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/entity/node/JqNode.java
@@ -92,7 +92,8 @@ public class JqNode extends Node {
     }
     //detect if the jq command is processing the inputs together
     public static boolean isNullInput(String command){
-        return command.matches("(?<!\\.)[^.]*inputs.*");//^(?<!\.)inputs
+        // Match the jq builtin `inputs` as a standalone word, but not `.inputs` (field access)
+        return command.matches(".*(?<!\\.)\\binputs\\b.*");
     }
 
     @Override

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -4,8 +4,6 @@ import com.api.jsonata4java.expressions.EvaluateException;
 import com.api.jsonata4java.expressions.EvaluateRuntimeException;
 import com.api.jsonata4java.expressions.Expressions;
 import com.api.jsonata4java.expressions.ParseException;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -29,14 +27,21 @@ import org.graalvm.polyglot.proxy.Proxy;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.hibernate.Session;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
+import net.thisptr.jackson.jq.BuiltinFunctionLoader;
+import net.thisptr.jackson.jq.Expression;
+import net.thisptr.jackson.jq.Function;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.PathOutput;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.Version;
+import net.thisptr.jackson.jq.Versions;
+import net.thisptr.jackson.jq.exception.JsonQueryException;
+import net.thisptr.jackson.jq.path.Path;
+
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.PreparedStatement;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.DoubleBinaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,6 +49,23 @@ import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class NodeService {
+
+    private static final Scope JQ_SCOPE;
+    private static final ConcurrentHashMap<String, JsonQuery> JQ_CACHE = new ConcurrentHashMap<>();
+    static {
+        JQ_SCOPE = Scope.newEmptyScope();
+        BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_6, JQ_SCOPE);
+    }
+
+    private static JsonQuery compileJq(String filter) throws JsonQueryException {
+        JsonQuery cached = JQ_CACHE.get(filter);
+        if (cached != null) {
+            return cached;
+        }
+        JsonQuery compiled = JsonQuery.compile(filter, Versions.JQ_1_6);
+        JQ_CACHE.put(filter, compiled);
+        return compiled;
+    }
 
     @Inject
     EntityManager em;
@@ -847,119 +869,92 @@ public class NodeService {
     @Transactional
     public List<Value> calculateJqValues(JqNode node,Map<String,Value> sourceValues,int startingOrdinal) throws IOException {
         List<Value> rtrn = new ArrayList<>();
-        List<String> args = new ArrayList<>();
-        List<File> paths = new ArrayList<>();
-        File tmpFilter = Files.createTempFile("h5m.jq." + node.name,".txt").toFile();
-        tmpFilter.deleteOnExit();
-        Files.write(tmpFilter.toPath(),node.operation.getBytes());
 
-        args.addAll(List.of(
-                "/usr/bin/jq",
-                "--from-file",
-                tmpFilter.toPath().toAbsolutePath().toString()
-        ));
-        if ( JqNode.isNullInput(node.operation)){
-            args.add("--null-input");
-        }else if(node.sources.size()>1 || sourceValues.size() >1){//if this is a multi file input
-            args.add("--slurp");
+        // Compile the jq filter expression
+        JsonQuery query;
+        try {
+            query = compileJq(node.operation);
+        } catch (JsonQueryException e) {
+            System.err.println("Error compiling jq filter for node " + node.id + " " + node.name + ": " + e.getMessage());
+            return rtrn;
         }
 
-        args.add("--compact-output");
-        args.add("--");//terminate argument processing
-        //iterate sources to preserve order
-        //another CME while iterating an entity collection, who is mutating these nodes?
-        List.copyOf(node.sources).forEach(sourceNode -> {
-            if(sourceValues.containsKey(sourceNode.name)){
-                try {
-                    Value sourceValue = sourceValues.get(sourceNode.name);
-                    File f = Files.createTempFile("h5m."+sourceNode.name,".json").toFile();
-                    valueService.writeToFile(sourceValue.id,f.getAbsolutePath());
-                    paths.add(f);
-                    args.add(f.getAbsolutePath());
-                }catch(IOException e){
-                    System.err.println("failed to create temporary file for "+sourceNode.name+"\n"+e.getMessage());
-                }
-
-            }
-        });
-        //if there are no sources we just add all the inputs together
-        if(node.sources.isEmpty()){
-            sourceValues.values().forEach(sourceValue -> {
-                try {
-                    File f = Files.createTempFile("h5m.", ".json").toFile();
-                    valueService.writeToFile(sourceValue.id, f.getAbsolutePath());
-                    paths.add(f);
-                    args.add(f.getAbsolutePath());
-                }catch(IOException e){
-                    System.err.println("failed to create temporary file\n"+e.getMessage());
+        // Collect source data in order, preserving node.sources ordering
+        List<JsonNode> sourceData = new ArrayList<>();
+        if (!node.sources.isEmpty()) {
+            List.copyOf(node.sources).forEach(sourceNode -> {
+                if (sourceValues.containsKey(sourceNode.name)) {
+                    sourceData.add(sourceValues.get(sourceNode.name).data);
                 }
             });
-
-        }
-        Path destinationPath = Files.createTempFile(".h5m." + node.name+".",".out");//getOutPath().resolve(name + "." + startingOrdinal);
-        destinationPath.toFile().deleteOnExit();
-        ProcessBuilder processBuilder = new ProcessBuilder(args);
-        processBuilder.environment().put("TERM", "xterm");
-        //processBuilder.directory(getJqPath().resolve(name).toFile()); //not yet creating the working directory
-        processBuilder.redirectOutput(destinationPath.toFile());
-        //processBuilder.redirectErrorStream(true);
-        Process p = processBuilder.start();
-        String line = null;
-        StringBuilder err = new StringBuilder();
-        try (BufferedReader reader = p.errorReader()) {
-            while ((line = reader.readLine()) != null) {
-                //TODO handle error output from process
-                err.append(line);
-                err.append(System.lineSeparator());
-            }
-        }
-        try (BufferedReader reader = p.inputReader()) {
-            while ((line = reader.readLine()) != null) {
-                err.append(line);
-                err.append(System.lineSeparator());
-                //TODO handle output that somehow wasn't redirected
-            }
-        }
-        if(!err.isEmpty()){
-            System.err.println("Error processing "+node.id+" "+node.name+"\n  values: "+sourceValues.entrySet().stream().map(e->e.getKey()+"="+e.getValue().id).collect(Collectors.joining(", "))+"\n"+err);
-        }
-        //TODO use onExit instead of blocking the thread?
-        try {
-            p.waitFor();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-        int ec = p.exitValue();
-        if (ec != 0) {
-            //TODO handle failed jq
         } else {
-            int order = startingOrdinal;
-            //create a token from each root
-            File f = destinationPath.toFile();
-            try (FileInputStream fis = new FileInputStream(f)) {
-                JsonFactory jf = new JsonFactory();
-                JsonParser jp = jf.createParser(fis);
-                jp.setCodec(new ObjectMapper());
-                jp.nextToken();
-                while (jp.hasCurrentToken()) {
-                    JsonNode jsNode = jp.readValueAsTree();
-                    if(!jsNode.isNull()){
-                        Value newValue = new Value();
-                        newValue.idx = order++;
-                        newValue.node = node;
-                        newValue.data = jsNode;
-                        newValue.sources = node.sources.stream().filter(n -> sourceValues.containsKey(n.name)).map(n -> sourceValues.get(n.name)).collect(Collectors.toList());
-                        rtrn.add(newValue);
-                    }
-                    jp.nextToken();
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            sourceValues.values().forEach(sourceValue -> sourceData.add(sourceValue.data));
         }
 
-        //remove temporary files
-        paths.forEach(File::delete);
+        // Determine jq mode and build input, mirroring how jq processes a JSONL stream:
+        //   --null-input:  . is null, sources accessible only via inputs/input
+        //   --slurp:       all sources combined into a single array
+        //   default:       filter runs on the single source value
+        boolean isNullInput = JqNode.isNullInput(node.operation);
+        boolean isSlurp = !isNullInput && (node.sources.size() > 1 || sourceValues.size() > 1);
+
+        JsonNode input;
+        if (isNullInput) {
+            input = NullNode.getInstance();
+        } else if (isSlurp) {
+            ObjectMapper mapper = new ObjectMapper();
+            ArrayNode slurped = mapper.createArrayNode();
+            sourceData.forEach(slurped::add);
+            input = slurped;
+        } else {
+            input = !sourceData.isEmpty() ? sourceData.getFirst() : NullNode.getInstance();
+        }
+
+        // Register custom inputs/input builtins so null-input filters can read the source stream
+        Scope childScope = Scope.newChildScope(JQ_SCOPE);
+        if (isNullInput) {
+            childScope.addFunction("inputs", 0, (Scope scope, List<Expression> args, JsonNode in,
+                                                  Path ipath, PathOutput output, Version version) -> {
+                for (JsonNode data : sourceData) {
+                    output.emit(data, null);
+                }
+            });
+            childScope.addFunction("input", 0, new Function() {
+                private int index = 0;
+                @Override
+                public void apply(Scope scope, List<Expression> args, JsonNode in,
+                                  Path ipath, PathOutput output, Version version) throws JsonQueryException {
+                    if (index < sourceData.size()) {
+                        output.emit(sourceData.get(index++), null);
+                    }
+                }
+            });
+        }
+        try {
+            int order = startingOrdinal;
+            List<JsonNode> results = new ArrayList<>();
+            query.apply(childScope, input, results::add);
+
+            for (JsonNode jsNode : results) {
+                if (!jsNode.isNull()) {
+                    Value newValue = new Value();
+                    newValue.idx = order++;
+                    newValue.node = node;
+                    newValue.data = jsNode;
+                    newValue.sources = node.sources.stream()
+                            .filter(n -> sourceValues.containsKey(n.name))
+                            .map(n -> sourceValues.get(n.name))
+                            .collect(Collectors.toList());
+                    rtrn.add(newValue);
+                }
+            }
+        } catch (JsonQueryException e) {
+            System.err.println("Error processing " + node.id + " " + node.name
+                    + "\n  values: " + sourceValues.entrySet().stream()
+                    .map(entry -> entry.getKey() + "=" + entry.getValue().id)
+                    .collect(Collectors.joining(", "))
+                    + "\n" + e.getMessage());
+        }
 
         return rtrn;
     }

--- a/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/h5m-core/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -18,9 +18,6 @@ import java.io.*;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -531,34 +528,6 @@ public class ValueService {
         return Value.find("node.id",node.id).list();
     }
 
-
-    //TODO concerned about writeToFile using "'s to wrap strings
-    //TODO have write to file return the filePath instead of accepting it as an argument
-    @Transactional
-    public void writeToFile(long valueId,String filePath){
-        Session session = em.unwrap(Session.class);
-        session.doWork(conn -> {
-            try(PreparedStatement statement = conn.prepareStatement("select data from value where id=?")){
-                statement.setLong(1,valueId);
-                try(ResultSet rs = statement.executeQuery()){
-                    if(rs.next()) {
-                        try (InputStream inputStream = rs.getBinaryStream(1);
-                             OutputStream outputStream = new FileOutputStream(filePath)) {
-
-                            long bytesCopied = inputStream.transferTo(outputStream);
-                            if (bytesCopied < 1) {
-                                System.err.println("failed to transfer data for value=" + valueId);
-                            }
-                        } catch (IOException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
-                }
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-        });
-    }
 
     @Transactional
     public int deleteDescendantValues(Value root,Node node){

--- a/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/node/JqNodeTest.java
+++ b/h5m-core/src/test/java/io/hyperfoil/tools/h5m/entity/node/JqNodeTest.java
@@ -11,7 +11,12 @@ public class JqNodeTest {
     @Test
     public void isNullInput(){
         assertTrue(JqNode.isNullInput("[inputs]"),"treating all inputs as an array should be a null input");
+        assertTrue(JqNode.isNullInput("inputs"),"bare inputs should be a null input");
+        assertTrue(JqNode.isNullInput("[inputs | .foo]"),"inputs in a pipeline should be a null input");
         assertFalse(JqNode.isNullInput(".inputs"),"accessing the inputs key should not trigger null input");
+        assertFalse(JqNode.isNullInput(".foo.inputs"),"nested field access should not trigger null input");
+        assertFalse(JqNode.isNullInput("myinputs"),"inputs as substring of another word should not trigger null input");
+        assertFalse(JqNode.isNullInput("inputstream"),"inputs prefix of another word should not trigger null input");
     }
 
 

--- a/h5m-core/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/h5m-core/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -18,9 +18,6 @@ import org.hibernate.LazyInitializationException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,27 +31,6 @@ public class ValueServiceTest extends FreshDb {
     @Inject
     TransactionManager tm;
 
-
-    @Test
-    public void writeToFile_string() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
-        tm.begin();
-        Node rootNode = new RootNode();
-        rootNode.persist();
-        Value rootValue = new Value(null,rootNode,new TextNode("a"));
-        rootValue.persist();
-        tm.commit();
-
-        File f = Files.createTempFile("h5m-test", ".writeToFile").toFile();
-        f.deleteOnExit();
-        valueService.writeToFile(rootValue.id,f.getAbsolutePath());
-
-        String content = Files.readString(f.toPath());
-
-        assertNotNull(content);
-        assertTrue(content.contains("a"));
-        assertEquals("\"a\"", content);
-        //TODO should string content include the quotes?
-    }
 
     @Test
     public void delete_does_not_cascade_and_delete_ancestor() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
                 <artifactId>JSONata4Java</artifactId>
                 <version>2.6.1</version>
             </dependency>
+            <dependency>
+                <groupId>net.thisptr</groupId>
+                <artifactId>jackson-jq</artifactId>
+                <version>1.6.0</version>
+            </dependency>
             <!-- DuckDB JDBC Driver -->
             <dependency>
                 <groupId>org.duckdb</groupId>


### PR DESCRIPTION
…uation

Replaces ProcessBuilder/temp-file jq invocation with jackson-jq (net.thisptr:jackson-jq:1.6.0), a pure Java jq implementation built on Jackson. This eliminates the system dependency on an installed jq binary, removes process forking and file I/O overhead, and simplifies CI workflows.

- Add jackson-jq dependency to parent and h5m-core pom.xml
- Rewrite NodeService.calculateJqValues() to use JsonQuery.compile/apply in-process
- Add JsonQuery compilation cache (ConcurrentHashMap) to avoid redundant compilations
- Harden isNullInput() regex with word boundaries to avoid false matches
- Harden inputs/[inputs] string replacement with regex word boundaries
- Remove dead ValueService.writeToFile() and its test (only used by old ProcessBuilder approach)
- Remove unused imports from ValueService, ValueServiceTest, NodeService
- Remove 'Install jq' step from CI and pull-request workflows
- Update README and design docs to reflect in-process jq evaluation