### PR TITLE
fix edge table delete cascade to preserve shared children (#5)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/EdgeQueries.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/EdgeQueries.java
@@ -1,0 +1,44 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import jakarta.persistence.EntityManager;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared edge table queries for edge tables (node_edge, value_edge).
+ */
+class EdgeQueries {
+
+    static long getParentCount(EntityManager em, String edgeTable, Long childId) {
+        return ((Number) em.createNativeQuery(
+                "SELECT COUNT(*) FROM " + edgeTable + " WHERE child_id = :childId"
+        ).setParameter("childId", childId).getSingleResult()).longValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    static Map<Long, Long> getParentCounts(EntityManager em, String edgeTable, List<Long> childIds) {
+        if (childIds.isEmpty()) return Map.of();
+        List<Object[]> rows = em.createNativeQuery(
+                "SELECT child_id, COUNT(*) FROM " + edgeTable + " WHERE child_id IN (:childIds) GROUP BY child_id"
+        ).setParameter("childIds", childIds).getResultList();
+        Map<Long, Long> result = new HashMap<>();
+        for (Object[] row : rows) {
+            result.put(((Number) row[0]).longValue(), ((Number) row[1]).longValue());
+        }
+        return result;
+    }
+
+    static void deleteParentEdges(EntityManager em, String edgeTable, Long parentId) {
+        em.createNativeQuery("DELETE FROM " + edgeTable + " WHERE parent_id = :parentId")
+                .setParameter("parentId", parentId)
+                .executeUpdate();
+    }
+
+    static void deleteChildEdges(EntityManager em, String edgeTable, Long childId) {
+        em.createNativeQuery("DELETE FROM " + edgeTable + " WHERE child_id = :childId")
+                .setParameter("childId", childId)
+                .executeUpdate();
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -164,12 +164,31 @@ public class NodeService implements NodeServiceInterface {
         ).setParameter("sourceId", n.id).getResultList();
     }
 
+    @Transactional
+    public long getNodeParentCount(NodeEntity node){
+        return EdgeQueries.getParentCount(em, "node_edge", node.id);
+    }
+
+    @Transactional
+    public Map<Long, Long> getNodeParentCounts(List<Long> childIds){
+        return EdgeQueries.getParentCounts(em, "node_edge", childIds);
+    }
+
     @Override
     @Transactional
     public void delete(Long nodeId){
         if(nodeId!=null) {
-            //remove nodes that depend on this or just remove the reference?
-            //getDependentNodes(node).forEach(this::delete);
+            NodeEntity node = NodeEntity.findById(nodeId);
+            if(node == null) return;
+            List<NodeEntity> dependents = getDependentNodes(node);
+            for(NodeEntity dependent : dependents){
+                long parentCount = getNodeParentCount(dependent);
+                if(parentCount <= 1){
+                    delete(dependent.id);
+                }
+            }
+            // clean up edge rows where this node is a parent (inverse side not managed by JPA)
+            EdgeQueries.deleteParentEdges(em, "node_edge", nodeId);
             NodeEntity.deleteById(nodeId);
         }
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -65,17 +65,31 @@ public class ValueService implements ValueServiceInterface {
     }
 
     @Transactional
-    public List<ValueEntity> getDependentNodes(ValueEntity v){
-        return NodeEntity.list("SELECT DISTINCT v FROM value v JOIN v.sources s WHERE s.id = ?1",v.id);
+    public List<ValueEntity> getDependentValues(ValueEntity v){
+        return ValueEntity.list("SELECT DISTINCT v FROM value v JOIN v.sources s WHERE s.id = ?1",v.id);
     }
 
+    @Transactional
+    public long getParentCount(ValueEntity value){
+        return EdgeQueries.getParentCount(em, "value_edge", value.id);
+    }
+
+    @Transactional
+    public Map<Long, Long> getParentCounts(List<Long> childIds){
+        return EdgeQueries.getParentCounts(em, "value_edge", childIds);
+    }
 
     @Transactional
     public void delete(ValueEntity value){
-        if(value.id != null){
-            //remove values that depend on this or just remove the reference?
-            getDependentNodes(value).forEach(this::delete);
-            ValueEntity.deleteById(value.id);
+        if(value.id != null && ValueEntity.findById(value.id) != null){
+            List<ValueEntity> dependents = getDependentValues(value);
+            for(ValueEntity dependent : dependents){
+                long parentCount = EdgeQueries.getParentCount(em, "value_edge", dependent.id);
+                if(parentCount <= 1){
+                    delete(dependent);
+                }
+            }
+            deleteValueAndEdges(value.id);
         }
     }
 
@@ -541,9 +555,18 @@ public class ValueService implements ValueServiceInterface {
     @Transactional
     public int deleteDescendantValues(ValueEntity root, NodeEntity node){
         List<ValueEntity> descendants = getDescendantValues(root,node);
+        Set<Long> deletionSet = new HashSet<>();
+        deletionSet.add(root.id);
+        descendants.forEach(d -> deletionSet.add(d.id));
         descendants = KahnDagSort.sort(descendants,v->v.getSources()).reversed();
-        descendants.forEach(PanacheEntityBase::delete);
-        return descendants.size();
+        int deleted = 0;
+        for(ValueEntity v : descendants){
+            if(!hasExternalParent(v, deletionSet)){
+                deleteValueAndEdges(v.id);
+                deleted++;
+            }
+        }
+        return deleted;
     }
 
     @Transactional
@@ -552,9 +575,36 @@ public class ValueService implements ValueServiceInterface {
             return 0;//don't want to support deleting uploads just yet
         }
         List<ValueEntity> descendants = getDescendantValues(root);
-        descendants.forEach(ValueEntity::delete);
-        root.delete();
-        return 1+descendants.size();
+        Set<Long> purgeSet = new HashSet<>();
+        purgeSet.add(root.id);
+        descendants.forEach(d -> purgeSet.add(d.id));
+        descendants = KahnDagSort.sort(descendants,v->v.getSources()).reversed();
+        int deleted = 0;
+        for(ValueEntity d : descendants){
+            if(!hasExternalParent(d, purgeSet)){
+                deleteValueAndEdges(d.id);
+                deleted++;
+            }
+        }
+        deleteValueAndEdges(root.id);
+        return 1 + deleted;
+    }
+
+    private void deleteValueAndEdges(long valueId) {
+        EdgeQueries.deleteParentEdges(em, "value_edge", valueId);
+        EdgeQueries.deleteChildEdges(em, "value_edge", valueId);
+        em.createNativeQuery("DELETE FROM value WHERE id = :id")
+                .setParameter("id", valueId).executeUpdate();
+    }
+
+    private boolean hasExternalParent(ValueEntity value, Set<Long> deletionSet){
+        List<?> externalParents = em.createNativeQuery(
+            "SELECT 1 FROM value_edge WHERE child_id = :childId AND parent_id NOT IN (:deletionSet)"
+        ).setParameter("childId", value.id)
+         .setParameter("deletionSet", deletionSet)
+         .setMaxResults(1)
+         .getResultList();
+        return !externalParents.isEmpty();
     }
 
     //TODO getHash(ValueEntity value) to see if a new value is different than the persisted one

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -75,6 +75,35 @@ public class NodeServiceTest extends FreshDb {
     }
 
     @Test
+    public void delete_does_not_cascade_to_shared_dependent() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity sourceA = new JqNode("sourceA",".a");
+        sourceA.sources=List.of(rootNode);
+        sourceA.persist();
+        NodeEntity sourceB = new JqNode("sourceB",".b");
+        sourceB.sources=List.of(rootNode);
+        sourceB.persist();
+        // sharedNode has both sourceA and sourceB as parents
+        NodeEntity sharedNode = new JqNode("shared",".shared");
+        sharedNode.sources=List.of(sourceA, sourceB);
+        sharedNode.persist();
+        tm.commit();
+
+        tm.begin();
+        nodeService.delete(sourceA.id);
+        tm.commit();
+
+        // sharedNode should still exist because sourceB is still a parent
+        NodeEntity foundShared = NodeEntity.findById(sharedNode.id);
+        assertNotNull(foundShared, "shared node should not be deleted when one source is removed");
+        // sourceB should still exist
+        NodeEntity foundB = NodeEntity.findById(sourceB.id);
+        assertNotNull(foundB, "sourceB should still exist");
+    }
+
+    @Test
     public void renameParameters_spaced_parameters() {
         assertEquals("function foo( biz , buz ){}", nodeService.renameParameters("function foo( fiz , fuzz ){}", Map.of("fiz", "biz", "fuzz", "buz")));
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -16,6 +16,7 @@ import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.*;
 import org.hibernate.LazyInitializationException;
 import org.junit.jupiter.api.Disabled;
@@ -40,6 +41,9 @@ public class ValueServiceTest extends FreshDb {
     @Inject
     TransactionManager tm;
 
+    @Inject
+    EntityManager em;
+
     @Test
     public void delete_does_not_cascade_and_delete_ancestor() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
         tm.begin();
@@ -63,6 +67,216 @@ public class ValueServiceTest extends FreshDb {
         assertNotNull(found);
     }
 
+
+    @Test
+    public void delete_does_not_cascade_to_shared_child() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a",".a");
+        aNode.sources=List.of(rootNode);
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b",".b");
+        bNode.sources=List.of(rootNode);
+        bNode.persist();
+
+        ValueEntity rootValue = new ValueEntity(null,rootNode,new TextNode("root"));
+        rootValue.persist();
+        ValueEntity aValue = new ValueEntity(null,aNode,new TextNode("a"));
+        aValue.sources=List.of(rootValue);
+        aValue.persist();
+        ValueEntity bValue = new ValueEntity(null,bNode,new TextNode("b"));
+        bValue.sources=List.of(rootValue);
+        bValue.persist();
+        // X is shared: both aValue and bValue are parents
+        ValueEntity xValue = new ValueEntity(null,aNode,new TextNode("x"));
+        xValue.sources=List.of(aValue, bValue);
+        xValue.persist();
+        tm.commit();
+
+        tm.begin();
+        valueService.delete(aValue);
+        tm.commit();
+
+        // X should still exist because bValue is still a parent
+        ValueEntity foundX = ValueEntity.findById(xValue.id);
+        assertNotNull(foundX, "shared child X should not be deleted when one parent is removed");
+        // bValue should still exist
+        ValueEntity foundB = ValueEntity.findById(bValue.id);
+        assertNotNull(foundB, "bValue should still exist");
+    }
+
+    @Test
+    public void delete_cascades_to_exclusive_child() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a",".a");
+        aNode.sources=List.of(rootNode);
+        aNode.persist();
+
+        ValueEntity rootValue = new ValueEntity(null,rootNode,new TextNode("root"));
+        rootValue.persist();
+        ValueEntity aValue = new ValueEntity(null,aNode,new TextNode("a"));
+        aValue.sources=List.of(rootValue);
+        aValue.persist();
+        // X has only aValue as parent
+        ValueEntity xValue = new ValueEntity(null,aNode,new TextNode("x"));
+        xValue.sources=List.of(aValue);
+        xValue.persist();
+        tm.commit();
+
+        tm.begin();
+        valueService.delete(aValue);
+        tm.commit();
+
+        // X should be deleted because aValue was its only parent
+        ValueEntity foundX = ValueEntity.findById(xValue.id);
+        assertNull(foundX, "exclusive child X should be deleted when its only parent is removed");
+    }
+
+    @Test
+    public void delete_mixed_shared_and_exclusive() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a",".a");
+        aNode.sources=List.of(rootNode);
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b",".b");
+        bNode.sources=List.of(rootNode);
+        bNode.persist();
+
+        ValueEntity rootValue = new ValueEntity(null,rootNode,new TextNode("root"));
+        rootValue.persist();
+        ValueEntity aValue = new ValueEntity(null,aNode,new TextNode("a"));
+        aValue.sources=List.of(rootValue);
+        aValue.persist();
+        ValueEntity bValue = new ValueEntity(null,bNode,new TextNode("b"));
+        bValue.sources=List.of(rootValue);
+        bValue.persist();
+        // X is shared between aValue and bValue
+        ValueEntity xValue = new ValueEntity(null,aNode,new TextNode("x"));
+        xValue.sources=List.of(aValue, bValue);
+        xValue.persist();
+        // Y is exclusive to aValue
+        ValueEntity yValue = new ValueEntity(null,aNode,new TextNode("y"));
+        yValue.sources=List.of(aValue);
+        yValue.persist();
+        tm.commit();
+
+        tm.begin();
+        valueService.delete(aValue);
+        tm.commit();
+
+        // X should survive (shared with bValue)
+        ValueEntity foundX = ValueEntity.findById(xValue.id);
+        assertNotNull(foundX, "shared child X should survive");
+        // Y should be deleted (exclusive to aValue)
+        ValueEntity foundY = ValueEntity.findById(yValue.id);
+        assertNull(foundY, "exclusive child Y should be deleted");
+    }
+
+    @Test
+    public void deleteDescendantValues_preserves_shared_descendants() throws Exception {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a", ".a");
+        aNode.sources = List.of(rootNode);
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b", ".b");
+        bNode.sources = List.of(rootNode);
+        bNode.persist();
+
+        ValueEntity rootValue = new ValueEntity(null, rootNode, new TextNode("root"));
+        rootValue.persist();
+        ValueEntity aValue = new ValueEntity(null, aNode, new TextNode("a"));
+        aValue.sources = List.of(rootValue);
+        aValue.persist();
+        ValueEntity bValue = new ValueEntity(null, bNode, new TextNode("b"));
+        bValue.sources = List.of(rootValue);
+        bValue.persist();
+        // shared: child of both aValue and bValue
+        ValueEntity sharedValue = new ValueEntity(null, aNode, new TextNode("shared"));
+        sharedValue.sources = List.of(aValue, bValue);
+        sharedValue.persist();
+        // exclusive: child of aValue only
+        ValueEntity exclusiveValue = new ValueEntity(null, aNode, new TextNode("exclusive"));
+        exclusiveValue.sources = List.of(aValue);
+        exclusiveValue.persist();
+        tm.commit();
+
+        tm.begin();
+        int deleted = valueService.deleteDescendantValues(rootValue, aNode);
+        // verify within same transaction using native SQL to bypass L1 cache
+        long aCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", aValue.id).getSingleResult()).longValue();
+        long exclusiveCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", exclusiveValue.id).getSingleResult()).longValue();
+        long sharedCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", sharedValue.id).getSingleResult()).longValue();
+        tm.commit();
+
+        // aValue (parentCount=1) and exclusiveValue (parentCount=1) should be deleted
+        // sharedValue (parentCount=2 from aValue+bValue) should survive
+        assertEquals(0, aCount, "aValue should be deleted (single parent)");
+        assertEquals(0, exclusiveCount, "exclusive descendant should be deleted");
+        assertEquals(1, sharedCount, "shared descendant should survive");
+        assertEquals(2, deleted, "aValue and exclusiveValue should be deleted");
+    }
+
+    @Test
+    public void purge_removes_subtree_preserves_external() throws Exception {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a", ".a");
+        aNode.sources = List.of(rootNode);
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b", ".b");
+        bNode.sources = List.of(rootNode);
+        bNode.persist();
+
+        ValueEntity rootValue = new ValueEntity(null, rootNode, new TextNode("root"));
+        rootValue.persist();
+        // aValue is the purge target
+        ValueEntity aValue = new ValueEntity(null, aNode, new TextNode("a"));
+        aValue.sources = List.of(rootValue);
+        aValue.persist();
+        ValueEntity bValue = new ValueEntity(null, bNode, new TextNode("b"));
+        bValue.sources = List.of(rootValue);
+        bValue.persist();
+        // child only reachable via aValue
+        ValueEntity childOfA = new ValueEntity(null, aNode, new TextNode("childOfA"));
+        childOfA.sources = List.of(aValue);
+        childOfA.persist();
+        // shared child with external parent bValue
+        ValueEntity sharedChild = new ValueEntity(null, aNode, new TextNode("shared"));
+        sharedChild.sources = List.of(aValue, bValue);
+        sharedChild.persist();
+        tm.commit();
+
+        tm.begin();
+        int purged = valueService.purge(aValue);
+        long aCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", aValue.id).getSingleResult()).longValue();
+        long childCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", childOfA.id).getSingleResult()).longValue();
+        long sharedCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", sharedChild.id).getSingleResult()).longValue();
+        long bCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
+                .setParameter("id", bValue.id).getSingleResult()).longValue();
+        tm.commit();
+
+        // aValue and childOfA should be gone
+        assertEquals(0, aCount, "purge target should be deleted");
+        assertEquals(0, childCount, "exclusive child should be deleted");
+        // shared child and bValue should survive
+        assertEquals(1, sharedCount, "shared child should survive (external parent bValue)");
+        assertEquals(1, bCount, "bValue should survive");
+        assertEquals(2, purged, "should delete aValue (root) + childOfA (exclusive) = 2");
+    }
 
     @Test
     public void lazy_data() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, JsonProcessingException {


### PR DESCRIPTION
When deleting a node/value with references in edge tables (node_edge, value_edge), shared children are now preserved if they have other parents. Fixes the entity/query mismatch in getDependentValues, adds parent count checks before cascading deletes, and cleans up inverse edge rows.