### PR TITLE
Fix LazyInitializationException for Value.data across transaction bou…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -249,6 +249,18 @@ public class NodeService {
      */
     @Transactional
     public List<Value> calculateValues(Node node, List<Value> roots) throws IOException {
+        // Re-attach any detached root values to the current persistence context
+        // so that lazy fields (e.g. Value.data) can be loaded within this session
+        List<Value> managedRoots = new ArrayList<>(roots.size());
+        for (int i = 0; i < roots.size(); i++) {
+            Value root = roots.get(i);
+            if (root.id != null && !em.contains(root)) {
+                managedRoots.add(em.find(Value.class, root.id));
+            } else {
+                managedRoots.add(root);
+            }
+        }
+        roots = managedRoots;
         List<Value> rtrn = new ArrayList<>();
         switch (node.type){
             //nodes that operate one root at a time

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.hibernate.Hibernate;
 import org.hibernate.Session;
 import org.hibernate.query.NativeQuery;
 
@@ -486,6 +487,10 @@ public class ValueService {
                     "SELECT DISTINCT v FROM Value v LEFT JOIN FETCH v.sources WHERE v IN :values",
                     Value.class
             ).setParameter("values", found).getResultList();
+            // Initialize lazy data field while session is still open
+            for (int i = 0; i < found.size(); i++) {
+                Hibernate.initialize(found.get(i).data);
+            }
         }
         return found.stream().collect(Collectors.toMap(Value::getPath,v->v));
     }


### PR DESCRIPTION
…ndaries

WorkRunner is not a CDI bean so its @Transactional is ignored, causing detached entities to lose their session. Re-attach root values in NodeService.calculateValues() and initialize lazy data field in ValueService.getDescendantValueByPath() before the transaction commits.