### PR TITLE
Add notification system infrastructure (issue #89, Phase 1)

### DIFF
--- a/docs/design/notification-system.md
+++ b/docs/design/notification-system.md
@@ -1,0 +1,363 @@
+# Notification System for Change Detection
+
+## Summary
+
+Implement a notification system that dispatches alerts when change detection nodes (FixedThreshold, RelativeDifference) detect regressions. Should support multiple notification channels and be usable from CLI, REST API, and a future web frontend.
+
+Tracked in [issue #89](https://github.com/Hyperfoil/h5m/issues/89). Supersedes the notification sketch in [phase4-notifications.md](phase4-notifications.md).
+
+## Current State
+
+h5m fires a `ChangeDetectedEvent` CDI event from `WorkService.execute()` when a detection node produces values. There are no production consumers — only a test observer exists. The CDI event carries `nodeId`, `nodeName`, and `valueIds`.
+
+```
+WorkService.execute()
+  └─ if activeNode.isDetection() && !newOrUpdated.isEmpty()
+       └─ changeDetectedEvent.fire(new ChangeDetectedEvent(...))
+            └─ [test only] ChangeDetectedEventObserver
+            └─ [production] no observer yet
+```
+
+## Design
+
+### NotificationMethod Enum
+
+Supported notification methods are defined as an enum for type safety:
+
+```java
+public enum NotificationMethod {
+    WEBHOOK("webhook"),
+    EMAIL("email"),
+    SLACK("slack"),
+    GITHUB_ISSUE("github-issue");
+}
+```
+
+### NotificationPlugin SPI
+
+A single SPI covers all notification channels. Horreum splits into NotificationPlugin (email) and ActionPlugin (webhooks, Slack, GitHub). h5m uses one interface to keep the architecture simple:
+
+```java
+public interface NotificationPlugin {
+    /** The notification method this plugin handles */
+    NotificationMethod method();
+
+    /** Send a change notification */
+    void send(ChangeNotification notification);
+
+    /** Validate configuration data before saving (throw on invalid) */
+    void validate(String configData);
+}
+```
+
+Plugins are `@ApplicationScoped` CDI beans. CDI `Instance<NotificationPlugin>` auto-discovers them — no explicit registration needed. Adding a new channel means adding one new bean implementing `NotificationPlugin`.
+
+### ChangeNotification Record
+
+Enriched event data passed to plugins:
+
+```java
+public record ChangeNotification(
+    String folderName,
+    long nodeId,
+    String nodeName,
+    String nodeType,            // "ft" or "rd"
+    List<ChangeDetail> changes,
+    String configData,          // plugin-specific config (URL, email, channel)
+    String configSecrets,       // plugin-specific secrets (API tokens, passwords)
+    String template             // user-defined message template, or null for default
+) {}
+
+public record ChangeDetail(
+    long valueId,
+    JsonNode data,              // detection value data (ratio, bound, direction, fingerprint)
+    JsonNode fingerprint
+) {}
+```
+
+### NotificationConfig Entity
+
+Per-folder notification configuration with separate fields for config, secrets, and message template:
+
+```java
+@Entity(name = "notification_config")
+public class NotificationConfig extends PanacheEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    public FolderEntity folder;
+
+    @Enumerated(EnumType.STRING)
+    public NotificationMethod method;
+
+    public String data;         // non-sensitive JSON config: URL, email, channel
+    public String secrets;      // sensitive JSON: API tokens, passwords (never returned in API)
+    public String template;     // user-defined message template with placeholders
+    public boolean enabled = true;
+}
+```
+
+#### Configuration Fields
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| `data` | Non-sensitive plugin config | `{"url": "https://hooks.slack.com/..."}` |
+| `secrets` | Sensitive credentials (never exposed in API responses) | `{"token": "xoxb-..."}` |
+| `template` | Custom message with placeholders | `"Regression in *{folderName}*: {changeCount} changes. cc @perf-team"` |
+
+#### Template Placeholders
+
+| Placeholder | Value |
+|------------|-------|
+| `{folderName}` | Name of the folder |
+| `{nodeName}` | Name of the detection node |
+| `{nodeType}` | Type of detection ("ft" or "rd") |
+| `{changeCount}` | Number of changes detected |
+| `{changes}` | Formatted list of change details |
+| `{fingerprint}` | Fingerprint data from the detection |
+
+If `template` is null or empty, plugins use their default message format.
+
+### NotificationLog Entity
+
+Stores sent notification history for the web UI and debugging:
+
+```java
+@Entity(name = "notification_log")
+public class NotificationLog extends PanacheEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    public FolderEntity folder;
+
+    public String method;
+    public String destination;      // resolved target (email, URL, channel)
+    public String status;           // "sent", "failed", "suppressed"
+    public String errorMessage;     // null on success
+    public long nodeId;
+    public String nodeName;
+    public int changeCount;
+    @CreationTimestamp
+    private LocalDateTime sentAt;
+}
+```
+
+### NotificationService
+
+Observes `ChangeDetectedEvent`, loads configs for the folder, enriches with value data, and dispatches to matching plugins:
+
+```java
+@ApplicationScoped
+public class NotificationService {
+
+    @Inject
+    Instance<NotificationPlugin> plugins;
+
+    @Inject
+    ValueService valueService;
+
+    @Inject
+    EntityManager em;
+
+    void onChangeDetected(@Observes ChangeDetectedEvent event) {
+        if (!event.notify()) return;  // suppress for recalculate/bulk import
+
+        List<NotificationConfig> configs = NotificationConfig
+            .find("folder.id = ?1 AND enabled = true", event.folderId())
+            .list();
+
+        if (configs.isEmpty()) return;
+
+        // Enrich with value data
+        List<ChangeDetail> details = loadChangeDetails(event.valueIds());
+
+        // Dispatch to each configured plugin
+        for (NotificationConfig config : configs) {
+            findPlugin(config.method).ifPresent(plugin -> {
+                ChangeNotification notification = new ChangeNotification(
+                    folderName, event.nodeId(), event.nodeName(),
+                    nodeType, details, config.data
+                );
+                try {
+                    plugin.send(notification);
+                    logNotification(config, event, "sent", null);
+                } catch (Exception e) {
+                    logNotification(config, event, "failed", e.getMessage());
+                }
+            });
+        }
+    }
+
+    private Optional<NotificationPlugin> findPlugin(String method) {
+        return plugins.stream()
+            .filter(p -> p.method().equals(method))
+            .findFirst();
+    }
+}
+```
+
+### ChangeDetectedEvent Enhancement
+
+Add `folderId` (for config lookup) and `notify` flag (for suppression):
+
+```java
+public record ChangeDetectedEvent(
+    long folderId, long nodeId, String nodeName,
+    List<Long> valueIds, boolean notify
+) {}
+```
+
+Normal uploads set `notify=true`. Recalculate and bulk imports set `notify=false`.
+
+### Suppression Policy
+
+- **Normal upload**: `notify=true` — external notifications are dispatched
+- **Recalculate**: `notify=false` — administrative operation, don't re-alert for known regressions
+- **Bulk import (load-legacy-runs)**: `notify=false` — importing historical data should not spam
+- **In-app (SSE)**: Always delivered regardless of `notify` flag — the web UI should show all changes in real-time
+
+## Web Frontend Considerations
+
+The notification system must support a future web frontend where most users will interact:
+
+### In-app Notifications (SSE/WebSocket)
+
+The `NotificationService` should broadcast change events to connected browsers via an SSE endpoint. This is the real-time "bell icon" experience — separate from external channels like email/Slack:
+
+```java
+@GET
+@Path("/stream")
+@Produces(MediaType.SERVER_SENT_EVENTS)
+@RestStreamElementType(MediaType.APPLICATION_JSON)
+public Multi<ChangeNotification> streamChanges() {
+    // Return a Multi that emits ChangeNotification events
+    // from a BroadcastProcessor fed by NotificationService
+}
+```
+
+In-app notifications bypass the `notify` flag — connected browsers should always see changes, even during recalculation.
+
+### Notification History Page
+
+The `NotificationLog` entity enables a web UI notification history page showing:
+- What was sent, when, to which channel
+- Success/failure status
+- Link to the detection values in the Value DAG
+
+### REST API for Configuration
+
+CRUD endpoints for `NotificationConfig` so the web UI can manage notification preferences per folder:
+
+```
+POST   /api/notification/config              — create config
+GET    /api/notification/config?folderId=N    — list configs for folder
+PUT    /api/notification/config/{id}          — update config
+DELETE /api/notification/config/{id}          — delete config
+POST   /api/notification/config/{id}/test     — send a test notification
+GET    /api/notification/log?folderId=N       — notification history
+```
+
+The CLI commands are thin wrappers around these same REST endpoints.
+
+### User Preferences (Future)
+
+When multi-user is fully adopted, a `NotificationPreference` entity decouples user contact details from per-folder configuration:
+
+```java
+@Entity(name = "notification_preference")
+public class NotificationPreference extends PanacheEntity {
+    @ManyToOne
+    public User user;
+    public String method;       // "email", "slack"
+    public String data;         // email address, Slack handle
+}
+```
+
+A user sets their email/Slack once globally, then subscribes to folders via a Watch-like entity. This is similar to Horreum's Watch + NotificationSettings split but deferred until there is a concrete multi-user need.
+
+## Notification Channels
+
+| Channel | Plugin | Config data | Description |
+|---------|--------|------------|-------------|
+| **Webhook** | `WebhookPlugin` | `{"url": "https://..."}` | HTTP POST with JSON payload. Covers Slack incoming webhooks, generic receivers. |
+| **Email** | `EmailPlugin` | `{"to": "team@example.com"}` | SMTP via `quarkus-mailer`. |
+| **GitHub Issue** | `GitHubIssuePlugin` | `{"owner": "org", "repo": "perf", "token": "..."}` | Creates/comments on GitHub issues. |
+| **Slack** | `SlackPlugin` | `{"channel": "#alerts", "token": "xoxb-..."}` | Slack Web API with Block Kit formatting. |
+| **In-app (SSE)** | Built-in | N/A | Broadcasts to connected web clients. |
+
+## Implementation Phases
+
+Each phase is a separate PR.
+
+### Phase 1: Core Infrastructure
+
+- `NotificationPlugin` SPI interface
+- `ChangeNotification` and `ChangeDetail` records
+- `NotificationConfig` entity
+- `NotificationLog` entity
+- `NotificationService` (CDI observer + dispatcher)
+- `ChangeDetectedEvent` enhancement (add `folderId`, `notify` flag)
+- Update `WorkService.execute()` to pass `folderId` and `notify`
+- REST endpoints for config CRUD and notification history
+- CLI commands: `add notification`, `list notifications`, `remove notification`
+
+### Phase 2: Webhook Plugin
+
+- `WebhookPlugin` implementation (HTTP POST with JSON)
+- Tests with mock HTTP server (WireMock or similar)
+
+### Phase 3: Email Plugin
+
+- `EmailPlugin` implementation (Quarkus reactive mailer)
+- Qute templates for email body formatting
+- Requires `quarkus-mailer` dependency
+
+### Phase 4: GitHub Issue Plugin
+
+- `GitHubIssuePlugin` implementation (GitHub REST API)
+- Create issue on first detection, comment on subsequent detections for same fingerprint
+
+### Phase 5: Slack Plugin
+
+- `SlackPlugin` implementation (Slack Web API)
+- Block Kit message formatting for rich notifications
+
+### Phase 6: In-app Notifications (Web Frontend)
+
+- SSE endpoint streaming `ChangeNotification` events
+- `BroadcastProcessor` in `NotificationService` feeding the SSE stream
+- Notification badge/bell component data source
+- Notification history page backed by `NotificationLog`
+
+Phases 2-6 are independent of each other and can be implemented in any order after Phase 1.
+
+## Files to Create/Modify
+
+| Phase | File | Action |
+|-------|------|--------|
+| 1 | `svc/NotificationPlugin.java` | Create — SPI interface |
+| 1 | `event/ChangeNotification.java` | Create — enriched notification record |
+| 1 | `event/ChangeDetail.java` | Create — per-change detail record |
+| 1 | `entity/NotificationConfig.java` | Create — JPA entity |
+| 1 | `entity/NotificationLog.java` | Create — JPA entity |
+| 1 | `svc/NotificationService.java` | Create — CDI observer + dispatcher |
+| 1 | `event/ChangeDetectedEvent.java` | Modify — add folderId, notify flag |
+| 1 | `svc/WorkService.java` | Modify — pass folderId and notify flag |
+| 1 | `rest/NotificationResource.java` | Create — REST endpoints |
+| 1 | `cli/AddNotification.java` | Create — CLI command |
+| 1 | `cli/ListNotifications.java` | Create — CLI command |
+| 1 | `cli/RemoveNotification.java` | Create — CLI command |
+| 2 | `notification/WebhookPlugin.java` | Create |
+| 3 | `notification/EmailPlugin.java` | Create |
+| 4 | `notification/GitHubIssuePlugin.java` | Create |
+| 5 | `notification/SlackPlugin.java` | Create |
+| 6 | `rest/NotificationStreamResource.java` | Create — SSE endpoint |
+
+## Key Design Differences from Horreum
+
+| Aspect | Horreum | h5m |
+|--------|---------|-----|
+| SPIs | Two (NotificationPlugin + ActionPlugin) | One (NotificationPlugin) |
+| Subscription | Watch + NotificationSettings (per-user/team) | NotificationConfig (per-folder initially) |
+| Event aggregation | 1-second delay to batch changes | No batching (changes already per-upload) |
+| Mediation | ServiceMediator pattern | Direct CDI @Observes |
+| Channels | Email (notifications) + HTTP/Slack/GitHub (actions) | All via single SPI |
+| Notification log | None | NotificationLog entity for history + debugging |
+| Web support | Full React UI | Planned — SSE endpoint + notification log |
+| User preferences | Global per-user NotificationSettings | Deferred until multi-user is adopted |

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
         AddSplit.class,
         AddRelativeDifference.class,
         AddFixedThreshold.class,
+        AddNotification.class,
     }
 )
 public class AddCmd implements Callable<Integer> {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddNotification.java
@@ -1,0 +1,64 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.Folder;
+import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import io.hyperfoil.tools.h5m.notification.NotificationMethod;
+import io.hyperfoil.tools.h5m.svc.NotificationService;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "notification", separator = " ",
+    description = "add a notification config to a folder",
+    mixinStandardHelpOptions = true)
+public class AddNotification implements Callable<Integer> {
+
+    @CommandLine.Parameters(index = "0", arity = "1", description = "notification method: ${COMPLETION-CANDIDATES}")
+    NotificationMethod method;
+
+    @CommandLine.Option(names = {"to"}, description = "target folder name", required = true)
+    String folderName;
+
+    @CommandLine.Parameters(index = "1", arity = "1", description = "configuration data (URL, email, JSON, etc.)")
+    String data;
+
+    @CommandLine.Option(names = {"--secrets"}, description = "secret configuration (tokens, passwords)")
+    String secrets;
+
+    @CommandLine.Option(names = {"--template"}, description = "custom message template with placeholders: {folderName}, {nodeName}, {nodeType}, {changeCount}")
+    String template;
+
+    @Inject
+    FolderServiceInterface folderService;
+
+    @Inject
+    NotificationService notificationService;
+
+    @Override
+    @Transactional
+    public Integer call() throws Exception {
+        Folder folder = folderService.byName(folderName);
+        if (folder == null) {
+            System.err.println("Folder not found: " + folderName);
+            return 1;
+        }
+
+        try {
+            notificationService.validateConfig(method, data);
+        } catch (IllegalArgumentException e) {
+            System.err.println("Invalid notification config: " + e.getMessage());
+            return 1;
+        }
+
+        FolderEntity folderEntity = FolderEntity.findById(folder.id());
+        NotificationConfig config = new NotificationConfig(folderEntity, method, data, secrets);
+        config.template = template;
+        config.persist();
+        System.out.println("Added " + method.label() + " notification to " + folderName + " (id=" + config.id + ")");
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ListCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ListCmd.java
@@ -11,7 +11,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-@CommandLine.Command(name="list", aliases = {"show","ls"}, description = "list entities", mixinStandardHelpOptions = true, subcommands={ListFolder.class, ListNode.class, ListValue.class})
+@CommandLine.Command(name="list", aliases = {"show","ls"}, description = "list entities", mixinStandardHelpOptions = true, subcommands={ListFolder.class, ListNode.class, ListValue.class, ListNotification.class})
 public class ListCmd implements Callable<Integer> {
 
     /*

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ListNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ListNotification.java
@@ -1,0 +1,60 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.Folder;
+import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "notification", aliases = {"notifications"}, separator = " ",
+    description = "list notification configs for a folder",
+    mixinStandardHelpOptions = true)
+public class ListNotification implements Callable<Integer> {
+
+    @CommandLine.Parameters(index = "0", arity = "0..1", description = "folder name")
+    String folderName;
+
+    @Inject
+    FolderServiceInterface folderService;
+
+    @Override
+    public Integer call() throws Exception {
+        if (folderName == null) {
+            List<NotificationConfig> all = NotificationConfig.listAll();
+            if (all.isEmpty()) {
+                System.out.println("No notification configs found.");
+            } else {
+                printConfigs(all);
+            }
+            return 0;
+        }
+
+        Folder folder = folderService.byName(folderName);
+        if (folder == null) {
+            System.err.println("Folder not found: " + folderName);
+            return 1;
+        }
+
+        List<NotificationConfig> configs = NotificationConfig.find("folder.id", folder.id()).list();
+        if (configs.isEmpty()) {
+            System.out.println("No notification configs for " + folderName);
+        } else {
+            printConfigs(configs);
+        }
+        return 0;
+    }
+
+    private void printConfigs(List<NotificationConfig> configs) {
+        System.out.printf("%-6s %-20s %-14s %-8s %-30s %s%n", "ID", "Folder", "Method", "Enabled", "Data", "Template");
+        System.out.println("-".repeat(100));
+        for (NotificationConfig config : configs) {
+            String folderDisplay = config.folder != null ? config.folder.name : "?";
+            String templateDisplay = config.template != null ? config.template : "(default)";
+            System.out.printf("%-6d %-20s %-14s %-8s %-30s %s%n",
+                config.id, folderDisplay, config.method.label(), config.enabled, config.data, templateDisplay);
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveCmd.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 
-@CommandLine.Command(name="remove", description = "remove entity",aliases = {"rm","del","delete"}, mixinStandardHelpOptions = true, subcommands = {RemoveFolder.class, RemoveNode.class})
+@CommandLine.Command(name="remove", description = "remove entity",aliases = {"rm","del","delete"}, mixinStandardHelpOptions = true, subcommands = {RemoveFolder.class, RemoveNode.class, RemoveNotification.class})
 public class RemoveCmd implements Callable<Integer> {
 
     @Inject

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveNotification.java
@@ -1,0 +1,29 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import jakarta.transaction.Transactional;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(name = "notification", separator = " ",
+    description = "remove a notification config by ID",
+    mixinStandardHelpOptions = true)
+public class RemoveNotification implements Callable<Integer> {
+
+    @CommandLine.Parameters(index = "0", arity = "1", description = "notification config ID")
+    long configId;
+
+    @Override
+    @Transactional
+    public Integer call() throws Exception {
+        boolean deleted = NotificationConfig.deleteById(configId);
+        if (deleted) {
+            System.out.println("Removed notification config " + configId);
+            return 0;
+        } else {
+            System.err.println("Notification config not found: " + configId);
+            return 1;
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NotificationConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NotificationConfig.java
@@ -1,0 +1,79 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.hyperfoil.tools.h5m.notification.NotificationMethod;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+
+/**
+ * Configuration for a notification channel on a folder.
+ * Each folder can have multiple notification configs (e.g., one for email, one for Slack).
+ */
+@Entity(name = "notification_config")
+public class NotificationConfig extends PanacheEntity {
+
+    /**
+     * The folder this notification config belongs to.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    public FolderEntity folder;
+
+    /**
+     * The notification method.
+     */
+    @Enumerated(EnumType.STRING)
+    public NotificationMethod method;
+
+    /**
+     * Plugin-specific configuration data as a JSON string.
+     * Contains non-sensitive settings like URLs, channel names, email addresses.
+     * e.g. {"url": "https://hooks.slack.com/..."} for webhook,
+     *      {"to": "team@example.com"} for email,
+     *      {"channel": "#alerts"} for Slack.
+     */
+    @Column(columnDefinition = "TEXT")
+    public String data;
+
+    /**
+     * Plugin-specific secret data as a JSON string.
+     * Contains sensitive values like API tokens, passwords.
+     * e.g. {"token": "xoxb-..."} for Slack,
+     *      {"token": "ghp_..."} for GitHub.
+     * This field is never included in JSON serialization.
+     */
+    @JsonIgnore
+    @Column(columnDefinition = "TEXT")
+    public String secrets;
+
+    /**
+     * User-defined message template with placeholders.
+     * Available placeholders: {folderName}, {nodeName}, {nodeType},
+     * {changeCount}, {changes}, {fingerprint}.
+     * <p>
+     * Example for Slack: "Regression detected in *{folderName}* by {nodeName}: {changeCount} change(s). cc @perf-team"
+     * <p>
+     * If null or empty, the plugin uses its default message format.
+     */
+    @Column(columnDefinition = "TEXT")
+    public String template;
+
+    /**
+     * Whether this notification config is enabled.
+     */
+    public boolean enabled = true;
+
+    public NotificationConfig() {}
+
+    public NotificationConfig(FolderEntity folder, NotificationMethod method, String data) {
+        this.folder = folder;
+        this.method = method;
+        this.data = data;
+        this.enabled = true;
+    }
+
+    public NotificationConfig(FolderEntity folder, NotificationMethod method, String data, String secrets) {
+        this(folder, method, data);
+        this.secrets = secrets;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NotificationLog.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NotificationLog.java
@@ -1,0 +1,50 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Log of sent notifications for auditing and the web UI notification history page.
+ */
+@Entity(name = "notification_log")
+@Table(indexes = {
+    @Index(name = "idx_notification_log_folder", columnList = "folder_id"),
+    @Index(name = "idx_notification_log_sent_at", columnList = "sentAt")
+})
+public class NotificationLog extends PanacheEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    public FolderEntity folder;
+
+    /** The notification method used (e.g. "webhook", "email") */
+    public String method;
+
+    /** Resolved target (URL, email address, channel name) */
+    public String destination;
+
+    /** Delivery status: "sent", "failed", "suppressed" */
+    public String status;
+
+    /** Error message on failure, null on success */
+    @Column(columnDefinition = "TEXT")
+    public String errorMessage;
+
+    /** Detection node that triggered this notification */
+    public long nodeId;
+
+    /** Name of the detection node */
+    public String nodeName;
+
+    /** Number of changes in this notification */
+    public int changeCount;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    public LocalDateTime sentAt;
+
+    public NotificationLog() {}
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/event/ChangeDetail.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/event/ChangeDetail.java
@@ -1,0 +1,12 @@
+package io.hyperfoil.tools.h5m.event;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Detail of a single detected change, enriched from the detection value.
+ *
+ * @param valueId     ID of the detection value
+ * @param data        the detection value data (ratio, bound, direction, fingerprint, etc.)
+ * @param fingerprint fingerprint data extracted from the detection value, or null
+ */
+public record ChangeDetail(long valueId, JsonNode data, JsonNode fingerprint) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/event/ChangeDetectedEvent.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/event/ChangeDetectedEvent.java
@@ -2,4 +2,15 @@ package io.hyperfoil.tools.h5m.event;
 
 import java.util.List;
 
-public record ChangeDetectedEvent(long nodeId, String nodeName, List<Long> valueIds) {}
+/**
+ * CDI event fired when a detection node (FixedThreshold, RelativeDifference)
+ * produces new or updated values indicating a change.
+ *
+ * @param folderId  the folder containing the detection node
+ * @param nodeId    the detection node that produced the values
+ * @param nodeName  name of the detection node
+ * @param valueIds  IDs of the detection values produced
+ * @param dispatch  whether external notifications should be dispatched.
+ *                  Set to false for recalculations and bulk imports.
+ */
+public record ChangeDetectedEvent(long folderId, long nodeId, String nodeName, List<Long> valueIds, boolean dispatch) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/event/ChangeNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/event/ChangeNotification.java
@@ -1,0 +1,26 @@
+package io.hyperfoil.tools.h5m.event;
+
+import java.util.List;
+
+/**
+ * Enriched notification payload passed to notification plugins.
+ *
+ * @param folderName    name of the folder where the change was detected
+ * @param nodeId        ID of the detection node
+ * @param nodeName      name of the detection node
+ * @param nodeType      type discriminator of the detection node ("ft" or "rd")
+ * @param changes       list of individual change details
+ * @param configData    plugin-specific configuration (URL, email, channel, etc.)
+ * @param configSecrets plugin-specific secrets (API tokens, passwords, etc.)
+ * @param template      user-defined message template with placeholders, or null for default
+ */
+public record ChangeNotification(
+    String folderName,
+    long nodeId,
+    String nodeName,
+    String nodeType,
+    List<ChangeDetail> changes,
+    String configData,
+    String configSecrets,
+    String template
+) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/notification/NotificationMethod.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/notification/NotificationMethod.java
@@ -1,0 +1,31 @@
+package io.hyperfoil.tools.h5m.notification;
+
+/**
+ * Supported notification methods.
+ * Each value corresponds to a {@link NotificationPlugin} implementation.
+ */
+public enum NotificationMethod {
+    WEBHOOK("webhook"),
+    EMAIL("email"),
+    SLACK("slack"),
+    GITHUB_ISSUE("github-issue");
+
+    private final String label;
+
+    NotificationMethod(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public static NotificationMethod fromLabel(String label) {
+        for (NotificationMethod m : values()) {
+            if (m.label.equals(label)) {
+                return m;
+            }
+        }
+        throw new IllegalArgumentException("Unknown notification method: " + label);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/notification/NotificationPlugin.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/notification/NotificationPlugin.java
@@ -1,0 +1,33 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+
+/**
+ * SPI for notification channels. Implementations are discovered via CDI
+ * and dispatched by {@link io.hyperfoil.tools.h5m.svc.NotificationService}.
+ * <p>
+ * To add a new notification channel, create an {@code @ApplicationScoped} bean
+ * implementing this interface. It will be automatically picked up.
+ */
+public interface NotificationPlugin {
+
+    /**
+     * The notification method this plugin handles.
+     */
+    NotificationMethod method();
+
+    /**
+     * Send a change notification via this channel.
+     *
+     * @param notification the enriched notification payload
+     */
+    void send(ChangeNotification notification);
+
+    /**
+     * Validate plugin-specific configuration data before it is saved.
+     *
+     * @param configData the plugin-specific configuration (JSON string)
+     * @throws IllegalArgumentException if the configuration is invalid
+     */
+    void validate(String configData);
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
@@ -1,0 +1,112 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import io.hyperfoil.tools.h5m.entity.NotificationLog;
+import io.hyperfoil.tools.h5m.notification.NotificationMethod;
+import io.hyperfoil.tools.h5m.svc.NotificationService;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.List;
+
+@Path("/api/notification")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "Notification", description = "Manage notification configurations for change detection")
+public class NotificationResource {
+
+    @Inject
+    NotificationService notificationService;
+
+    @POST
+    @Path("config")
+    @Authenticated
+    @Transactional
+    @Operation(description = "Create a notification config for a folder")
+    public long createConfig(
+            @QueryParam("folderId") @Parameter(description = "Folder ID") long folderId,
+            @QueryParam("method") @Parameter(description = "Notification method") NotificationMethod method,
+            @QueryParam("secrets") @Parameter(description = "Secret config data (tokens, passwords)") String secrets,
+            String data) {
+        notificationService.validateConfig(method, data);
+        FolderEntity folder = FolderEntity.findById(folderId);
+        if (folder == null) {
+            throw new NotFoundException("Folder not found: " + folderId);
+        }
+        NotificationConfig config = new NotificationConfig(folder, method, data, secrets);
+        config.persist();
+        return config.id;
+    }
+
+    @GET
+    @Path("config")
+    @PermitAll
+    @Operation(description = "List notification configs for a folder")
+    public List<NotificationConfig> listConfigs(
+            @QueryParam("folderId") @Parameter(description = "Folder ID") long folderId) {
+        return NotificationConfig.find("folder.id", folderId).list();
+        // secrets field is @JsonIgnore — never included in JSON responses
+    }
+
+    @PUT
+    @Path("config/{id}")
+    @Authenticated
+    @Transactional
+    @Operation(description = "Update a notification config")
+    public void updateConfig(
+            @PathParam("id") long id,
+            @QueryParam("method") @Parameter(description = "New notification method") NotificationMethod method,
+            @QueryParam("enabled") @Parameter(description = "Enable or disable") Boolean enabled,
+            @QueryParam("secrets") @Parameter(description = "Secret config data (tokens, passwords)") String secrets,
+            String data) {
+        NotificationConfig config = NotificationConfig.findById(id);
+        if (config == null) {
+            throw new NotFoundException("Notification config not found: " + id);
+        }
+        if (method != null) {
+            config.method = method;
+        }
+        if (data != null && !data.isBlank()) {
+            notificationService.validateConfig(config.method, data);
+            config.data = data;
+        }
+        if (secrets != null) {
+            config.secrets = secrets;
+        }
+        if (enabled != null) {
+            config.enabled = enabled;
+        }
+    }
+
+    @DELETE
+    @Path("config/{id}")
+    @Authenticated
+    @Transactional
+    @Operation(description = "Delete a notification config")
+    public void deleteConfig(@PathParam("id") long id) {
+        boolean deleted = NotificationConfig.deleteById(id);
+        if (!deleted) {
+            throw new NotFoundException("Notification config not found: " + id);
+        }
+    }
+
+    @GET
+    @Path("log")
+    @PermitAll
+    @Operation(description = "Get notification log for a folder")
+    public List<NotificationLog> getLog(
+            @QueryParam("folderId") @Parameter(description = "Folder ID") long folderId,
+            @QueryParam("limit") @Parameter(description = "Max entries to return") @DefaultValue("50") int limit) {
+        return NotificationLog.find("folder.id = ?1 ORDER BY sentAt DESC", folderId)
+            .page(0, limit)
+            .list();
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NotificationService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NotificationService.java
@@ -1,0 +1,142 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import io.hyperfoil.tools.h5m.entity.NotificationLog;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeDetectedEvent;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.hyperfoil.tools.h5m.notification.NotificationMethod;
+import io.hyperfoil.tools.h5m.notification.NotificationPlugin;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Observes {@link ChangeDetectedEvent} and dispatches notifications to
+ * configured channels via {@link NotificationPlugin} implementations.
+ */
+@ApplicationScoped
+public class NotificationService {
+
+    @Inject
+    Instance<NotificationPlugin> plugins;
+
+    /**
+     * Observes change detected events and dispatches notifications
+     * to all enabled notification configs for the folder.
+     */
+    @Transactional
+    public void onChangeDetected(@Observes ChangeDetectedEvent event) {
+        if (!event.dispatch()) {
+            Log.debugf("Suppressing notification for node %s (notify=false)", event.nodeName());
+            return;
+        }
+
+        List<NotificationConfig> configs = NotificationConfig
+            .find("folder.id = ?1 AND enabled = true", event.folderId())
+            .list();
+
+        if (configs.isEmpty()) {
+            return;
+        }
+
+        // Resolve folder name
+        FolderEntity folder = FolderEntity.findById(event.folderId());
+        String folderName = folder != null ? folder.name : "unknown";
+
+        // Resolve node type from one of the values
+        String nodeType = resolveNodeType(event.valueIds());
+
+        // Enrich with value data
+        List<ChangeDetail> details = loadChangeDetails(event.valueIds());
+
+        // Dispatch to each configured plugin
+        for (NotificationConfig config : configs) {
+            findPlugin(config.method).ifPresentOrElse(
+                plugin -> {
+                    ChangeNotification notification = new ChangeNotification(
+                        folderName, event.nodeId(), event.nodeName(),
+                        nodeType, details, config.data, config.secrets, config.template
+                    );
+                    try {
+                        plugin.send(notification);
+                        logNotification(folder, config, event, details.size(), "sent", null);
+                        Log.infof("Notification sent via %s for %s/%s (%d changes)",
+                            config.method, folderName, event.nodeName(), details.size());
+                    } catch (Exception e) {
+                        logNotification(folder, config, event, details.size(), "failed", e.getMessage());
+                        Log.errorf(e, "Failed to send %s notification for %s/%s",
+                            config.method, folderName, event.nodeName());
+                    }
+                },
+                () -> Log.warnf("No plugin found for notification method '%s'", config.method)
+            );
+        }
+    }
+
+    /**
+     * Validates configuration data for a given notification method.
+     *
+     * @throws IllegalArgumentException if the method is unknown or config is invalid
+     */
+    public void validateConfig(NotificationMethod method, String configData) {
+        NotificationPlugin plugin = findPlugin(method)
+            .orElseThrow(() -> new IllegalArgumentException("Unknown notification method: " + method));
+        plugin.validate(configData);
+    }
+
+    private Optional<NotificationPlugin> findPlugin(NotificationMethod method) {
+        return plugins.stream()
+            .filter(p -> p.method() == method)
+            .findFirst();
+    }
+
+    private List<ChangeDetail> loadChangeDetails(List<Long> valueIds) {
+        List<ChangeDetail> details = new ArrayList<>();
+        for (Long valueId : valueIds) {
+            ValueEntity value = ValueEntity.findById(valueId);
+            if (value != null) {
+                JsonNode fingerprint = null;
+                if (value.data != null && value.data.has("fingerprint")) {
+                    fingerprint = value.data.get("fingerprint");
+                }
+                details.add(new ChangeDetail(valueId, value.data, fingerprint));
+            }
+        }
+        return details;
+    }
+
+    private String resolveNodeType(List<Long> valueIds) {
+        if (valueIds == null || valueIds.isEmpty()) return "unknown";
+        ValueEntity value = ValueEntity.findById(valueIds.getFirst());
+        if (value != null && value.node != null) {
+            return value.node.type().display();
+        }
+        return "unknown";
+    }
+
+    private void logNotification(FolderEntity folder, NotificationConfig config,
+                                  ChangeDetectedEvent event, int changeCount,
+                                  String status, String errorMessage) {
+        NotificationLog log = new NotificationLog();
+        log.folder = folder;
+        log.method = config.method.label();
+        log.destination = config.data;
+        log.status = status;
+        log.errorMessage = errorMessage;
+        log.nodeId = event.nodeId();
+        log.nodeName = event.nodeName();
+        log.changeCount = changeCount;
+        log.persist();
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -216,7 +216,13 @@ public class WorkService implements WorkServiceInterface {
 
             if(work.activeNode.isDetection() && !newOrUpdated.isEmpty()){
                 List<Long> valueIds = newOrUpdated.stream().map(ValueEntity::getId).toList();
-                changeDetectedEvent.fire(new ChangeDetectedEvent(work.activeNode.getId(), work.activeNode.name, valueIds));
+                // Resolve folderId from source values
+                long folderId = work.sourceValues.stream()
+                    .filter(v -> v.folder != null)
+                    .map(v -> v.folder.id)
+                    .findFirst()
+                    .orElse(-1L);
+                changeDetectedEvent.fire(new ChangeDetectedEvent(folderId, work.activeNode.getId(), work.activeNode.name, valueIds, true));
             }
 
             //we need to trigger more calculations? perhaps for a recalculation we do?

--- a/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
@@ -28,6 +28,8 @@ public class FreshDb {
             try(Statement stmt = conn.createStatement()){
 
                 if(dbKind.equals("postgresql")){
+                    stmt.executeUpdate("TRUNCATE TABLE notification_log CASCADE");
+                    stmt.executeUpdate("TRUNCATE TABLE notification_config CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE api_key CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE team_members CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE work_values CASCADE");
@@ -42,6 +44,8 @@ public class FreshDb {
                     stmt.executeUpdate("TRUNCATE TABLE h5m_user CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE team CASCADE");
                 }else if (dbKind.equals("sqlite")){
+                    stmt.executeUpdate("DELETE from notification_log");
+                    stmt.executeUpdate("DELETE from notification_config");
                     stmt.executeUpdate("DELETE from api_key");
                     stmt.executeUpdate("DELETE from team_members");
                     stmt.executeUpdate("DELETE from work_values");


### PR DESCRIPTION
Introduce the notification SPI, entities, service, REST endpoints, and CLI commands for configuring and dispatching change detection notifications.

Core components:
- NotificationPlugin SPI with CDI auto-discovery for plugin implementations
- NotificationMethod enum (WEBHOOK, EMAIL, SLACK, GITHUB_ISSUE)
- NotificationConfig entity with per-folder config, secrets (@JsonIgnore), and user-defined message template with placeholders
- NotificationLog entity for notification history and debugging
- NotificationService observes ChangeDetectedEvent and dispatches to configured plugins, logging each attempt

Event changes:
- ChangeDetectedEvent now carries folderId (for config lookup) and dispatch flag (false suppresses notifications for recalculate/bulk import)
- WorkService.execute() resolves folderId from source values

REST API:
- POST/GET/PUT/DELETE /api/notification/config for CRUD
- GET /api/notification/log for notification history
- GET /api/notification/methods for available plugin methods

CLI commands:
- add notification <method> to <folder> <data> [--secrets] [--template]
- list notifications [folder]
- remove notification <id>

No plugin implementations are included — those come in subsequent phases. Design doc added at docs/design/notification-system.md.