### PR TITLE
Add indexes on value(node_id, folder_id) and remove redundant OR from…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -16,6 +16,10 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Entity(name = "value")
+@Table(indexes = {
+    @Index(name = "idx_value_node_id", columnList = "node_id"),
+    @Index(name = "idx_value_folder_id", columnList = "folder_id")
+})
 public class ValueEntity extends PanacheEntity {
 
     @Column(columnDefinition = "JSONB")

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -487,12 +487,12 @@ public class ValueService implements ValueServiceInterface {
         rtrn.addAll(em.createNativeQuery(
                 """
                 WITH RECURSIVE sourceRecursive (v_id) AS (
-                    SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId OR ve.child_id = :rootId
+                    SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId
                     UNION ALL
                     SELECT ve.child_id from value_edge ve JOIN sourceRecursive sr
                     ON ve.parent_id = sr.v_id
                 )
-                SELECT distinct * FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id WHERE v.node_id = :nodeId
+                SELECT distinct v.* FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id WHERE v.node_id = :nodeId
                 """, ValueEntity.class
         ).setParameter("rootId", root.id).setParameter("nodeId",node.id).getResultList());
         return rtrn;
@@ -528,7 +528,7 @@ public class ValueService implements ValueServiceInterface {
         }
         List<ValueEntity> all = em.createNativeQuery("""
                 WITH RECURSIVE sourceRecursive (v_id) AS (
-                    SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId OR ve.child_id = :rootId
+                    SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId
                     UNION ALL
                     SELECT ve.child_id from value_edge ve JOIN sourceRecursive sr ON ve.parent_id = sr.v_id
                 )

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -982,6 +983,70 @@ public class ValueServiceTest extends FreshDb {
 
         assertFalse(found.contains(rootValue),"descendants should not include self: "+found);
         assertTrue(found.contains(bravobravoValue),"descendants should include value from target node: "+found);
+    }
+
+    @Test
+    public void getDescendantValues_excludes_root_when_same_node() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        // Single node — all values belong to the same node type
+        NodeEntity node = new JqNode("sametype");
+        node.persist();
+
+        // root → child → grandchild, all on the same node
+        ValueEntity rootValue = new ValueEntity(null, node, new TextNode("root-data"));
+        rootValue.persist();
+
+        ValueEntity childValue = new ValueEntity(null, node, new TextNode("child-data"));
+        childValue.sources = List.of(rootValue);
+        childValue.persist();
+
+        ValueEntity grandchildValue = new ValueEntity(null, node, new TextNode("grandchild-data"));
+        grandchildValue.sources = List.of(childValue);
+        grandchildValue.persist();
+        tm.commit();
+
+        // Query descendants of rootValue filtered to the SAME node type
+        List<ValueEntity> found = valueService.getDescendantValues(rootValue, node);
+
+        assertFalse(found.contains(rootValue),
+            "root value should not appear in its own descendants even when node types match");
+        assertTrue(found.contains(childValue),
+            "child value should be in descendants");
+        assertTrue(found.contains(grandchildValue),
+            "grandchild value should be in descendants");
+        assertEquals(2, found.size(),
+            "should find exactly 2 descendants: " + found);
+    }
+
+    @Test
+    public void getDescendantValuesByNodes_excludes_root_when_same_node() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity node = new JqNode("sametype");
+        node.persist();
+
+        ValueEntity rootValue = new ValueEntity(null, node, new TextNode("root-data"));
+        rootValue.persist();
+
+        ValueEntity childValue = new ValueEntity(null, node, new TextNode("child-data"));
+        childValue.sources = List.of(rootValue);
+        childValue.persist();
+
+        ValueEntity grandchildValue = new ValueEntity(null, node, new TextNode("grandchild-data"));
+        grandchildValue.sources = List.of(childValue);
+        grandchildValue.persist();
+        tm.commit();
+
+        Map<Long, List<ValueEntity>> found = valueService.getDescendantValuesByNodes(rootValue, List.of(node));
+
+        List<ValueEntity> values = found.getOrDefault(node.getId(), List.of());
+        assertFalse(values.contains(rootValue),
+            "root value should not appear in its own descendants even when node types match");
+        assertTrue(values.contains(childValue),
+            "child value should be in descendants");
+        assertTrue(values.contains(grandchildValue),
+            "grandchild value should be in descendants");
+        assertEquals(2, values.size(),
+            "should find exactly 2 descendants: " + values);
     }
 
     @Test


### PR DESCRIPTION
… recursive CTE base case

- Add @Table indexes for node_id and folder_id on ValueEntity, critical for CTE query performance when filtering results by node
- Remove 'OR ve.child_id = :rootId' from getDescendantValues and getDescendantValuesByNodes CTEs — the OR prevented efficient index usage on parent_id and was unnecessary (root is never its own descendant)
- Add tests verifying descendants exclude root when root shares the same node type as the query target