### PR TITLE
Add security and roles infrastructure (issue #52)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
@@ -1,0 +1,20 @@
+package io.hyperfoil.tools.h5m.api.svc;
+
+import io.hyperfoil.tools.h5m.entity.Team;
+
+import java.util.List;
+
+public interface TeamServiceInterface {
+
+    long create(String name);
+
+    void delete(long teamId);
+
+    Team byName(String name);
+
+    List<Team> list();
+
+    void addMember(long teamId, long userId);
+
+    void removeMember(long teamId, long userId);
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
@@ -1,0 +1,19 @@
+package io.hyperfoil.tools.h5m.api.svc;
+
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+
+import java.util.List;
+
+public interface UserServiceInterface {
+
+    long create(String username, Role role);
+
+    User byUsername(String username);
+
+    List<User> list();
+
+    void setRole(long userId, Role role);
+
+    long count();
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
@@ -1,0 +1,43 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "add-member", description = "add a user to a team", mixinStandardHelpOptions = true)
+public class AdminAddMember implements Callable<Integer> {
+
+    @Inject
+    TeamServiceInterface teamService;
+
+    @Inject
+    UserServiceInterface userService;
+
+    @CommandLine.Parameters(index = "0", description = "username")
+    public String username;
+
+    @CommandLine.Parameters(index = "1", description = "team name")
+    public String teamName;
+
+    @Override
+    public Integer call() {
+        User user = userService.byUsername(username);
+        if (user == null) {
+            System.err.println("User not found: " + username);
+            return 1;
+        }
+        Team team = teamService.byName(teamName);
+        if (team == null) {
+            System.err.println("Team not found: " + teamName);
+            return 1;
+        }
+        teamService.addMember(team.id, user.id);
+        System.out.println("Added " + username + " to team " + teamName);
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCmd.java
@@ -1,0 +1,26 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+        name = "admin",
+        description = "admin operations",
+        mixinStandardHelpOptions = true,
+        subcommands = {
+                AdminCreateTeam.class,
+                AdminCreateUser.class,
+                AdminListTeams.class,
+                AdminListUsers.class,
+                AdminAddMember.class,
+        }
+)
+public class AdminCmd implements Callable<Integer> {
+    @Override
+    public Integer call() throws Exception {
+        CommandLine cmd = new CommandLine(this);
+        cmd.usage(System.out);
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateTeam.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateTeam.java
@@ -1,0 +1,24 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "create-team", description = "create a new team", mixinStandardHelpOptions = true)
+public class AdminCreateTeam implements Callable<Integer> {
+
+    @Inject
+    TeamServiceInterface teamService;
+
+    @CommandLine.Parameters(index = "0", description = "team name")
+    public String name;
+
+    @Override
+    public Integer call() {
+        long id = teamService.create(name);
+        System.out.println("Created team: " + name + " (id=" + id + ")");
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateUser.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateUser.java
@@ -1,0 +1,28 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.hyperfoil.tools.h5m.entity.Role;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "create-user", description = "create a new user", mixinStandardHelpOptions = true)
+public class AdminCreateUser implements Callable<Integer> {
+
+    @Inject
+    UserServiceInterface userService;
+
+    @CommandLine.Parameters(index = "0", description = "username")
+    public String username;
+
+    @CommandLine.Option(names = {"--role"}, description = "role (ADMIN or USER)", defaultValue = "USER")
+    public Role role;
+
+    @Override
+    public Integer call() {
+        long id = userService.create(username, role);
+        System.out.println("Created user: " + username + " (id=" + id + ", role=" + role + ")");
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListTeams.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListTeams.java
@@ -1,0 +1,23 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
+import io.hyperfoil.tools.h5m.entity.Team;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.List;
+
+@CommandLine.Command(name = "list-teams", description = "list all teams", mixinStandardHelpOptions = true)
+public class AdminListTeams implements Runnable {
+
+    @Inject
+    TeamServiceInterface teamService;
+
+    @Override
+    public void run() {
+        List<Team> teams = teamService.list();
+        System.out.println(ListCmd.table(80, teams,
+                List.of("name", "members"),
+                List.of(t -> t.name, t -> t.members.size())));
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListUsers.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListUsers.java
@@ -1,0 +1,23 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.List;
+
+@CommandLine.Command(name = "list-users", description = "list all users", mixinStandardHelpOptions = true)
+public class AdminListUsers implements Runnable {
+
+    @Inject
+    UserServiceInterface userService;
+
+    @Override
+    public void run() {
+        List<User> users = userService.list();
+        System.out.println(ListCmd.table(80, users,
+                List.of("username", "role"),
+                List.of(u -> u.username, u -> u.role.name())));
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 @QuarkusMain
 @TopCommand
-@CommandLine.Command(name="", mixinStandardHelpOptions = true,separator = " ", subcommands={CommandLine.HelpCommand.class, AutoComplete.GenerateCompletion.class, ListCmd.class, AddCmd.class, RemoveCmd.class})
+@CommandLine.Command(name="", mixinStandardHelpOptions = true,separator = " ", subcommands={CommandLine.HelpCommand.class, AutoComplete.GenerateCompletion.class, ListCmd.class, AddCmd.class, RemoveCmd.class, AdminCmd.class})
 public class H5m implements QuarkusApplication {
 
     //@Inject

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKey.java
@@ -1,0 +1,47 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+@Entity(name = "api_key")
+public class ApiKey extends PanacheEntity {
+
+    @Column(name = "key_hash")
+    public String keyHash; // SHA-256 hex
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    public User user;
+
+    public String description;
+
+    public Instant createdAt;
+
+    public Instant lastUsedAt;
+
+    public long activeDays; // number of idle days before the key expires
+
+    public boolean revoked;
+
+    public ApiKey() {}
+
+    public boolean isExpired(Instant now) {
+        Instant reference = lastUsedAt != null ? lastUsedAt : createdAt;
+        return revoked || (reference != null && now.isAfter(reference.plus(activeDays, ChronoUnit.DAYS)));
+    }
+
+    public void recordAccess() {
+        this.lastUsedAt = Instant.now();
+    }
+
+    @Override
+    public String toString() {
+        return "ApiKey<" + id + ">[ user=" + (user != null ? user.username : "null") +
+                " description=" + description + " ]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
@@ -12,6 +12,9 @@ public class FolderEntity extends PanacheEntity {
     @OneToOne(cascade = {CascadeType.ALL})
     public NodeGroupEntity group;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    public Team team;
+
     @Override
     public final boolean equals(Object o) {
         if (!(o instanceof FolderEntity that)) {

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/Role.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/Role.java
@@ -1,0 +1,6 @@
+package io.hyperfoil.tools.h5m.entity;
+
+public enum Role {
+    ADMIN,
+    USER
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/Team.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/Team.java
@@ -1,0 +1,50 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "team")
+public class Team extends PanacheEntity {
+
+    @Column(unique = true)
+    public String name;
+
+    @ManyToMany
+    @JoinTable(
+            name = "team_members",
+            joinColumns = @JoinColumn(name = "team_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    public List<User> members = new ArrayList<>();
+
+    public Team() {}
+
+    public Team(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Team that)) {
+            return false;
+        }
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "Team<" + id + ">[ name=" + name + " ]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/User.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/User.java
@@ -1,0 +1,49 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.ManyToMany;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "h5m_user")
+public class User extends PanacheEntity {
+
+    @Column(unique = true)
+    public String username;
+
+    @Enumerated(EnumType.STRING)
+    public Role role;
+
+    @ManyToMany(mappedBy = "members")
+    public List<Team> teams = new ArrayList<>();
+
+    public User() {}
+
+    public User(String username, Role role) {
+        this.username = username;
+        this.role = role;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof User that)) {
+            return false;
+        }
+        return username.equals(that.username);
+    }
+
+    @Override
+    public int hashCode() {
+        return username.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "User<" + id + ">[ username=" + username + " role=" + role + " ]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/AuthorizationService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/AuthorizationService.java
@@ -1,0 +1,77 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class AuthorizationService {
+
+    @ConfigProperty(name = "h5m.security.enabled", defaultValue = "false")
+    boolean securityEnabled;
+
+    @Inject
+    UserService userService;
+
+    @Inject
+    EntityManager em;
+
+    public boolean isLocalMode() {
+        return !securityEnabled;
+    }
+
+    @Transactional
+    public boolean isAdmin(String username) {
+        if (isLocalMode()) {
+            return true;
+        }
+        User user = userService.byUsername(username);
+        return user != null && user.role == Role.ADMIN;
+    }
+
+    @Transactional
+    public boolean isMemberOfTeam(String username, long teamId) {
+        if (isLocalMode()) {
+            return true;
+        }
+        Long count = em.createQuery(
+                "SELECT COUNT(m) FROM team t JOIN t.members m WHERE t.id = :teamId AND m.username = :username",
+                Long.class)
+                .setParameter("teamId", teamId)
+                .setParameter("username", username)
+                .getSingleResult();
+        return count > 0;
+    }
+
+    @Transactional
+    public boolean canModifyFolder(String username, FolderEntity folder) {
+        if (isLocalMode()) {
+            return true;
+        }
+        if (isAdmin(username)) {
+            return true;
+        }
+        if (folder.team == null) {
+            return true; // legacy folder with no team — unrestricted
+        }
+        return isMemberOfTeam(username, folder.team.id);
+    }
+
+    public void requireAdmin(String username) {
+        if (!isAdmin(username)) {
+            throw new SecurityException("Admin access required");
+        }
+    }
+
+    public void requireFolderModify(String username, FolderEntity folder) {
+        if (!canModifyFolder(username, folder)) {
+            throw new SecurityException(
+                    "User " + username + " is not a member of team " + folder.team.name);
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -6,6 +6,7 @@ import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
+import io.hyperfoil.tools.h5m.entity.Team;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import io.hyperfoil.tools.h5m.entity.work.Work;
@@ -32,6 +33,9 @@ public class FolderService implements FolderServiceInterface {
     WorkService workService;
 
     @Inject
+    AuthorizationService authService;
+
+    @Inject
     ApiMapper apiMapper;
 
     @Override
@@ -42,6 +46,18 @@ public class FolderService implements FolderServiceInterface {
         entity.group = new NodeGroupEntity(name); //TODO do we auto-create a nodeGroup?
         FolderEntity.persist(entity);
         return entity.id;
+    }
+
+    @Transactional
+    public long create(String name, String teamName) {
+        Team team = Team.find("name", teamName).firstResult();
+        if (team == null) {
+            throw new IllegalArgumentException("Team not found: " + teamName);
+        }
+        long id = create(name);
+        FolderEntity entity = FolderEntity.findById(id);
+        entity.team = team;
+        return id;
     }
 
     @Transactional

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
@@ -1,0 +1,59 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
+import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+
+@ApplicationScoped
+public class TeamService implements TeamServiceInterface {
+
+    @Override
+    @Transactional
+    public long create(String name) {
+        Team team = new Team(name);
+        team.persist();
+        return team.id;
+    }
+
+    @Override
+    @Transactional
+    public void delete(long teamId) {
+        Team.deleteById(teamId);
+    }
+
+    @Override
+    @Transactional
+    public Team byName(String name) {
+        return Team.find("name", name).firstResult();
+    }
+
+    @Override
+    @Transactional
+    public List<Team> list() {
+        return Team.listAll();
+    }
+
+    @Override
+    @Transactional
+    public void addMember(long teamId, long userId) {
+        Team team = Team.findById(teamId);
+        User user = User.findById(userId);
+        if (team != null && user != null && !team.members.contains(user)) {
+            team.members.add(user);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void removeMember(long teamId, long userId) {
+        Team team = Team.findById(teamId);
+        User user = User.findById(userId);
+        if (team != null && user != null) {
+            team.members.remove(user);
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
@@ -1,0 +1,48 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+
+import java.util.List;
+
+@ApplicationScoped
+public class UserService implements UserServiceInterface {
+
+    @Override
+    @Transactional
+    public long create(String username, Role role) {
+        User user = new User(username, role);
+        user.persist();
+        return user.id;
+    }
+
+    @Override
+    @Transactional
+    public User byUsername(String username) {
+        return User.find("username", username).firstResult();
+    }
+
+    @Override
+    @Transactional
+    public List<User> list() {
+        return User.listAll();
+    }
+
+    @Override
+    @Transactional
+    public void setRole(long userId, Role role) {
+        User user = User.findById(userId);
+        if (user != null) {
+            user.role = role;
+        }
+    }
+
+    @Override
+    @Transactional
+    public long count() {
+        return User.count();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,3 +53,7 @@ quarkus.log.category."org.hibernate".level=ERROR
 #for debugging production jar
 #10m timeout
 quarkus.transaction-manager.default-transaction-timeout=PT10m
+
+# Security - disabled by default (local/CLI mode)
+h5m.security.enabled=false
+h5m.api-key.expiration-days=365

--- a/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
@@ -27,6 +27,8 @@ public class FreshDb {
             try(Statement stmt = conn.createStatement()){
 
                 if(dbKind.equals("postgresql")){
+                    stmt.executeUpdate("TRUNCATE TABLE api_key CASCADE");
+                    stmt.executeUpdate("TRUNCATE TABLE team_members CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE work_values CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE work_nodes CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE work CASCADE");
@@ -36,7 +38,11 @@ public class FreshDb {
                     stmt.executeUpdate("TRUNCATE TABLE node_group CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE node_edge CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE node CASCADE");
+                    stmt.executeUpdate("TRUNCATE TABLE h5m_user CASCADE");
+                    stmt.executeUpdate("TRUNCATE TABLE team CASCADE");
                 }else if (dbKind.equals("sqlite")){
+                    stmt.executeUpdate("DELETE from api_key");
+                    stmt.executeUpdate("DELETE from team_members");
                     stmt.executeUpdate("DELETE from work_values");
                     stmt.executeUpdate("DELETE from work_nodes");
                     stmt.executeUpdate("DELETE from work");
@@ -46,6 +52,8 @@ public class FreshDb {
                     stmt.executeUpdate("DELETE from node_group");
                     stmt.executeUpdate("DELETE from node_edge");
                     stmt.executeUpdate("DELETE from node");
+                    stmt.executeUpdate("DELETE from h5m_user");
+                    stmt.executeUpdate("DELETE from team");
                 }
             }
         }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
@@ -1,0 +1,130 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(SecurityEnabledProfile.class)
+public class AuthorizationServiceTest extends FreshDb {
+
+    @Inject
+    AuthorizationService authService;
+
+    @Inject
+    TeamService teamService;
+
+    @Inject
+    UserService userService;
+
+    @Inject
+    FolderService folderService;
+
+    @Test
+    void security_is_enabled() {
+        assertFalse(authService.isLocalMode());
+    }
+
+    @Test
+    void isAdmin_returns_true_for_admin_user() {
+        userService.create("admin-user", Role.ADMIN);
+        assertTrue(authService.isAdmin("admin-user"));
+    }
+
+    @Test
+    void isAdmin_returns_false_for_regular_user() {
+        userService.create("regular", Role.USER);
+        assertFalse(authService.isAdmin("regular"));
+    }
+
+    @Test
+    void isAdmin_returns_false_for_unknown_user() {
+        assertFalse(authService.isAdmin("nonexistent"));
+    }
+
+    @Test
+    @Transactional
+    void canModifyFolder_returns_true_for_team_member() {
+        long teamId = teamService.create("dev");
+        long userId = userService.create("alice", Role.USER);
+        teamService.addMember(teamId, userId);
+
+        FolderEntity folder = new FolderEntity();
+        folder.name = "test-folder";
+        folder.team = Team.findById(teamId);
+        folder.persist();
+
+        assertTrue(authService.canModifyFolder("alice", folder));
+    }
+
+    @Test
+    @Transactional
+    void canModifyFolder_returns_false_for_non_member() {
+        long teamId = teamService.create("dev");
+        userService.create("outsider", Role.USER);
+
+        FolderEntity folder = new FolderEntity();
+        folder.name = "test-folder";
+        folder.team = Team.findById(teamId);
+        folder.persist();
+
+        assertFalse(authService.canModifyFolder("outsider", folder));
+    }
+
+    @Test
+    @Transactional
+    void canModifyFolder_returns_true_for_admin() {
+        long teamId = teamService.create("dev");
+        userService.create("boss", Role.ADMIN);
+
+        FolderEntity folder = new FolderEntity();
+        folder.name = "test-folder";
+        folder.team = Team.findById(teamId);
+        folder.persist();
+
+        assertTrue(authService.canModifyFolder("boss", folder));
+    }
+
+    @Test
+    @Transactional
+    void canModifyFolder_returns_true_when_folder_has_no_team() {
+        userService.create("anyone", Role.USER);
+
+        FolderEntity folder = new FolderEntity();
+        folder.name = "legacy-folder";
+        folder.persist();
+
+        assertTrue(authService.canModifyFolder("anyone", folder));
+    }
+
+    @Test
+    @Transactional
+    void requireFolderModify_throws_for_non_member() {
+        long teamId = teamService.create("dev");
+        userService.create("outsider", Role.USER);
+
+        FolderEntity folder = new FolderEntity();
+        folder.name = "test-folder";
+        folder.team = Team.findById(teamId);
+        folder.persist();
+
+        assertThrows(SecurityException.class,
+                () -> authService.requireFolderModify("outsider", folder));
+    }
+
+    @Test
+    void requireAdmin_throws_for_non_admin() {
+        userService.create("regular", Role.USER);
+        assertThrows(SecurityException.class,
+                () -> authService.requireAdmin("regular"));
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/SecurityEnabledProfile.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/SecurityEnabledProfile.java
@@ -1,0 +1,12 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class SecurityEnabledProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("h5m.security.enabled", "true");
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
@@ -1,0 +1,89 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class TeamServiceTest extends FreshDb {
+
+    @Inject
+    TeamService teamService;
+
+    @Inject
+    UserService userService;
+
+    @Test
+    void create_team() {
+        long id = teamService.create("test-team");
+        assertTrue(id > 0);
+        Team team = teamService.byName("test-team");
+        assertNotNull(team);
+        assertEquals("test-team", team.name);
+    }
+
+    @Test
+    void list_teams() {
+        teamService.create("alpha");
+        teamService.create("beta");
+        List<Team> teams = teamService.list();
+        assertEquals(2, teams.size());
+    }
+
+    @Test
+    void delete_team() {
+        long id = teamService.create("to-delete");
+        assertNotNull(teamService.byName("to-delete"));
+        teamService.delete(id);
+        assertNull(teamService.byName("to-delete"));
+    }
+
+    @Test
+    @Transactional
+    void add_member() {
+        long teamId = teamService.create("dev-team");
+        long userId = userService.create("alice", Role.USER);
+        teamService.addMember(teamId, userId);
+
+        Team team = Team.findById(teamId);
+        assertNotNull(team);
+        assertEquals(1, team.members.size());
+        assertEquals("alice", team.members.get(0).username);
+    }
+
+    @Test
+    @Transactional
+    void remove_member() {
+        long teamId = teamService.create("dev-team");
+        long userId = userService.create("bob", Role.USER);
+        teamService.addMember(teamId, userId);
+
+        Team team = Team.findById(teamId);
+        assertEquals(1, team.members.size());
+
+        teamService.removeMember(teamId, userId);
+        team = Team.findById(teamId);
+        assertEquals(0, team.members.size());
+    }
+
+    @Test
+    @Transactional
+    void add_member_is_idempotent() {
+        long teamId = teamService.create("dev-team");
+        long userId = userService.create("carol", Role.USER);
+        teamService.addMember(teamId, userId);
+        teamService.addMember(teamId, userId);
+
+        Team team = Team.findById(teamId);
+        assertEquals(1, team.members.size());
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/UserServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/UserServiceTest.java
@@ -1,0 +1,58 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class UserServiceTest extends FreshDb {
+
+    @Inject
+    UserService userService;
+
+    @Test
+    void create_user() {
+        long id = userService.create("stalep", Role.ADMIN);
+        assertTrue(id > 0);
+        User user = userService.byUsername("stalep");
+        assertNotNull(user);
+        assertEquals("stalep", user.username);
+        assertEquals(Role.ADMIN, user.role);
+    }
+
+    @Test
+    void list_users() {
+        userService.create("alice", Role.USER);
+        userService.create("bob", Role.ADMIN);
+        List<User> users = userService.list();
+        assertEquals(2, users.size());
+    }
+
+    @Test
+    void set_role() {
+        long id = userService.create("carol", Role.USER);
+        userService.setRole(id, Role.ADMIN);
+        User user = userService.byUsername("carol");
+        assertEquals(Role.ADMIN, user.role);
+    }
+
+    @Test
+    void count() {
+        assertEquals(0, userService.count());
+        userService.create("one", Role.USER);
+        userService.create("two", Role.USER);
+        assertEquals(2, userService.count());
+    }
+
+    @Test
+    void byUsername_returns_null_for_missing() {
+        assertNull(userService.byUsername("nonexistent"));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -11,3 +11,6 @@ quarkus.hibernate-orm.schema-management.strategy = update
 # @Transactional work. A smaller pool causes connection starvation and flakiness.
 quarkus.datasource.jdbc.max-size=10
 quarkus.transaction-manager.default-transaction-timeout=PT10m
+
+# Tests run in local mode - no auth
+h5m.security.enabled=false


### PR DESCRIPTION
Introduces User, Team, and ApiKey entities with AuthorizationService as a single authorization checkpoint. Security is config-driven via h5m.security.enabled (default false) preserving backward compatibility. Adds CLI admin commands for user/team management and tests for all new services including security-enabled profile tests.