### PR TITLE
Remove CascadeType.MERGE from Work entity relationships

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class Work  extends PanacheEntity implements Runnable, Comparable<Work>{
 
     @BatchSize(size=10)
-    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(
             name="work_values",
             joinColumns = @JoinColumn(name = "work_id"),
@@ -30,7 +30,7 @@ public class Work  extends PanacheEntity implements Runnable, Comparable<Work>{
     public List<ValueEntity> sourceValues;//multiple values could happen for cross test comparisons and
 
     @BatchSize(size=10)
-    @ManyToMany(cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+    @ManyToMany(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY)
     @JoinTable(
             name="work_nodes",
             joinColumns = @JoinColumn(name = "work_id"),


### PR DESCRIPTION
## Summary
Remove `CascadeType.MERGE` from `sourceValues` and `sourceNodes` on the Work entity, keeping only `CascadeType.PERSIST`.

## Problem
`em.merge(work)` in `WorkService.create()` cascades to every related `ValueEntity` and `NodeEntity`, causing Hibernate to re-serialize their JSONB `data` columns for UPDATE statements — even though these entities are already managed and unmodified in the persistence context.

Allocation profiling (async-profiler `--alloc --total`) showed this cascade produced **9.4 GB** of unnecessary JSON serialization during a 5-run rhivos import:

| Serialization path | Before | After |
|---|---|---|
| UPDATE (cascade merge) | 9,442 MB | **0 MB** |
| INSERT (actual writes) | 1,247 MB | 1,224 MB |
| **Total allocated** | **31.6 GB** | **20.8 GB** |

## Why this does not change behavior

All three Work creation sites pass only **managed, unmodified** entities as source values and nodes — `CascadeType.MERGE` was a no-op that triggered redundant serialization:

1. **`FolderService.upload()`** — nodes loaded via JPQL `JOIN FETCH`, values just created by `valueService.create()` in the same transaction. All managed.
2. **`FolderService.recalculate()`** — nodes and values loaded via queries in the same transaction. All managed.
3. **`WorkService.execute()`** — dependent nodes from `getDependentNodes()` (JPQL with `JOIN FETCH`), source values from `em.find(Work)`. All managed.

Since all related entities are already managed when `em.merge(work)` is called, the cascade merge has no effect other than triggering Hibernate to dirty-check and re-serialize their JSONB columns.

`CascadeType.PERSIST` is retained so that transient entities passed as sources are still automatically persisted via cascade.

## Benchmark — rhivos-perf-comprehensive legacy import (5 runs, 4 workers, PostgreSQL)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total allocation | 31.6 GB | 20.8 GB | **-34%** |
| Wall-clock | 1m24s | 1m14s | **-12%** |
| CPU user | 1m06s | 0m56s | **-15%** |

## Test plan
- [x] All 207 tests pass
- [x] Verified all Work creation sites only pass managed entities
- [x] Allocation profile confirms UPDATE serialization eliminated