### PR TITLE
fix NodeServiceTest.*qvss* tests

### DIFF
--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -848,10 +848,8 @@ public class NodeServiceTest extends FreshDb {
         // calculate jq values for both nodes
         Map<String, ValueEntity> sourceValues = Map.of("upload", rootValue);
         tm.begin();
-        List<ValueEntity> qvValues = nodeService.calculateJqValues(quarkusVersionNode, sourceValues, 0);
-        qvValues.forEach(ValueEntity.getEntityManager()::merge);
-        List<ValueEntity> jvValues = nodeService.calculateJqValues(javaVersionNode, sourceValues, 0);
-        jvValues.forEach(ValueEntity.getEntityManager()::merge);
+        List<ValueEntity> qvValues = nodeService.calculateJqValues(quarkusVersionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
+        List<ValueEntity> jvValues = nodeService.calculateJqValues(javaVersionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
         tm.commit();
 
         assertEquals(1, qvValues.size(), "should extract one QUARKUS_VERSION value");
@@ -1150,16 +1148,13 @@ public class NodeServiceTest extends FreshDb {
 
             Map<String, ValueEntity> sourceValues = Map.of("upload", rootValue);
             tm.begin();
-            List<ValueEntity> tpValues = nodeService.calculateJqValues(throughputNode, sourceValues, 0);
-            tpValues.forEach(ValueEntity.getEntityManager()::merge);
-            List<ValueEntity> verValues = nodeService.calculateJqValues(versionNode, sourceValues, 0);
-            verValues.forEach(ValueEntity.getEntityManager()::merge);
+            List<ValueEntity> tpValues = nodeService.calculateJqValues(throughputNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();;
+            List<ValueEntity> verValues = nodeService.calculateJqValues(versionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();;
             // compute fingerprint values
             if (!verValues.isEmpty()) {
                 Map<String, ValueEntity> fpSourceValues = new HashMap<>();
                 fpSourceValues.put("version", verValues.getFirst());
-                List<ValueEntity> fpValues = nodeService.calculateFpValues(fpNode, fpSourceValues, 0);
-                fpValues.forEach(ValueEntity.getEntityManager()::merge);
+                List<ValueEntity> fpValues = nodeService.calculateFpValues(fpNode, fpSourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
             }
             tm.commit();
 


### PR DESCRIPTION
The qvss tests in NodeServiceTest are creating duplicate Values because they call `merge` for a collection of Values without updating the entries in the collection.

merge returns a new, attached entity and does not mutate the input entity. This leaves the entities in the collection with id=null. Those collection of Values are used as sources for new Values in the test and that results in duplicate Values when the new Values are merged.

This fixes the issue by storing the returned Values from `merge` in the collection.