### PR TITLE
Add FixedThreshold change detection for static min/max bounds

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
@@ -17,6 +17,7 @@ import java.util.concurrent.Callable;
         AddSqlJsonpathAll.class,
         AddSplit.class,
         AddRelativeDifference.class,
+        AddFixedThreshold.class,
     }
 )
 public class AddCmd implements Callable<Integer> {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
@@ -1,0 +1,150 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
+import io.hyperfoil.tools.h5m.entity.node.FingerprintNode;
+import io.hyperfoil.tools.h5m.entity.node.FixedThreshold;
+import io.hyperfoil.tools.h5m.svc.NodeGroupService;
+import io.hyperfoil.tools.h5m.svc.NodeService;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+@CommandLine.Command(name = "fixedthreshold", separator = " ", description = "add a fixed threshold node", mixinStandardHelpOptions = true)
+public class AddFixedThreshold implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"to"}, description = "target group / test") String groupName;
+
+    @CommandLine.Option(names = {"range"}, arity = "1", description = "node that produces the value to inspect")
+    String rangeName;
+
+    @CommandLine.Option(names = {"by"}, description = "grouping node", arity = "0..1")
+    public String groupBy;
+
+    @CommandLine.Option(names = {"fingerprint"}, description = "node names to use as fingerprint")
+    List<String> fingerprints;
+
+    @CommandLine.Option(names = {"--fingerprint-filter", "-ff"}, arity = "0..1", description = "jq filter expression for fingerprints")
+    String fingerprintFilter;
+
+    @CommandLine.Option(names = {"min"}, arity = "0..1", description = "minimum threshold value")
+    Double min;
+
+    @CommandLine.Option(names = {"max"}, arity = "0..1", description = "maximum threshold value")
+    Double max;
+
+    @CommandLine.Option(names = {"min-inclusive"}, arity = "0..1", description = "whether min boundary value is within range", defaultValue = "true")
+    boolean minInclusive;
+
+    @CommandLine.Option(names = {"max-inclusive"}, arity = "0..1", description = "whether max boundary value is within range", defaultValue = "true")
+    boolean maxInclusive;
+
+    @CommandLine.Parameters(index = "0", arity = "1", description = "node name") String name;
+
+    @Inject
+    NodeGroupService nodeGroupService;
+
+    @Inject
+    NodeService nodeService;
+
+    @Override
+    public Integer call() throws Exception {
+        if (name == null || name.isEmpty()) {
+            System.err.println("missing node name");
+            return 1;
+        }
+        if (groupName == null || groupName.isEmpty()) {
+            System.err.println("missing group name");
+            return 1;
+        }
+        NodeGroupEntity foundGroup = nodeGroupService.byName(groupName);
+        if (foundGroup == null) {
+            System.err.println("node group with name " + groupName + " does not exist");
+            return 1;
+        }
+
+        List<NodeEntity> foundNodes = nodeService.findNodeByFqdn(name, foundGroup.id);
+        if (!foundNodes.isEmpty()) {
+            System.err.println(groupName + " already has " + name + " node(s)\n  " + foundNodes.stream().map(NodeEntity::getFqdn).collect(Collectors.joining("\n  ")));
+        }
+
+        if (rangeName == null || rangeName.isEmpty()) {
+            System.err.println("Missing range");
+            return 1;
+        }
+        foundNodes = nodeService.findNodeByFqdn(rangeName, foundGroup.id);
+        if (foundNodes.isEmpty()) {
+            System.err.println("could not find matching range node by name " + rangeName);
+            return 1;
+        } else if (foundNodes.size() > 1) {
+            System.err.println("found more than one matching range node by name " + rangeName + "\n  " + foundNodes.stream().map(NodeEntity::getFqdn).collect(Collectors.joining("\n  ")));
+            return 1;
+        }
+        NodeEntity rangeNode = foundNodes.getFirst();
+
+        NodeEntity groupByNode = null;
+        if (groupBy != null && !groupBy.isEmpty()) {
+            foundNodes = nodeService.findNodeByFqdn(groupBy, foundGroup.id);
+            if (foundNodes.isEmpty()) {
+                System.err.println("could not find matching group by node with name" + groupBy);
+                return 1;
+            } else if (foundNodes.size() > 1) {
+                System.err.println("found more than one matching group by node for name " + groupBy + "\n  " + foundNodes.stream().map(NodeEntity::getFqdn).collect(Collectors.joining("\n  ")));
+                return 1;
+            }
+            groupByNode = foundNodes.getFirst();
+        }
+        if (groupByNode == null) {
+            groupByNode = foundGroup.root;
+        }
+
+        List<NodeEntity> fingerprintNodes = new ArrayList<>();
+        if (fingerprints != null && !fingerprints.isEmpty()) {
+            List<String> fingerprintNames = fingerprints.stream().flatMap(fp -> Arrays.stream(fp.split(","))).map(String::trim).filter(v -> !v.isBlank()).toList();
+            for (String fingerprintName : fingerprintNames) {
+                foundNodes = nodeService.findNodeByFqdn(fingerprintName, foundGroup.id);
+                if (foundNodes.isEmpty()) {
+                    System.err.println("could not find matching fingerprint node by name " + fingerprintName);
+                    return 1;
+                } else if (foundNodes.size() > 1) {
+                    System.err.println("found more than one matching fingerprint node by name " + fingerprintName + "\n  " + foundNodes.stream().map(NodeEntity::getFqdn).collect(Collectors.joining("\n  ")));
+                    return 1;
+                }
+                fingerprintNodes.add(foundNodes.getFirst());
+            }
+        }
+        FingerprintNode fingerprintNode = new FingerprintNode("_fp-" + name, "", fingerprintNodes);
+        fingerprintNode.group = foundGroup;
+
+        FixedThreshold fixedThreshold = new FixedThreshold();
+        fixedThreshold.name = name;
+        fixedThreshold.group = foundGroup;
+        List<NodeEntity> sources = new ArrayList<>();
+        sources.add(fingerprintNode);
+        sources.add(groupByNode);
+        sources.add(rangeNode);
+        fixedThreshold.sources = sources;
+
+        if (min != null) {
+            fixedThreshold.setMin(min);
+        }
+        if (max != null) {
+            fixedThreshold.setMax(max);
+        }
+        fixedThreshold.setMinInclusive(minInclusive);
+        fixedThreshold.setMaxInclusive(maxInclusive);
+
+        if (fingerprintFilter != null && !fingerprintFilter.isBlank()) {
+            fixedThreshold.setFingerprintFilter(fingerprintFilter);
+        }
+
+        NodeEntity created = nodeService.create(fixedThreshold);
+
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
@@ -1,0 +1,156 @@
+package io.hyperfoil.tools.h5m.entity.node;
+
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.yaup.json.Json;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.Transient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@DiscriminatorValue("ft")
+public class FixedThreshold extends NodeEntity {
+
+    private static final String MIN = "min";
+    private static final String MAX = "max";
+    private static final String MIN_INCLUSIVE = "minInclusive";
+    private static final String MAX_INCLUSIVE = "maxInclusive";
+    private static final String FINGERPRINT_FILTER = "fingerprintFilter";
+
+    public enum ViolationType {
+        ABOVE("above"),
+        BELOW("below");
+
+        private final String label;
+
+        ViolationType(String label) {
+            this.label = label;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
+
+    @Transient
+    private Json config;
+
+    public FixedThreshold() {
+        config = new Json();
+    }
+
+    public FixedThreshold(String name, String operation) {
+        super(name, operation);
+        config = new Json();
+    }
+
+    @PostLoad
+    public void loadConfig() {
+        if (this.config == null || this.config.isEmpty()) {
+            if (this.operation != null && !this.operation.isBlank()) {
+                config = Json.fromString(this.operation);
+            } else {
+                config = new Json();
+            }
+        }
+    }
+
+    public void setNodes(NodeEntity fingerprint, NodeEntity groupBy, NodeEntity range) {
+        List<NodeEntity> sources = new ArrayList<>();
+        sources.add(fingerprint);
+        sources.add(groupBy);
+        sources.add(range);
+        this.sources = sources;
+    }
+
+    @Transient
+    public NodeEntity getFingerprintNode() {
+        return sources.get(0);
+    }
+
+    @Transient
+    public NodeEntity getGroupByNode() {
+        return sources.get(1);
+    }
+
+    @Transient
+    public NodeEntity getRangeNode() {
+        return sources.get(2);
+    }
+
+    @Transient
+    public double getMin() {
+        Object val = config.get(MIN);
+        if (val instanceof Number) {
+            return ((Number) val).doubleValue();
+        }
+        return Double.NaN;
+    }
+
+    public void setMin(double min) {
+        config.set(MIN, min);
+        operation = config.toString();
+    }
+
+    @Transient
+    public double getMax() {
+        Object val = config.get(MAX);
+        if (val instanceof Number) {
+            return ((Number) val).doubleValue();
+        }
+        return Double.NaN;
+    }
+
+    public void setMax(double max) {
+        config.set(MAX, max);
+        operation = config.toString();
+    }
+
+    @Transient
+    public boolean isMinEnabled() {
+        return config.has(MIN);
+    }
+
+    @Transient
+    public boolean isMaxEnabled() {
+        return config.has(MAX);
+    }
+
+    @Transient
+    public boolean isMinInclusive() {
+        return config.getBoolean(MIN_INCLUSIVE, true);
+    }
+
+    public void setMinInclusive(boolean minInclusive) {
+        config.set(MIN_INCLUSIVE, minInclusive);
+        operation = config.toString();
+    }
+
+    @Transient
+    public boolean isMaxInclusive() {
+        return config.getBoolean(MAX_INCLUSIVE, true);
+    }
+
+    public void setMaxInclusive(boolean maxInclusive) {
+        config.set(MAX_INCLUSIVE, maxInclusive);
+        operation = config.toString();
+    }
+
+    @Transient
+    public String getFingerprintFilter() {
+        return config.getString(FINGERPRINT_FILTER);
+    }
+
+    public void setFingerprintFilter(String fingerprintFilter) {
+        config.set(FINGERPRINT_FILTER, fingerprintFilter);
+        operation = config.toString();
+    }
+
+    @Override
+    protected NodeEntity shallowCopy() {
+        return new FixedThreshold(name, operation);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -282,6 +282,13 @@ public class NodeService {
                     rtrn.addAll(found);
                 }
                 break;
+            case "ft":
+                FixedThreshold ft = (FixedThreshold) node;
+                for(int rIdx=0; rIdx<roots.size(); rIdx++){
+                    ValueEntity root =  roots.get(rIdx);
+                    rtrn.addAll(calculateFixedThresholdValues(ft,root,rtrn.size()));
+                }
+                break;
             default:
                 System.err.println("calculateValues unknown node type: " + node.type);
         }
@@ -451,6 +458,79 @@ public class NodeService {
                 }
             }
         }catch (Exception e){
+            e.printStackTrace();
+        }
+        return rtrn;
+    }
+
+    @Transactional
+    public List<ValueEntity> calculateFixedThresholdValues(FixedThreshold ft, ValueEntity root, int startingOrdinal) throws IOException {
+        List<ValueEntity> rtrn = new ArrayList<>();
+        try {
+            NodeEntity groupBy = NodeEntity.findById(ft.getGroupByNode().getId());
+            List<ValueEntity> fingerprintValues = valueService.getDescendantValues(root, ft.getFingerprintNode());
+            String fpFilter = ft.getFingerprintFilter();
+
+            // Check fingerprint filter — if all fingerprints are filtered out, skip this root
+            JsonNode fingerprintData = null;
+            for (int fIdx = 0; fIdx < fingerprintValues.size(); fIdx++) {
+                ValueEntity fingerprintValue = fingerprintValues.get(fIdx);
+                if (fpFilter != null && !evaluateFingerprintFilter(fpFilter, fingerprintValue.data)) {
+                    continue;
+                }
+                fingerprintData = fingerprintValue.data;
+                break;
+            }
+            if (fingerprintData == null) {
+                return rtrn;
+            }
+
+            // Get range values scoped to this root only
+            List<ValueEntity> rangeValues = valueService.getDescendantValues(root, ft.getRangeNode());
+            for (int rIdx = 0; rIdx < rangeValues.size(); rIdx++) {
+                ValueEntity rangeValue = rangeValues.get(rIdx);
+                Double numericValue;
+                if (rangeValue.data instanceof NumericNode numericNode) {
+                    numericValue = numericNode.asDouble();
+                } else if (rangeValue.data.toString().matches("[0-9]+\\.?[0-9]*")) {
+                    numericValue = Double.parseDouble(rangeValue.data.toString());
+                } else {
+                    continue;
+                }
+
+                FixedThreshold.ViolationType violationType = null;
+                double bound = Double.NaN;
+
+                if (ft.isMinEnabled()) {
+                    if (ft.isMinInclusive() ? numericValue < ft.getMin() : numericValue <= ft.getMin()) {
+                        violationType = FixedThreshold.ViolationType.BELOW;
+                        bound = ft.getMin();
+                    }
+                }
+                if (violationType == null && ft.isMaxEnabled()) {
+                    if (ft.isMaxInclusive() ? numericValue > ft.getMax() : numericValue >= ft.getMax()) {
+                        violationType = FixedThreshold.ViolationType.ABOVE;
+                        bound = ft.getMax();
+                    }
+                }
+
+                if (violationType != null) {
+                    ObjectMapper mapper = new ObjectMapper();
+                    ObjectNode data = mapper.createObjectNode();
+                    data.set("value", new DoubleNode(numericValue));
+                    data.set("bound", new DoubleNode(bound));
+                    data.put("direction", violationType.label());
+                    data.set("fingerprint", fingerprintData);
+                    ValueEntity changeValue = new ValueEntity(root.folder, ft, data);
+                    changeValue.idx = startingOrdinal;
+                    List<ValueEntity> foundParents = valueService.getAncestor(root, groupBy);
+                    if (foundParents.size() == 1) {
+                        changeValue.sources = foundParents;
+                    }
+                    rtrn.add(changeValue);
+                }
+            }
+        } catch (Exception e) {
             e.printStackTrace();
         }
         return rtrn;

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
@@ -609,6 +609,56 @@ public class H5mTest {
         assertTrue(result.getOutput().contains("Count: 8"));
     }
     @Test
+    public void calculate_fixedthreshold_node(QuarkusMainLauncher launcher) throws IOException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        Path folder = Files.createTempDirectory("h5m");
+        // value 5.0 is below min=10
+        Path filePath01 = Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "y": 5.0, "fp1": "alpha"
+                }
+                """
+        );
+        // value 50.0 is within [10, 100]
+        Path filePath02 = Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "y": 50.0, "fp1": "alpha"
+                }
+                """
+        );
+        // value 150.0 is above max=100
+        Path filePath03 = Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "y": 150.0, "fp1": "alpha"
+                }
+                """
+        );
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "rangeNode", ".y"},
+                new String[]{"add", "jq", "to", testName, "fp1", ".fp1"},
+                new String[]{"list", testName, "nodes"},
+                new String[]{"add", "fixedthreshold", "ftNode", "to", testName, "range", "rangeNode", "fingerprint", "fp1", "min", "10", "max", "100"},
+                new String[]{"list", testName, "nodes"},
+                new String[]{"upload", folder.toString(), "to", testName},
+                new String[]{"list", "value", "from", testName}
+        );
+        results.forEach(result -> {
+            assertEquals(0, result.exitCode(), result.getOutput());
+        });
+
+        LaunchResult last = results.getLast();
+        // 3 rangeNode values + 3 fp1 values + 3 _fp-ftNode values + 2 fixedthreshold violations = 11
+        assertTrue(last.getOutput().contains("Count: 11"), "expect 11 values from test\n" + last.getOutput());
+    }
+
+    @Test
     public void list_values_as_table(QuarkusMainLauncher launcher) throws IOException {
         String testName = StackWalker.getInstance()
                 .walk(s -> s.skip(0).findFirst())

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -1028,4 +1028,243 @@ public class NodeServiceTest extends FreshDb {
         assertTrue(armWithX86Filter.isEmpty(),
             "arm root with x86 filter should produce no results but found " + armWithX86Filter.size());
     }
+
+    @Test
+    public void calculateFixedThreshold_basic_violations() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity rangeNode = new JqNode("range", ".y", rootNode);
+        rangeNode.persist();
+        NodeEntity fingerprintNode = new JqNode("fingerprint", ".fingerprint", rootNode);
+        fingerprintNode.persist();
+
+        // Create 3 root values with range values [5.0, 50.0, 150.0]
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("root1"));
+        root1.persist();
+        ValueEntity root2 = new ValueEntity(null, rootNode, new TextNode("root2"));
+        root2.persist();
+        ValueEntity root3 = new ValueEntity(null, rootNode, new TextNode("root3"));
+        root3.persist();
+
+        ValueEntity range1 = new ValueEntity(null, rangeNode, DoubleNode.valueOf(5.0));
+        range1.sources = List.of(root1);
+        range1.persist();
+        ValueEntity range2 = new ValueEntity(null, rangeNode, DoubleNode.valueOf(50.0));
+        range2.sources = List.of(root2);
+        range2.persist();
+        ValueEntity range3 = new ValueEntity(null, rangeNode, DoubleNode.valueOf(150.0));
+        range3.sources = List.of(root3);
+        range3.persist();
+
+        // Fingerprint values
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode fpData = mapper.createObjectNode();
+        fpData.put("env", "test");
+        ValueEntity fp1 = new ValueEntity(null, fingerprintNode, fpData);
+        fp1.sources = List.of(root1);
+        fp1.persist();
+        ValueEntity fp2 = new ValueEntity(null, fingerprintNode, fpData);
+        fp2.sources = List.of(root2);
+        fp2.persist();
+        ValueEntity fp3 = new ValueEntity(null, fingerprintNode, fpData);
+        fp3.sources = List.of(root3);
+        fp3.persist();
+        tm.commit();
+
+        // Create FixedThreshold with min=10, max=100, minInclusive=true, maxInclusive=true
+        FixedThreshold ft = new FixedThreshold();
+        ft.setMin(10);
+        ft.setMax(100);
+        ft.setMinInclusive(true);
+        ft.setMaxInclusive(true);
+        ft.setNodes(fingerprintNode, rootNode, rangeNode);
+
+        // Each root is processed independently (non-cumulative)
+        List<ValueEntity> found1 = nodeService.calculateFixedThresholdValues(ft, root1, 0);
+        List<ValueEntity> found2 = nodeService.calculateFixedThresholdValues(ft, root2, 0);
+        List<ValueEntity> found3 = nodeService.calculateFixedThresholdValues(ft, root3, 0);
+
+        // 5.0 below min=10 → violation
+        assertEquals(1, found1.size(), "root1 (5.0) should produce 1 violation (below min)");
+        assertEquals("below", found1.getFirst().data.get("direction").asText());
+        assertEquals(5.0, found1.getFirst().data.get("value").asDouble());
+        assertEquals(10.0, found1.getFirst().data.get("bound").asDouble());
+
+        // 50.0 in range → no violation
+        assertEquals(0, found2.size(), "root2 (50.0) should produce no violations");
+
+        // 150.0 above max=100 → violation
+        assertEquals(1, found3.size(), "root3 (150.0) should produce 1 violation (above max)");
+        assertEquals("above", found3.getFirst().data.get("direction").asText());
+        assertEquals(150.0, found3.getFirst().data.get("value").asDouble());
+        assertEquals(100.0, found3.getFirst().data.get("bound").asDouble());
+
+        // Verify violation data fields
+        for (ValueEntity v : List.of(found1.getFirst(), found3.getFirst())) {
+            assertTrue(v.data.has("value"), "result should contain value field");
+            assertTrue(v.data.has("bound"), "result should contain bound field");
+            assertTrue(v.data.has("direction"), "result should contain direction field");
+            assertTrue(v.data.has("fingerprint"), "result should contain fingerprint field");
+        }
+    }
+
+    @Test
+    public void calculateFixedThreshold_with_qvss_data() throws IOException, SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        // Load multiple qvss JSON files
+        File qvssDir = new File(getClass().getClassLoader().getResource("qvss").getFile());
+        List<File> qvssFiles;
+        try (Stream<java.nio.file.Path> paths = Files.list(qvssDir.toPath())) {
+            qvssFiles = paths.map(java.nio.file.Path::toFile)
+                    .filter(f -> f.getName().endsWith(".json"))
+                    .sorted()
+                    .limit(10)
+                    .toList();
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.name = "upload";
+        rootNode.persist();
+        JqNode throughputNode = new JqNode("throughput", ".results.\"quarkus3-jvm\".load.avThroughput", rootNode);
+        throughputNode.persist();
+        JqNode versionNode = new JqNode("version", ".config.QUARKUS_VERSION", rootNode);
+        versionNode.persist();
+
+        // Persist fingerprint node and compute fp values per root
+        FingerprintNode fpNode = new FingerprintNode("fp", "fp", List.of(versionNode));
+        fpNode.persist();
+        tm.commit();
+
+        // Load each qvss file, create root + jq values + fingerprint values
+        List<ValueEntity> allRootValues = new ArrayList<>();
+        int throughputCount = 0;
+        for (File f : qvssFiles) {
+            JsonNode qvssData = mapper.readTree(f);
+            tm.begin();
+            ValueEntity rootValue = new ValueEntity(null, rootNode, qvssData);
+            rootValue.persist();
+            tm.commit();
+            allRootValues.add(rootValue);
+
+            Map<String, ValueEntity> sourceValues = Map.of("upload", rootValue);
+            tm.begin();
+            List<ValueEntity> tpValues = nodeService.calculateJqValues(throughputNode, sourceValues, 0);
+            tpValues.forEach(ValueEntity.getEntityManager()::merge);
+            List<ValueEntity> verValues = nodeService.calculateJqValues(versionNode, sourceValues, 0);
+            verValues.forEach(ValueEntity.getEntityManager()::merge);
+            // compute fingerprint values
+            if (!verValues.isEmpty()) {
+                Map<String, ValueEntity> fpSourceValues = new HashMap<>();
+                fpSourceValues.put("version", verValues.getFirst());
+                List<ValueEntity> fpValues = nodeService.calculateFpValues(fpNode, fpSourceValues, 0);
+                fpValues.forEach(ValueEntity.getEntityManager()::merge);
+            }
+            tm.commit();
+
+            if (!tpValues.isEmpty()) {
+                throughputCount++;
+            }
+        }
+        assertTrue(throughputCount > 0, "should have at least one file with quarkus3-jvm throughput data");
+
+        // Create FixedThreshold with min=10000, max=15000
+        FixedThreshold ft = new FixedThreshold();
+        ft.setMin(10000);
+        ft.setMax(15000);
+        ft.setMinInclusive(true);
+        ft.setMaxInclusive(true);
+        ft.setNodes(fpNode, rootNode, throughputNode);
+
+        int totalViolations = 0;
+        for (ValueEntity rootValue : allRootValues) {
+            List<ValueEntity> violations = nodeService.calculateFixedThresholdValues(ft, rootValue, 0);
+            totalViolations += violations.size();
+            for (ValueEntity v : violations) {
+                double val = v.data.get("value").asDouble();
+                String dir = v.data.get("direction").asText();
+                if ("above".equals(dir)) {
+                    assertTrue(val > 15000, "above violation should have value > 15000 but was " + val);
+                } else if ("below".equals(dir)) {
+                    assertTrue(val < 10000, "below violation should have value < 10000 but was " + val);
+                }
+            }
+        }
+        assertTrue(totalViolations > 0, "should detect at least one threshold violation across qvss data");
+    }
+
+    @Test
+    public void calculateFixedThreshold_inclusive_vs_exclusive() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity rangeNode = new JqNode("range", ".y", rootNode);
+        rangeNode.persist();
+        NodeEntity fingerprintNode = new JqNode("fingerprint", ".fingerprint", rootNode);
+        fingerprintNode.persist();
+
+        // Range values exactly at boundaries [10.0, 100.0]
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("root1"));
+        root1.persist();
+        ValueEntity root2 = new ValueEntity(null, rootNode, new TextNode("root2"));
+        root2.persist();
+
+        ValueEntity range1 = new ValueEntity(null, rangeNode, DoubleNode.valueOf(10.0));
+        range1.sources = List.of(root1);
+        range1.persist();
+        ValueEntity range2 = new ValueEntity(null, rangeNode, DoubleNode.valueOf(100.0));
+        range2.sources = List.of(root2);
+        range2.persist();
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode fpData = mapper.createObjectNode();
+        fpData.put("env", "test");
+        ValueEntity fp1 = new ValueEntity(null, fingerprintNode, fpData);
+        fp1.sources = List.of(root1);
+        fp1.persist();
+        ValueEntity fp2 = new ValueEntity(null, fingerprintNode, fpData);
+        fp2.sources = List.of(root2);
+        fp2.persist();
+        tm.commit();
+
+        // both inclusive → no violations (10 >= 10, 100 <= 100)
+        FixedThreshold ftInclusive = new FixedThreshold();
+        ftInclusive.setMin(10);
+        ftInclusive.setMax(100);
+        ftInclusive.setMinInclusive(true);
+        ftInclusive.setMaxInclusive(true);
+        ftInclusive.setNodes(fingerprintNode, rootNode, rangeNode);
+
+        List<ValueEntity> inclusiveR1 = nodeService.calculateFixedThresholdValues(ftInclusive, root1, 0);
+        List<ValueEntity> inclusiveR2 = nodeService.calculateFixedThresholdValues(ftInclusive, root2, 0);
+        assertEquals(0, inclusiveR1.size(), "minInclusive=true: value 10 should NOT violate min=10");
+        assertEquals(0, inclusiveR2.size(), "maxInclusive=true: value 100 should NOT violate max=100");
+
+        // both exclusive → both violate (10 <= 10, 100 >= 100)
+        FixedThreshold ftExclusive = new FixedThreshold();
+        ftExclusive.setMin(10);
+        ftExclusive.setMax(100);
+        ftExclusive.setMinInclusive(false);
+        ftExclusive.setMaxInclusive(false);
+        ftExclusive.setNodes(fingerprintNode, rootNode, rangeNode);
+
+        List<ValueEntity> exclusiveR1 = nodeService.calculateFixedThresholdValues(ftExclusive, root1, 0);
+        List<ValueEntity> exclusiveR2 = nodeService.calculateFixedThresholdValues(ftExclusive, root2, 0);
+        assertEquals(1, exclusiveR1.size(), "minInclusive=false: value 10 should violate min=10");
+        assertEquals(1, exclusiveR2.size(), "maxInclusive=false: value 100 should violate max=100");
+
+        // mixed: minInclusive=false, maxInclusive=true → only min boundary violates
+        FixedThreshold ftMixed = new FixedThreshold();
+        ftMixed.setMin(10);
+        ftMixed.setMax(100);
+        ftMixed.setMinInclusive(false);
+        ftMixed.setMaxInclusive(true);
+        ftMixed.setNodes(fingerprintNode, rootNode, rangeNode);
+
+        List<ValueEntity> mixedR1 = nodeService.calculateFixedThresholdValues(ftMixed, root1, 0);
+        List<ValueEntity> mixedR2 = nodeService.calculateFixedThresholdValues(ftMixed, root2, 0);
+        assertEquals(1, mixedR1.size(), "minInclusive=false: value 10 should violate min=10");
+        assertEquals(0, mixedR2.size(), "maxInclusive=true: value 100 should NOT violate max=100");
+    }
 }


### PR DESCRIPTION
Implement threshold-based change detection that flags numeric values crossing configured min/max boundaries. This provides feature parity with Horreum's fixed threshold detection.

- FixedThreshold entity (@DiscriminatorValue("ft")) with min, max, inclusive, and fingerprintFilter config stored as JSON in operation
- AddFixedThreshold CLI command (add fixedthreshold)
- calculateFixedThresholdValues() in NodeService with violation output containing value, bound, direction, and fingerprint fields
- Work.java recognizes FixedThreshold as cumulative