### PR TITLE
Skip Hibernate deep copy for ValueEntity.data JSON column

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -9,7 +9,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.persistence.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.Mutability;
 import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.java.Immutability;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -25,6 +27,7 @@ public class ValueEntity extends PanacheEntity {
     @Column(columnDefinition = "JSONB")
     @JdbcTypeCode(SqlTypes.JSON)
     @Basic(fetch = FetchType.LAZY)
+    @Mutability(Immutability.class)
     public JsonNode data;
 
     //not yet used but the idea is to sort multiple values based on idx to preserve node output order for next nodes input


### PR DESCRIPTION
## Summary
- Add `@Mutability(Immutability.class)` to `ValueEntity.data` so Hibernate uses reference equality for dirty-checking instead of deserializing and comparing the full JSON tree

## Problem
Hibernate's `FormatMapperBasedJavaType.deepCopy` deserializes and re-serializes the JSONB `data` column on every flush to create a snapshot for dirty comparison. Profiling showed this consumed ~50% of CPU during uploads (deepCopy + dirty-checking combined).

## Fix
`@Mutability(Immutability.class)` tells Hibernate the field value is never mutated in-place — changes are only made by replacing the reference (`data = newData`). Hibernate then uses the original reference as the snapshot and compares with `==` instead of deep tree comparison.

All code paths that modify `data` use reference replacement, never in-place mutation (e.g., no `data.put("key", val)`), so reference equality is correct.

## Benchmark — rhivos-perf-comprehensive legacy import (5 runs, 4 workers, PostgreSQL)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Wall-clock | 1m36s | 1m20s | **-17%** |
| CPU user | 2m02s | 0m59s | **-51%** |
| dirty-checking samples | 3,946 | 2 | **-99.97%** |
| deepCopy samples | 2,169 | 0 | **-100%** |
| GC samples | 1,764 | 1,572 | -11% |

## Test plan
- [x] All 207 existing tests pass
- [x] Verified no code path mutates `data` in-place — all are reference replacements
- [x] Recalculation tests confirm dirty detection still works for `existingValue.data = newValue.data` reassignment