### PR TITLE
Fix createParameters to wrap source values in ObjectNode for unmatche…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
@@ -99,7 +99,11 @@ public class JsNode extends NodeEntity {
                 }
             }else{
                 if(!sourceValues.containsKey(param)){
-                    System.err.println("unable to find parameter value for " + param);
+                    if(params.size()==1 && !sourceValues.isEmpty()){
+                        ObjectNode obj = mapper.createObjectNode();
+                        sourceValues.forEach((k,v) -> obj.set(k, v.data));
+                        rtrn.add(obj);
+                    }
                 }else{
                     if(currentNode != null){
                         currentNode.set(param,sourceValues.get(param).data);

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
@@ -144,6 +144,39 @@ public class JsNodeTest {
     }
 
     @Test
+    public void createParameters_single_param_unmatched_wraps_in_object() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, ValueEntity> values = Map.of(
+                "source0", new ValueEntity(null, null, mapper.readTree("\"hello\"")),
+                "source1", new ValueEntity(null, null, mapper.readTree("\"world\""))
+        );
+        List<JsonNode> params = JsNode.createParameters("obj => Object.values(obj)", values);
+        assertNotNull(params);
+        assertEquals(1, params.size(), "should wrap all sources into one ObjectNode");
+        assertInstanceOf(ObjectNode.class, params.get(0));
+        ObjectNode obj = (ObjectNode) params.get(0);
+        assertTrue(obj.has("source0"), "should contain source0 key");
+        assertTrue(obj.has("source1"), "should contain source1 key");
+        assertEquals("\"hello\"", obj.get("source0").toString());
+        assertEquals("\"world\"", obj.get("source1").toString());
+    }
+
+    @Test
+    public void createParameters_single_param_single_source_wraps_in_object() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, ValueEntity> values = Map.of(
+                "mySource", new ValueEntity(null, null, mapper.readTree("\"value\""))
+        );
+        List<JsonNode> params = JsNode.createParameters("obj => obj.mySource", values);
+        assertNotNull(params);
+        assertEquals(1, params.size());
+        assertInstanceOf(ObjectNode.class, params.get(0));
+        ObjectNode obj = (ObjectNode) params.get(0);
+        assertTrue(obj.has("mySource"));
+        assertEquals("\"value\"", obj.get("mySource").toString());
+    }
+
+    @Test
     public void parse_sources(){
         Map<String, NodeEntity> existing = Map.of("a",new JqNode("a",".a"),
                 "b",new JqNode("b",".b"));


### PR DESCRIPTION
…d single-param functions (#67)

When a JS function has a single parameter name that doesn't match any source value key (e.g., obj => Object.values(obj).find(v => v != null)), createParameters now wraps all source values into a named-property ObjectNode instead of returning an empty list.

Previously, the function would receive no arguments, causing Object.values(undefined) to throw or — when the raw value was passed through a different code path — Object.values("string") to iterate characters, truncating values to their first character.

Fixes #67