### PR TITLE
Handle JS function parameters with default values in JsNode.parse (#68)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
@@ -31,11 +31,13 @@ public class JsNode extends NodeEntity {
      * its sources.
      */
     public static JsNode parse(String name, String input, Function<String,List<NodeEntity>> nodeFn){
+        return parse(name, input, nodeFn, false);
+    }
+    public static JsNode parse(String name, String input, Function<String,List<NodeEntity>> nodeFn, boolean ignoreMissing){
         if(input==null || input.isBlank()){
             System.err.println("missing js node input");
             return null;
         }
-        JsNode rtrn = null;
         List<String> parameters = getParameterNames(input);
         if(parameters == null){
             System.err.println("unable to recognize javascript function from:\n"+input);
@@ -44,12 +46,16 @@ public class JsNode extends NodeEntity {
         boolean ok = true;
         List<NodeEntity> sourceNodes = new ArrayList<>();
         for (String param : parameters) {
-            List<NodeEntity> foundNodes = nodeFn.apply(param);
+            String paramName = param.contains("=") ? param.substring(0, param.indexOf('=')).trim() : param;
+            boolean hasDefault = param.contains("=");
+            List<NodeEntity> foundNodes = nodeFn.apply(paramName);
             if (foundNodes.isEmpty()) {
-                System.err.println("Could not find node for " + param);
-                ok = false;
+                if (!hasDefault) {
+                    System.err.println("Could not find node for " + paramName);
+                    ok = false;
+                }
             } else if (foundNodes.size() > 1) {
-                System.err.println("Found more than one node matching " + param);
+                System.err.println("Found more than one node matching " + paramName);
                 for (int i = 0; i < foundNodes.size(); i++) {
                     System.err.println(i + " " + foundNodes.get(i).getFqdn());
                 }
@@ -58,10 +64,10 @@ public class JsNode extends NodeEntity {
                 sourceNodes.add(foundNodes.get(0));
             }
         }
-        if(ok) {
-            rtrn = new JsNode(name, input, sourceNodes);
+        if(ok || (ignoreMissing && !sourceNodes.isEmpty())) {
+            return new JsNode(name, input, sourceNodes);
         }
-        return rtrn;
+        return null;
     }
 
     public static List<JsonNode> createParameters(String function, Map<String, ValueEntity> sourceValues){

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
@@ -163,4 +163,45 @@ public class JsNodeTest {
         assertEquals(existing.get("b"),sources.get(1),"expected b value");
     }
 
+    @Test
+    public void parse_with_default_params_skips_missing(){
+        Map<String, NodeEntity> existing = Map.of("data", new JqNode("data", ".data"));
+
+        Function<String,List<NodeEntity>> getExisting = s ->
+                existing.containsKey(s) ? List.of(existing.get(s)) : Collections.emptyList();
+
+        // Function has 3 params but only 'data' has a node; others have defaults
+        JsNode node = JsNode.parse("node", "(data, threshold=0.5, verbose=false) => data > threshold", getExisting);
+        assertNotNull(node, "should succeed — unmatched params have defaults");
+        assertEquals(1, node.sources.size());
+        assertEquals(existing.get("data"), node.sources.get(0));
+    }
+
+    @Test
+    public void parse_fails_when_required_param_missing(){
+        Map<String, NodeEntity> existing = Map.of("a", new JqNode("a", ".a"));
+
+        Function<String,List<NodeEntity>> getExisting = s ->
+                existing.containsKey(s) ? List.of(existing.get(s)) : Collections.emptyList();
+
+        // 'b' has no default and no node — should fail
+        JsNode node = JsNode.parse("node", "(a, b) => a + b", getExisting);
+        assertNull(node, "should fail — 'b' has no default and no node");
+    }
+
+    @Test
+    public void parse_with_complex_defaults(){
+        Map<String, NodeEntity> existing = Map.of("nestedArr", new JqNode("nestedArr", ".data"));
+
+        Function<String,List<NodeEntity>> getExisting = s ->
+                existing.containsKey(s) ? List.of(existing.get(s)) : Collections.emptyList();
+
+        // Simulates Horreum boot-time label with string defaults
+        String func = "(nestedArr, nameRegexPattern=\"Starting Load\", calculateCvPercent=false, index = 0) => { return nestedArr; }";
+        JsNode node = JsNode.parse("node", func, getExisting);
+        assertNotNull(node, "should succeed — only nestedArr is required");
+        assertEquals(1, node.sources.size());
+        assertEquals(existing.get("nestedArr"), node.sources.get(0));
+    }
+
 }


### PR DESCRIPTION
JsNode.parse now strips default values (e.g., threshold=0.5) from parameter names before looking up source nodes. Parameters with defaults that don't match any node are treated as optional — the JS runtime will use their default values at execution time.

This fixes the legacy import for Horreum labels with complex functions like boot-time's KPI labels:
  (nestedArr, nameRegexPattern="...", calculateCvPercent=false, ...) => {}
These have 6 parameters but only 1 extractor. Previously parse() failed because it couldn't find nodes for the 5 defaulted parameters.

Also adds ignoreMissing parameter to the public parse() API, allowing callers to accept partial source resolution when combined with other fallback mechanisms.

Fixes #68