### PR TITLE
Added DetectionNode and fixed fingerprint scoping for all detection types

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -133,7 +133,7 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
     public abstract NodeType type();
 
     public boolean isDetection() {
-        return type() == NodeType.FIXED_THRESHOLD || type() == NodeType.RELATIVE_DIFFERENCE;
+        return this instanceof io.hyperfoil.tools.h5m.entity.node.DetectionNode;
     }
 
     public boolean hasNonRootSource(){

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/DetectionNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/DetectionNode.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.tools.h5m.entity.node;
+
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+
+/**
+ * Common interface for change detection node types (FixedThreshold, RelativeDifference, etc.)
+ * that share fingerprint, groupBy, and range source nodes plus an optional fingerprint filter.
+ */
+public interface DetectionNode {
+    NodeEntity getFingerprintNode();
+    NodeEntity getGroupByNode();
+    NodeEntity getRangeNode();
+    String getFingerprintFilter();
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Entity
 @DiscriminatorValue("ft")
-public class FixedThreshold extends NodeEntity {
+public class FixedThreshold extends NodeEntity implements DetectionNode {
 
     private static final String MIN = "min";
     private static final String MAX = "max";

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Entity
 @DiscriminatorValue("rd")
-public class RelativeDifference extends NodeEntity {
+public class RelativeDifference extends NodeEntity implements DetectionNode {
 
     private static final String THRESHOLD = "threshold";
     public static final double DEFAULT_THRESHOLD = 0.2;

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -507,62 +507,57 @@ public class NodeService implements NodeServiceInterface {
             List<ValueEntity> fingerprintValues = valueService.getDescendantValues(root, ft.getFingerprintNode());
             String fpFilter = ft.getFingerprintFilter();
 
-            // Check fingerprint filter — if all fingerprints are filtered out, skip this root
-            JsonNode fingerprintData = null;
             for (int fIdx = 0; fIdx < fingerprintValues.size(); fIdx++) {
                 ValueEntity fingerprintValue = fingerprintValues.get(fIdx);
                 if (fpFilter != null && !evaluateFingerprintFilter(fpFilter, fingerprintValue.data)) {
                     continue;
                 }
-                fingerprintData = fingerprintValue.data;
-                break;
-            }
-            if (fingerprintData == null) {
-                return rtrn;
-            }
 
-            // Get range values scoped to this root only
-            List<ValueEntity> rangeValues = valueService.getDescendantValues(root, ft.getRangeNode());
-            for (int rIdx = 0; rIdx < rangeValues.size(); rIdx++) {
-                ValueEntity rangeValue = rangeValues.get(rIdx);
-                Double numericValue;
-                if (rangeValue.data instanceof NumericNode numericNode) {
-                    numericValue = numericNode.asDouble();
-                } else if (rangeValue.data.toString().matches("[0-9]+\\.?[0-9]*")) {
-                    numericValue = Double.parseDouble(rangeValue.data.toString());
-                } else {
-                    continue;
-                }
-
-                FixedThreshold.ViolationType violationType = null;
-                double bound = Double.NaN;
-
-                if (ft.isMinEnabled()) {
-                    if (ft.isMinInclusive() ? numericValue < ft.getMin() : numericValue <= ft.getMin()) {
-                        violationType = FixedThreshold.ViolationType.BELOW;
-                        bound = ft.getMin();
+                // Get range values scoped to this fingerprint and current root
+                List<ValueEntity> rangeValues = valueService.findMatchingFingerprint(
+                    ft.getRangeNode(), groupBy, fingerprintValue, null, null, root, -1, -1, true
+                );
+                for (int rIdx = 0; rIdx < rangeValues.size(); rIdx++) {
+                    ValueEntity rangeValue = rangeValues.get(rIdx);
+                    Double numericValue;
+                    if (rangeValue.data instanceof NumericNode numericNode) {
+                        numericValue = numericNode.asDouble();
+                    } else if (rangeValue.data.toString().matches("[0-9]+\\.?[0-9]*")) {
+                        numericValue = Double.parseDouble(rangeValue.data.toString());
+                    } else {
+                        continue;
                     }
-                }
-                if (violationType == null && ft.isMaxEnabled()) {
-                    if (ft.isMaxInclusive() ? numericValue > ft.getMax() : numericValue >= ft.getMax()) {
-                        violationType = FixedThreshold.ViolationType.ABOVE;
-                        bound = ft.getMax();
-                    }
-                }
 
-                if (violationType != null) {
-                    ObjectNode data = OBJECT_MAPPER.createObjectNode();
-                    data.set("value", new DoubleNode(numericValue));
-                    data.set("bound", new DoubleNode(bound));
-                    data.put("direction", violationType.label());
-                    data.set("fingerprint", fingerprintData);
-                    ValueEntity changeValue = new ValueEntity(root.folder, ft, data);
-                    changeValue.idx = startingOrdinal;
-                    List<ValueEntity> foundParents = valueService.getAncestor(root, groupBy);
-                    if (foundParents.size() == 1) {
-                        changeValue.sources = foundParents;
+                    FixedThreshold.ViolationType violationType = null;
+                    double bound = Double.NaN;
+
+                    if (ft.isMinEnabled()) {
+                        if (ft.isMinInclusive() ? numericValue < ft.getMin() : numericValue <= ft.getMin()) {
+                            violationType = FixedThreshold.ViolationType.BELOW;
+                            bound = ft.getMin();
+                        }
                     }
-                    rtrn.add(changeValue);
+                    if (violationType == null && ft.isMaxEnabled()) {
+                        if (ft.isMaxInclusive() ? numericValue > ft.getMax() : numericValue >= ft.getMax()) {
+                            violationType = FixedThreshold.ViolationType.ABOVE;
+                            bound = ft.getMax();
+                        }
+                    }
+
+                    if (violationType != null) {
+                        ObjectNode data = OBJECT_MAPPER.createObjectNode();
+                        data.set("value", new DoubleNode(numericValue));
+                        data.set("bound", new DoubleNode(bound));
+                        data.put("direction", violationType.label());
+                        data.set("fingerprint", fingerprintValue.data);
+                        ValueEntity changeValue = new ValueEntity(root.folder, ft, data);
+                        changeValue.idx = startingOrdinal;
+                        List<ValueEntity> foundParents = valueService.getAncestor(fingerprintValue, groupBy);
+                        if (foundParents.size() == 1) {
+                            changeValue.sources = foundParents;
+                        }
+                        rtrn.add(changeValue);
+                    }
                 }
             }
         } catch (Exception e) {

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -744,6 +745,256 @@ public class H5mTest {
         assertFalse(result.getOutput().contains("\"example\""),"strings should not be quoted");
 
     }
+    private Path createFixedThresholdSplitData() throws IOException {
+        Path folder = Files.createTempDirectory("h5m");
+        Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "items": [
+                    {"x": "item1", "y": 20.0, "fp1": "alpha"},
+                    {"x": "item2", "y": 175.0, "fp1": "beta"}
+                  ]
+                }
+                """
+        );
+        Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "items": [
+                    {"x": "item1", "y": 5.0, "fp1": "alpha"},
+                    {"x": "item2", "y": 150.0, "fp1": "beta"}
+                  ]
+                }
+                """
+        );
+        Files.writeString(Files.createTempFile(folder, "h5m", ".json").toAbsolutePath(),
+                """
+                {
+                  "items": [
+                    {"x": "item1", "y": 70.0, "fp1": "alpha"},
+                    {"x": "item2", "y": 100.0, "fp1": "beta"}
+                  ]
+                }
+                """
+        );
+        return folder;
+    }
 
+    @Test
+    public void calculate_fixedthreshold_with_multiple_parent_values(QuarkusMainLauncher launcher) throws IOException {
+        String testName = "calculate_fixedthreshold_with_multiple_parent_values";
+        Path folder = createFixedThresholdSplitData();
+
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "itemSplit", ".items[]"},
+                new String[]{"add", "jq", "to", testName, "itemName", "{itemSplit}:.x"},
+                new String[]{"add", "jq", "to", testName, "rangeNode", "{itemSplit}:.y"},
+                new String[]{"add", "jq", "to", testName, "categoryFp", "{itemSplit}:.fp1"},
+                new String[]{"add", "fixedthreshold", "ftNode", "to", testName,
+                        "range", "rangeNode", "by", "itemSplit", "fingerprint", "categoryFp", "min", "10", "max", "100"},
+                new String[]{"upload", folder.toString(), "to", testName},
+                new String[]{"list", "value", "from", testName}
+        );
+
+        results.forEach(result -> assertEquals(0, result.exitCode(), result.getOutput()));
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        assertTrue(output.contains("Count: 33"), "Expected 33 total values\n" + output);
+
+        // Scoping via 'by itemSplit': alpha fingerprint matched to item1 range values only
+        assertTrue(output.contains("\"y\":20,\"fp1\":\"alpha\""), "Alpha should scope to y=20");
+        assertTrue(output.contains("\"y\":5,\"fp1\":\"alpha\""), "Alpha should scope to y=5");
+        assertTrue(output.contains("\"y\":70,\"fp1\":\"alpha\""), "Alpha should scope to y=70");
+
+        // Scoping via 'by itemSplit': beta fingerprint matched to item2 range values only
+        assertTrue(output.contains("\"y\":175,\"fp1\":\"beta\""), "Beta should scope to y=175");
+        assertTrue(output.contains("\"y\":150,\"fp1\":\"beta\""), "Beta should scope to y=150");
+        assertTrue(output.contains("\"y\":100,\"fp1\":\"beta\""), "Beta should scope to y=100");
+    }
+
+    @Test
+    public void calculate_fixedthreshold_with_multiple_parent_values_with_by_split(QuarkusMainLauncher launcher) throws IOException {
+        String testName = "calculate_fixedthreshold_with_multiple_parent_values_with_by_split";
+        Path folder = createFixedThresholdSplitData();
+
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "itemSplit", ".items[]"},
+                new String[]{"add", "jq", "to", testName, "itemName", "{itemSplit}:.x"},
+                new String[]{"add", "jq", "to", testName, "rangeNode", "{itemSplit}:.y"},
+                new String[]{"add", "jq", "to", testName, "categoryFp", "{itemSplit}:.fp1"},
+                new String[]{"add", "fixedthreshold", "ftNode", "to", testName,
+                        "range", "rangeNode", "by", "itemSplit", "fingerprint", "categoryFp", "min", "10", "max", "100"},
+                new String[]{"upload", folder.toString(), "to", testName},
+                new String[]{"list", "value", "from", testName, "by", "itemSplit"}
+        );
+
+        results.forEach(result -> assertEquals(0, result.exitCode(), result.getOutput()));
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        // With 'by itemSplit', violations are parented under itemSplit values.
+        // Listing by itemSplit merges descendants into grouped rows, so violation
+        // data (below/above) should appear within the grouped output.
+        assertTrue(output.contains("Count: 6"), "Expected 6 groups (2 items x 3 uploads)\n" + output);
+        assertTrue(output.contains("below"), "Grouped output should contain below-threshold violation\n" + output);
+        assertTrue(output.contains("above"), "Grouped output should contain above-threshold violation\n" + output);
+    }
+
+    private String qvssPath(String filename) {
+        return new File(Objects.requireNonNull(
+                getClass().getClassLoader().getResource("qvss/" + filename)).getFile()
+        ).getAbsolutePath();
+    }
+
+    @Test
+    public void fixedthreshold_qvss_throughput(QuarkusMainLauncher launcher) {
+        String testName = "fixedthreshold_qvss_throughput";
+
+        // Throughput values (quarkus3-jvm avThroughput):
+        // 27405: 2203 (below), 27406: 2206 (below), 27271: 8778 (below), 27272: 9223 (below)
+        // 26594: 29482 (ok), 26598: 29715 (ok), 27279: 29490 (ok), 27897: 29576 (ok)
+        // 84315: 88777 (above)
+        // Threshold: min=10000, max=35000
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "throughput", ".results.\"quarkus3-jvm\".load.avThroughput"},
+                new String[]{"add", "jq", "to", testName, "version", ".config.QUARKUS_VERSION"},
+                new String[]{"add", "fixedthreshold", "ftNode", "to", testName,
+                        "range", "throughput",
+                        "fingerprint", "version",
+                        "min", "10000",
+                        "max", "35000"},
+                new String[]{"list", testName, "nodes"},
+                new String[]{"upload", qvssPath("27405.json"), "to", testName},
+                new String[]{"upload", qvssPath("27406.json"), "to", testName},
+                new String[]{"upload", qvssPath("27271.json"), "to", testName},
+                new String[]{"upload", qvssPath("27272.json"), "to", testName},
+                new String[]{"upload", qvssPath("26594.json"), "to", testName},
+                new String[]{"upload", qvssPath("26598.json"), "to", testName},
+                new String[]{"upload", qvssPath("27279.json"), "to", testName},
+                new String[]{"upload", qvssPath("27897.json"), "to", testName},
+                new String[]{"upload", qvssPath("84315.json"), "to", testName},
+                new String[]{"list", "value", "from", testName}
+        );
+
+        results.forEach(result -> {
+            assertEquals(0, result.exitCode(), result.getOutput());
+        });
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        // 4 below (2203, 2206, 8778, 9223) + 1 above (88777) = 5 violations
+        assertTrue(output.contains("below"), "should detect below-threshold violations\n" + output);
+        assertTrue(output.contains("above"), "should detect above-threshold violation\n" + output);
+    }
+
+    @Test
+    public void relativedifference_qvss_throughput_regression(QuarkusMainLauncher launcher) {
+        String testName = "relativedifference_qvss_throughput_regression";
+
+        // 9 files from Quarkus 3.7.x, chronological order, shared fingerprint "3.7":
+        // 26594: 3.7.1 tp=29482  (2024-02-02) — baseline
+        // 26598: 3.7.1 tp=29715  (2024-02-02) — stable
+        // 26599: 3.7.1 tp=29561  (2024-02-02) — stable
+        // 26776: 3.7.1 tp=29583  (2024-02-07) — stable
+        // 27271: 3.7.3 tp=8778   (2024-02-19) — big regression (~70% drop)
+        // 27272: 3.7.3 tp=9223   (2024-02-19) — still low
+        // 27279: 3.7.3 tp=29490  (2024-02-19) — recovery
+        // 27405: 3.7.4 tp=2203   (2024-02-22) — severe regression (~93% drop)
+        // 27406: 3.7.4 tp=2206   (2024-02-22) — still low
+        // Fingerprint: major.minor version extracted via split/join → "3.7"
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "throughput", ".results.\"quarkus3-jvm\".load.avThroughput"},
+                new String[]{"add", "jq", "to", testName, "majorMinor", ".config.QUARKUS_VERSION | split(\".\") | .[0:2] | join(\".\")"},
+                new String[]{"add", "jq", "to", testName, "startTime", ".timing.start"},
+                new String[]{"add", "relativedifference", "rdNode", "to", testName,
+                        "range", "throughput",
+                        "domain", "startTime",
+                        "fingerprint", "majorMinor",
+                        "window", "1",
+                        "minPrevious", "3",
+                        "threshold", "0.2"},
+                new String[]{"list", testName, "nodes"},
+                new String[]{"upload", qvssPath("26594.json"), "to", testName},
+                new String[]{"upload", qvssPath("26598.json"), "to", testName},
+                new String[]{"upload", qvssPath("26599.json"), "to", testName},
+                new String[]{"upload", qvssPath("26776.json"), "to", testName},
+                new String[]{"upload", qvssPath("27271.json"), "to", testName},
+                new String[]{"upload", qvssPath("27272.json"), "to", testName},
+                new String[]{"upload", qvssPath("27279.json"), "to", testName},
+                new String[]{"upload", qvssPath("27405.json"), "to", testName},
+                new String[]{"upload", qvssPath("27406.json"), "to", testName},
+                new String[]{"list", "value", "from", testName}
+        );
+
+        results.forEach(result -> {
+            assertEquals(0, result.exitCode(), result.getOutput());
+        });
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        // Detections expected when enough history builds up:
+        // The 29583→8778 drop (~70%) and 29490→2203 drop (~93%) should trigger detection
+        assertTrue(output.contains("ratio"), "should detect throughput regression via relative difference\n" + output);
+    }
+
+    @Test
+    public void fixedthreshold_qvss_split_by_framework(QuarkusMainLauncher launcher) {
+        String testName = "fixedthreshold_qvss_split_by_framework";
+
+        // 6 files with both quarkus-jvm and spring-jvm results:
+        // 7691:  quarkus=28795, spring=10714
+        // 7750:  quarkus=28904, spring=10758
+        // 6313:  quarkus=32798, spring=11088
+        // 6314:  quarkus=37391, spring=12269
+        // 16328: quarkus=28829, spring=9431
+        // 17333: quarkus=28772, spring=9700
+        // Split on .results | to_entries[], fingerprint on framework key
+        // Threshold min=15000: all spring-jvm values violate, no quarkus-jvm values violate
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add", "folder", testName},
+                new String[]{"add", "jq", "to", testName, "framework", ".results | to_entries[]"},
+                new String[]{"add", "jq", "to", testName, "throughput", "{framework}:.value.load.avThroughput"},
+                new String[]{"add", "jq", "to", testName, "fwName", "{framework}:.key"},
+                new String[]{"add", "fixedthreshold", "ftNode", "to", testName,
+                        "range", "throughput",
+                        "by", "framework",
+                        "fingerprint", "fwName",
+                        "min", "15000"},
+                new String[]{"list", testName, "nodes"},
+                new String[]{"upload", qvssPath("7691.json"), "to", testName},
+                new String[]{"upload", qvssPath("7750.json"), "to", testName},
+                new String[]{"upload", qvssPath("6313.json"), "to", testName},
+                new String[]{"upload", qvssPath("6314.json"), "to", testName},
+                new String[]{"upload", qvssPath("16328.json"), "to", testName},
+                new String[]{"upload", qvssPath("17333.json"), "to", testName},
+                new String[]{"list", "value", "from", testName}
+        );
+
+        results.forEach(result -> {
+            assertEquals(0, result.exitCode(), result.getOutput());
+        });
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        // All spring-jvm values (~9400-12200) are below min=15000
+        assertTrue(output.contains("below"), "should detect spring below threshold\n" + output);
+        assertTrue(output.contains("\"fwName\":\"spring-jvm\""),
+                "should have spring-jvm in violation fingerprint\n" + output);
+
+        // All quarkus-jvm values (~28700-37400) are above min=15000
+        // No violation should contain quarkus-jvm fingerprint — scoping must keep them separate
+        assertFalse(output.contains("\"fingerprint\":{\"fwName\":\"quarkus-jvm\"}"),
+                "quarkus-jvm should not appear in violations — scoping broken\n" + output);
+    }
 
 }


### PR DESCRIPTION
Introduces a DetectionNode interface (getFingerprintNode, getGroupByNode, getRangeNode, getFingerprintFilter) implemented by FixedThreshold and RelativeDifference. The shared findScopingNode(DetectionNode) method computes the nearest common ancestor of fingerprint and range nodes via BFS, replacing the user-specified groupBy in findMatchingFingerprint calls. This fixes incorrect cross-fingerprint matching when a split node fans uploads into multiple items.

- FixedThreshold: scopes range values per fingerprint instead of fetching all
- RelativeDifference: uses scopingNode for domain/range matching
- NodeType.isDetection() added for generic detection node identification
- Static ObjectMapper constant replaces per-call instantiation
- Test helper extracted to reduce FixedThreshold test duplication
- Enables previously disabled relativedifference dataset test