### PR TITLE
Add OIDC and API key authentication (issue #57)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.tools.h5m.api.svc;
+
+import io.hyperfoil.tools.h5m.entity.ApiKey;
+
+import java.util.List;
+
+public interface ApiKeyServiceInterface {
+
+    String create(String username, String description);
+
+    List<ApiKey> listByUser(String username);
+
+    void revoke(long keyId);
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCmd.java
@@ -14,6 +14,9 @@ import java.util.concurrent.Callable;
                 AdminListTeams.class,
                 AdminListUsers.class,
                 AdminAddMember.class,
+                AdminCreateApiKey.class,
+                AdminListApiKeys.class,
+                AdminRevokeApiKey.class,
         }
 )
 public class AdminCmd implements Callable<Integer> {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateApiKey.java
@@ -1,0 +1,29 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "create-api-key", description = "create an API key for a user", mixinStandardHelpOptions = true)
+public class AdminCreateApiKey implements Callable<Integer> {
+
+    @Inject
+    ApiKeyServiceInterface apiKeyService;
+
+    @CommandLine.Parameters(index = "0", description = "username")
+    public String username;
+
+    @CommandLine.Option(names = {"--description"}, description = "key description", defaultValue = "")
+    public String description;
+
+    @Override
+    public Integer call() {
+        String rawKey = apiKeyService.create(username, description);
+        System.out.println("API key created for user: " + username);
+        System.out.println("Key: " + rawKey);
+        System.out.println("WARNING: This key cannot be retrieved again. Store it securely.");
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListApiKeys.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListApiKeys.java
@@ -1,0 +1,33 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
+import io.hyperfoil.tools.h5m.entity.ApiKey;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.time.Instant;
+import java.util.List;
+
+@CommandLine.Command(name = "list-api-keys", description = "list API keys for a user", mixinStandardHelpOptions = true)
+public class AdminListApiKeys implements Runnable {
+
+    @Inject
+    ApiKeyServiceInterface apiKeyService;
+
+    @CommandLine.Parameters(index = "0", description = "username")
+    public String username;
+
+    @Override
+    public void run() {
+        List<ApiKey> keys = apiKeyService.listByUser(username);
+        Instant now = Instant.now();
+        System.out.println(ListCmd.table(100, keys,
+                List.of("id", "description", "created", "last_used", "revoked", "expired"),
+                List.of(k -> String.valueOf(k.id),
+                        k -> k.description != null ? k.description : "",
+                        k -> k.createdAt != null ? k.createdAt.toString() : "",
+                        k -> k.lastUsedAt != null ? k.lastUsedAt.toString() : "never",
+                        k -> String.valueOf(k.revoked),
+                        k -> String.valueOf(k.isExpired(now)))));
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminRevokeApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminRevokeApiKey.java
@@ -1,0 +1,24 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "revoke-api-key", description = "revoke an API key", mixinStandardHelpOptions = true)
+public class AdminRevokeApiKey implements Callable<Integer> {
+
+    @Inject
+    ApiKeyServiceInterface apiKeyService;
+
+    @CommandLine.Parameters(index = "0", description = "API key ID")
+    public long keyId;
+
+    @Override
+    public Integer call() {
+        apiKeyService.revoke(keyId);
+        System.out.println("API key " + keyId + " revoked.");
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKey.java
@@ -15,7 +15,7 @@ public class ApiKey extends PanacheEntity {
     @Column(name = "key_hash")
     public String keyHash; // SHA-256 hex
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     public User user;
 
     public String description;

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import io.hyperfoil.tools.yaup.json.Json;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -24,12 +26,14 @@ public class FolderResource {
 
     @GET
     @Path("{name}")
+    @PermitAll
     @Operation(description = "Retrieve a folder by its name")
     public Folder byName(@PathParam("name") String name) {
         return folderService.byName(name);
     }
 
     @GET
+    @PermitAll
     @Operation(description = "Get the upload count for all folders")
     public Map<String, Integer> getFolderUploadCount() {
         return folderService.getFolderUploadCount();
@@ -37,6 +41,7 @@ public class FolderResource {
 
     @POST
     @Path("{name}")
+    @Authenticated
     @Operation(description = "Create a new folder")
     public long create(@PathParam("name") String name) {
         return folderService.create(name);
@@ -44,6 +49,7 @@ public class FolderResource {
 
     @DELETE
     @Path("{name}")
+    @Authenticated
     @Operation(description = "Delete a folder by its name")
     public long delete(@PathParam("name") String name) {
         return folderService.delete(name);
@@ -51,6 +57,7 @@ public class FolderResource {
 
     @POST
     @Path("{name}/upload")
+    @Authenticated
     @Operation(description = "Upload JSON data to a folder")
     public void upload(
             @PathParam("name") String name,
@@ -61,6 +68,7 @@ public class FolderResource {
 
     @POST
     @Path("{name}/recalculate")
+    @Authenticated
     @Operation(description = "Recalculate all values in a folder")
     public void recalculate(@PathParam("name") String name) {
         folderService.recalculate(name);
@@ -68,6 +76,7 @@ public class FolderResource {
 
     @GET
     @Path("{name}/structure")
+    @PermitAll
     @Operation(description = "Get the structural representation of a folder")
     public Json structure(@PathParam("name") String name) {
         return folderService.structure(name);

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
@@ -2,6 +2,8 @@ package io.hyperfoil.tools.h5m.rest;
 
 import io.hyperfoil.tools.h5m.api.NodeGroup;
 import io.hyperfoil.tools.h5m.api.svc.NodeGroupServiceInterface;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -19,6 +21,7 @@ public class NodeGroupResource {
 
     @GET
     @Path("{name}")
+    @PermitAll
     @Operation(description = "Retrieve a node group by its name")
     public NodeGroup byName(@PathParam("name") String groupName) {
         return nodeGroupService.byName(groupName);
@@ -26,6 +29,7 @@ public class NodeGroupResource {
 
     @DELETE
     @Path("{id}")
+    @Authenticated
     @Operation(description = "Delete a node group by its ID")
     public void delete(@PathParam("id") Long groupId) {
         nodeGroupService.delete(groupId);

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -25,6 +27,7 @@ public class NodeResource {
     NodeServiceInterface nodeService;
 
     @POST
+    @Authenticated
     @Operation(description = "Create a new node with an operation")
     public Long create(
             @QueryParam("name") @NotEmpty String name,
@@ -36,6 +39,7 @@ public class NodeResource {
 
     @POST
     @Path("configured")
+    @Authenticated
     @Operation(description = "Create a new node with sources and configuration")
     public Long createConfigured(
             @QueryParam("name") @NotEmpty String name,
@@ -54,6 +58,7 @@ public class NodeResource {
 
     @DELETE
     @Path("{id}")
+    @Authenticated
     @Operation(description = "Delete a node by its ID")
     public void delete(@PathParam("id") Long nodeId) {
         nodeService.delete(nodeId);
@@ -61,6 +66,7 @@ public class NodeResource {
 
     @GET
     @Path("find")
+    @PermitAll
     @Operation(description = "Find nodes by FQDN within a specific group")
     public List<Node> findNodeByFqdn(
             @QueryParam("name") @Parameter(description = "FQDN of the node") String name,

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
@@ -3,6 +3,8 @@ package io.hyperfoil.tools.h5m.rest;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.h5m.api.Value;
 import io.hyperfoil.tools.h5m.api.svc.ValueServiceInterface;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -21,6 +23,7 @@ public class ValueResource {
     ValueServiceInterface valueService;
 
     @DELETE
+    @RolesAllowed("admin")
     @Operation(description = "Purge all values")
     public void purgeValues() {
         valueService.purgeValues();
@@ -28,6 +31,7 @@ public class ValueResource {
 
     @GET
     @Path("node/{nodeId}/descendants")
+    @PermitAll
     @Operation(description = "Get descendant values of a specific node")
     public List<Value> getNodeDescendantValues(@PathParam("nodeId") Long nodeId) {
         return valueService.getNodeDescendantValues(nodeId);
@@ -35,6 +39,7 @@ public class ValueResource {
 
     @GET
     @Path("node/{nodeId}/grouped")
+    @PermitAll
     @Operation(description = "Get grouped values for a specific node")
     public List<JsonNode> getGroupedValues(@PathParam("nodeId") Long nodeId) {
         return valueService.getGroupedValues(nodeId);

--- a/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyAuthenticationMechanism.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyAuthenticationMechanism.java
@@ -1,0 +1,79 @@
+package io.hyperfoil.tools.h5m.server;
+
+import java.util.Collections;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.AuthenticationRequest;
+import io.quarkus.security.identity.request.BaseAuthenticationRequest;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanism {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String H5M_PREFIX = "H5M_";
+
+    @ConfigProperty(name = "h5m.security.enabled", defaultValue = "false")
+    boolean securityEnabled;
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+        if (!securityEnabled) {
+            SecurityIdentity localAdmin = QuarkusSecurityIdentity.builder()
+                    .setPrincipal(new QuarkusPrincipal("local"))
+                    .addRole("admin")
+                    .addRole("user")
+                    .build();
+            return Uni.createFrom().item(localAdmin);
+        }
+        String authorization = context.request().headers().get("Authorization");
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return Uni.createFrom().nullItem();
+        }
+        String token = authorization.substring(BEARER_PREFIX.length());
+        if (!token.startsWith(H5M_PREFIX)) {
+            return Uni.createFrom().nullItem();
+        }
+        return identityProviderManager.authenticate(new Request(token));
+    }
+
+    @Override
+    public Uni<ChallengeData> getChallenge(RoutingContext context) {
+        return Uni.createFrom().item(new ChallengeData(HttpResponseStatus.UNAUTHORIZED.code(), null, null));
+    }
+
+    @Override
+    public Set<Class<? extends AuthenticationRequest>> getCredentialTypes() {
+        return Collections.singleton(Request.class);
+    }
+
+    @Override
+    public Uni<HttpCredentialTransport> getCredentialTransport(RoutingContext context) {
+        return Uni.createFrom().item(new HttpCredentialTransport(HttpCredentialTransport.Type.AUTHORIZATION, "Bearer"));
+    }
+
+    public static class Request extends BaseAuthenticationRequest implements AuthenticationRequest {
+
+        private final String key;
+
+        public Request(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
@@ -1,0 +1,43 @@
+package io.hyperfoil.tools.h5m.server;
+
+import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.svc.ApiKeyService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.IdentityProvider;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class ApiKeyIdentityProvider implements IdentityProvider<ApiKeyAuthenticationMechanism.Request> {
+
+    @Inject
+    ApiKeyService apiKeyService;
+
+    @Override
+    public Class<ApiKeyAuthenticationMechanism.Request> getRequestType() {
+        return ApiKeyAuthenticationMechanism.Request.class;
+    }
+
+    @Override
+    public Uni<SecurityIdentity> authenticate(ApiKeyAuthenticationMechanism.Request request,
+            AuthenticationRequestContext context) {
+        return context.runBlocking(() -> identityFromKey(request.getKey()));
+    }
+
+    @Transactional
+    SecurityIdentity identityFromKey(String key) {
+        User user = apiKeyService.validateKey(key);
+        if (user == null) {
+            return null;
+        }
+        return QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal(user.username))
+                .build();
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
@@ -1,0 +1,42 @@
+package io.hyperfoil.tools.h5m.server;
+
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.svc.UserService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
+
+    @Inject
+    UserService userService;
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        if (identity.isAnonymous()) {
+            return Uni.createFrom().item(identity);
+        }
+        return context.runBlocking(() -> addRoles(identity));
+    }
+
+    private SecurityIdentity addRoles(SecurityIdentity identity) {
+        String username = identity.getPrincipal().getName();
+        User user = userService.byUsername(username);
+        if (user == null) {
+            return identity;
+        }
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
+        builder.addRole("user");
+        if (user.role == Role.ADMIN) {
+            builder.addRole("admin");
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
@@ -1,0 +1,40 @@
+package io.hyperfoil.tools.h5m.server;
+
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.svc.UserService;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import io.quarkus.logging.Log;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.smallrye.mutiny.Uni;
+
+@ApplicationScoped
+@Priority(1)
+public class OidcUserProvisioner implements SecurityIdentityAugmentor {
+
+    @Inject
+    UserService userService;
+
+    @Override
+    public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+        if (identity.isAnonymous()) {
+            return Uni.createFrom().item(identity);
+        }
+        return context.runBlocking(() -> provisionIfNeeded(identity));
+    }
+
+    private SecurityIdentity provisionIfNeeded(SecurityIdentity identity) {
+        String username = identity.getPrincipal().getName();
+        if (userService.byUsername(username) != null) {
+            return identity;
+        }
+        Role role = userService.count() == 0 ? Role.ADMIN : Role.USER;
+        userService.create(username, role);
+        Log.infof("Auto-provisioned user %s with role %s", username, role);
+        return identity;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
@@ -1,0 +1,85 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
+import io.hyperfoil.tools.h5m.entity.ApiKey;
+import io.hyperfoil.tools.h5m.entity.User;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+
+@ApplicationScoped
+public class ApiKeyService implements ApiKeyServiceInterface {
+
+    @ConfigProperty(name = "h5m.api-key.expiration-days", defaultValue = "365")
+    long expirationDays;
+
+    @Inject
+    UserService userService;
+
+    @Override
+    @Transactional
+    public String create(String username, String description) {
+        User user = userService.byUsername(username);
+        if (user == null) {
+            throw new IllegalArgumentException("User not found: " + username);
+        }
+        String rawKey = "H5M_" + UUID.randomUUID().toString().replace("-", "_").toUpperCase();
+        ApiKey apiKey = new ApiKey();
+        apiKey.keyHash = hashKey(rawKey);
+        apiKey.user = user;
+        apiKey.description = description;
+        apiKey.createdAt = Instant.now();
+        apiKey.activeDays = expirationDays;
+        apiKey.revoked = false;
+        apiKey.persist();
+        return rawKey;
+    }
+
+    @Override
+    @Transactional
+    public List<ApiKey> listByUser(String username) {
+        return ApiKey.find("user.username", username).list();
+    }
+
+    @Override
+    @Transactional
+    public void revoke(long keyId) {
+        ApiKey key = ApiKey.findById(keyId);
+        if (key != null) {
+            key.revoked = true;
+        }
+    }
+
+    @Transactional
+    public User validateKey(String rawKey) {
+        if (rawKey == null || !rawKey.startsWith("H5M_")) {
+            return null;
+        }
+        String hash = hashKey(rawKey);
+        ApiKey apiKey = ApiKey.find("keyHash", hash).firstResult();
+        if (apiKey == null || apiKey.revoked || apiKey.isExpired(Instant.now())) {
+            return null;
+        }
+        apiKey.recordAccess();
+        return apiKey.user;
+    }
+
+    static String hashKey(String rawKey) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawKey.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -57,3 +57,14 @@ quarkus.transaction-manager.default-transaction-timeout=PT10m
 # Security - disabled by default (local/CLI mode)
 h5m.security.enabled=false
 h5m.api-key.expiration-days=365
+
+# Disable proactive auth so unauthenticated requests can reach @PermitAll endpoints
+quarkus.http.auth.proactive=false
+
+# OIDC - disabled by default (enable via environment for service deployments)
+quarkus.oidc.tenant-enabled=false
+quarkus.oidc.auth-server-url=${OIDC_AUTH_SERVER_URL:}
+quarkus.oidc.client-id=${OIDC_CLIENT_ID:h5m}
+quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:}
+quarkus.oidc.application-type=service
+quarkus.oidc.token.principal-claim=preferred_username

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
@@ -1,0 +1,104 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.svc.ApiKeyService;
+import io.hyperfoil.tools.h5m.svc.SecurityEnabledProfile;
+import io.hyperfoil.tools.h5m.svc.UserService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+@TestProfile(SecurityEnabledProfile.class)
+public class ApiKeyAuthTest extends FreshDb {
+
+    @Inject
+    UserService userService;
+
+    @Inject
+    ApiKeyService apiKeyService;
+
+    @Test
+    void write_endpoint_returns_401_without_auth() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .when().post("/api/folder/test")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void read_endpoint_returns_200_without_auth() {
+        given()
+                .when().get("/api/folder")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void write_endpoint_succeeds_with_valid_api_key() {
+        userService.create("writer", Role.USER);
+        String key = apiKeyService.create("writer", "write key");
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + key)
+                .when().post("/api/folder/auth-test")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void write_endpoint_returns_401_with_invalid_key() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer H5M_INVALID_KEY_12345678")
+                .when().post("/api/folder/test")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void write_endpoint_returns_401_with_revoked_key() {
+        userService.create("revoked-user", Role.USER);
+        String key = apiKeyService.create("revoked-user", "revoked key");
+        var keys = apiKeyService.listByUser("revoked-user");
+        apiKeyService.revoke(keys.get(0).id);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + key)
+                .when().post("/api/folder/test")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void purge_endpoint_returns_403_for_non_admin() {
+        userService.create("regular", Role.USER);
+        String key = apiKeyService.create("regular", "user key");
+
+        given()
+                .header("Authorization", "Bearer " + key)
+                .when().delete("/api/value")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    void purge_endpoint_succeeds_for_admin() {
+        userService.create("admin", Role.ADMIN);
+        String key = apiKeyService.create("admin", "admin key");
+
+        given()
+                .header("Authorization", "Bearer " + key)
+                .when().delete("/api/value")
+                .then()
+                .statusCode(204);
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
@@ -1,0 +1,81 @@
+package io.hyperfoil.tools.h5m.server;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.svc.SecurityEnabledProfile;
+import io.hyperfoil.tools.h5m.svc.UserService;
+import io.quarkus.security.identity.AuthenticationRequestContext;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.runtime.QuarkusPrincipal;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(SecurityEnabledProfile.class)
+public class AutoProvisioningTest extends FreshDb {
+
+    @Inject
+    OidcUserProvisioner provisioner;
+
+    @Inject
+    UserService userService;
+
+    private final AuthenticationRequestContext testContext = new AuthenticationRequestContext() {
+        @Override
+        public Uni<SecurityIdentity> runBlocking(Supplier<SecurityIdentity> supplier) {
+            return Uni.createFrom().item(supplier);
+        }
+    };
+
+    private SecurityIdentity identityFor(String username) {
+        return QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal(username))
+                .build();
+    }
+
+    @Test
+    void first_user_gets_admin_role() {
+        assertEquals(0, userService.count());
+        provisioner.augment(identityFor("first-user"), testContext)
+                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .awaitItem();
+
+        User user = userService.byUsername("first-user");
+        assertNotNull(user);
+        assertEquals(Role.ADMIN, user.role);
+    }
+
+    @Test
+    void subsequent_user_gets_user_role() {
+        userService.create("existing-admin", Role.ADMIN);
+
+        provisioner.augment(identityFor("new-user"), testContext)
+                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .awaitItem();
+
+        User user = userService.byUsername("new-user");
+        assertNotNull(user);
+        assertEquals(Role.USER, user.role);
+    }
+
+    @Test
+    void existing_user_not_duplicated() {
+        userService.create("alice", Role.USER);
+        assertEquals(1, userService.count());
+
+        provisioner.augment(identityFor("alice"), testContext)
+                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .awaitItem();
+
+        assertEquals(1, userService.count());
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
@@ -1,0 +1,111 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.ApiKey;
+import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.entity.User;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(SecurityEnabledProfile.class)
+public class ApiKeyServiceTest extends FreshDb {
+
+    @Inject
+    ApiKeyService apiKeyService;
+
+    @Inject
+    UserService userService;
+
+    @Test
+    void create_key_returns_prefixed_string() {
+        userService.create("alice", Role.USER);
+        String key = apiKeyService.create("alice", "test key");
+        assertNotNull(key);
+        assertTrue(key.startsWith("H5M_"));
+    }
+
+    @Test
+    void create_key_stores_hash_not_raw() {
+        userService.create("bob", Role.USER);
+        String rawKey = apiKeyService.create("bob", "my key");
+        List<ApiKey> keys = apiKeyService.listByUser("bob");
+        assertEquals(1, keys.size());
+        assertNotEquals(rawKey, keys.get(0).keyHash);
+    }
+
+    @Test
+    void validate_key_returns_user() {
+        userService.create("carol", Role.USER);
+        String rawKey = apiKeyService.create("carol", "valid key");
+        User user = apiKeyService.validateKey(rawKey);
+        assertNotNull(user);
+        assertEquals("carol", user.username);
+    }
+
+    @Test
+    void validate_key_returns_null_for_unknown() {
+        assertNull(apiKeyService.validateKey("H5M_UNKNOWN_KEY_VALUE_HERE"));
+    }
+
+    @Test
+    void validate_key_returns_null_for_invalid_prefix() {
+        assertNull(apiKeyService.validateKey("INVALID_KEY"));
+    }
+
+    @Test
+    void validate_key_returns_null_for_revoked() {
+        userService.create("dave", Role.USER);
+        String rawKey = apiKeyService.create("dave", "revoke me");
+        List<ApiKey> keys = apiKeyService.listByUser("dave");
+        apiKeyService.revoke(keys.get(0).id);
+        assertNull(apiKeyService.validateKey(rawKey));
+    }
+
+    @Test
+    void validate_key_updates_lastUsedAt() {
+        userService.create("eve", Role.USER);
+        String rawKey = apiKeyService.create("eve", "track access");
+        List<ApiKey> before = apiKeyService.listByUser("eve");
+        assertNull(before.get(0).lastUsedAt);
+
+        apiKeyService.validateKey(rawKey);
+
+        List<ApiKey> after = apiKeyService.listByUser("eve");
+        assertNotNull(after.get(0).lastUsedAt);
+    }
+
+    @Test
+    void list_keys_by_user() {
+        userService.create("frank", Role.USER);
+        apiKeyService.create("frank", "key one");
+        apiKeyService.create("frank", "key two");
+        List<ApiKey> keys = apiKeyService.listByUser("frank");
+        assertEquals(2, keys.size());
+    }
+
+    @Test
+    void revoke_key() {
+        userService.create("grace", Role.USER);
+        apiKeyService.create("grace", "to revoke");
+        List<ApiKey> keys = apiKeyService.listByUser("grace");
+        assertFalse(keys.get(0).revoked);
+
+        apiKeyService.revoke(keys.get(0).id);
+
+        keys = apiKeyService.listByUser("grace");
+        assertTrue(keys.get(0).revoked);
+    }
+
+    @Test
+    void create_key_throws_for_unknown_user() {
+        assertThrows(IllegalArgumentException.class,
+                () -> apiKeyService.create("nonexistent", "key"));
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -14,3 +14,4 @@ quarkus.transaction-manager.default-transaction-timeout=PT10m
 
 # Tests run in local mode - no auth
 h5m.security.enabled=false
+quarkus.oidc.tenant-enabled=false


### PR DESCRIPTION
Wire up HTTP authentication for h5m's REST API. API keys use Authorization: Bearer H5M_xxx with SHA-256 hashing. OIDC is opt-in via environment variables. First user to authenticate is auto-promoted to admin. Read endpoints are public, write endpoints require auth, value purge requires admin role. Local mode provides a synthetic admin identity so existing behavior is unchanged.