### PR TITLE
Add WebhookPlugin for HTTP POST notifications (issue #89, Phase 2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/io/hyperfoil/tools/h5m/notification/WebhookPlugin.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/notification/WebhookPlugin.java
@@ -1,0 +1,202 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.logging.Log;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Qute;
+import io.quarkus.qute.Template;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+
+/**
+ * Notification plugin that sends change notifications via HTTP POST (webhook).
+ * <p>
+ * Configuration data (JSON):
+ * <pre>{"url": "https://hooks.example.com/endpoint"}</pre>
+ * <p>
+ * Secret data (JSON, optional):
+ * <pre>{"authHeader": "Bearer token123"}</pre>
+ * <p>
+ * The payload is a JSON object containing the folder name, detection node info,
+ * and change details. If a custom template is provided, it is included as a
+ * {@code text} field in the payload — this makes it compatible with Slack
+ * incoming webhooks which use the {@code text} field for the message body.
+ */
+@ApplicationScoped
+public class WebhookPlugin implements NotificationPlugin {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    @Inject
+    Vertx vertx;
+
+    @Location("webhook_notification")
+    Template defaultTemplate;
+
+    private WebClient webClient;
+
+    @PostConstruct
+    void init() {
+        webClient = WebClient.create(vertx);
+    }
+
+    @Override
+    public NotificationMethod method() {
+        return NotificationMethod.WEBHOOK;
+    }
+
+    @Override
+    public void send(ChangeNotification notification) {
+        String urlStr = extractUrl(notification.configData());
+        String authHeader = extractAuthHeader(notification.configSecrets());
+
+        ObjectNode payload = buildPayload(notification);
+
+        URL url;
+        try {
+            url = new URL(urlStr);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Invalid webhook URL: " + urlStr, e);
+        }
+
+        RequestOptions options = new RequestOptions()
+            .setHost(url.getHost())
+            .setPort(url.getPort() != -1 ? url.getPort() : url.getDefaultPort())
+            .setURI(url.getPath() + (url.getQuery() != null ? "?" + url.getQuery() : ""))
+            .setSsl("https".equalsIgnoreCase(url.getProtocol()));
+
+        var request = webClient.request(HttpMethod.POST, options)
+            .putHeader("Content-Type", "application/json")
+            .putHeader("User-Agent", "h5m");
+
+        if (authHeader != null) {
+            request.putHeader("Authorization", authHeader);
+        }
+
+        HttpResponse<Buffer> response = request
+            .sendBuffer(Buffer.buffer(payload.toString()))
+            .await().atMost(TIMEOUT);
+
+        if (response.statusCode() >= 400) {
+            throw new RuntimeException("Webhook returned HTTP " + response.statusCode()
+                + ": " + response.bodyAsString());
+        }
+        Log.debugf("Webhook delivered to %s (HTTP %d)", urlStr, response.statusCode());
+    }
+
+    @Override
+    public void validate(String configData) {
+        if (configData == null || configData.isBlank()) {
+            throw new IllegalArgumentException("Webhook config data is required");
+        }
+        String url = extractUrl(configData);
+        if (url == null || url.isBlank()) {
+            throw new IllegalArgumentException("Webhook config must contain a 'url' field");
+        }
+        try {
+            new URL(url);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid webhook URL: " + url, e);
+        }
+        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+            throw new IllegalArgumentException("Webhook URL must start with http:// or https://");
+        }
+    }
+
+    private ObjectNode buildPayload(ChangeNotification notification) {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put("folder", notification.folderName());
+        payload.put("nodeId", notification.nodeId());
+        payload.put("nodeName", notification.nodeName());
+        payload.put("nodeType", notification.nodeType());
+        payload.put("changeCount", notification.changes().size());
+
+        // Include formatted text — compatible with Slack incoming webhooks
+        String text = formatMessage(notification);
+        payload.put("text", text);
+
+        ArrayNode changesArray = payload.putArray("changes");
+        for (ChangeDetail change : notification.changes()) {
+            ObjectNode changeNode = changesArray.addObject();
+            changeNode.put("valueId", change.valueId());
+            if (change.data() != null) {
+                changeNode.set("data", change.data());
+            }
+            if (change.fingerprint() != null) {
+                changeNode.set("fingerprint", change.fingerprint());
+            }
+        }
+
+        return payload;
+    }
+
+    private String formatMessage(ChangeNotification notification) {
+        if (notification.template() != null && !notification.template().isBlank()) {
+            return applyTemplate(notification.template(), notification);
+        }
+        return defaultTemplate
+            .data("folderName", notification.folderName())
+            .data("nodeName", notification.nodeName())
+            .data("nodeType", notification.nodeType())
+            .data("changeCount", notification.changes().size())
+            .data("changes", notification.changes())
+            .render();
+    }
+
+    private String applyTemplate(String template, ChangeNotification notification) {
+        return Qute.fmt(template)
+            .data("folderName", notification.folderName())
+            .data("nodeName", notification.nodeName())
+            .data("nodeType", notification.nodeType())
+            .data("changeCount", notification.changes().size())
+            .data("changes", notification.changes())
+            .render();
+    }
+
+    private String extractUrl(String configData) {
+        try {
+            JsonNode config = MAPPER.readTree(configData);
+            if (config.has("url")) {
+                return config.get("url").asText();
+            }
+            // If it's not JSON, treat the entire string as the URL
+            return configData.trim();
+        } catch (JsonProcessingException e) {
+            // Not valid JSON — treat as a plain URL
+            return configData.trim();
+        }
+    }
+
+    private String extractAuthHeader(String configSecrets) {
+        if (configSecrets == null || configSecrets.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode secrets = MAPPER.readTree(configSecrets);
+            if (secrets.has("authHeader")) {
+                return secrets.get("authHeader").asText();
+            }
+        } catch (JsonProcessingException e) {
+            // ignore malformed secrets
+        }
+        return null;
+    }
+}

--- a/src/main/resources/templates/webhook_notification.txt
+++ b/src/main/resources/templates/webhook_notification.txt
@@ -1,0 +1,4 @@
+Change detected in {folderName} by {nodeName} ({nodeType}): {changeCount} change(s)
+{#each changes}
+- Value ID: {it.valueId}{#if it.fingerprint}, Fingerprint: {it.fingerprint}{/if}
+{/each}

--- a/src/test/java/io/hyperfoil/tools/h5m/notification/WebhookPluginTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/notification/WebhookPluginTest.java
@@ -1,0 +1,260 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpServer;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class WebhookPluginTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    WebhookPlugin plugin;
+
+    // === Validation tests ===
+
+    @Test
+    public void validate_valid_json_config() {
+        assertDoesNotThrow(() -> plugin.validate("{\"url\": \"https://hooks.example.com/endpoint\"}"));
+    }
+
+    @Test
+    public void validate_plain_url() {
+        assertDoesNotThrow(() -> plugin.validate("https://hooks.example.com/endpoint"));
+    }
+
+    @Test
+    public void validate_accepts_https_url() {
+        assertDoesNotThrow(() -> plugin.validate("https://hooks.example.com/endpoint"));
+        assertDoesNotThrow(() -> plugin.validate("{\"url\": \"https://hooks.slack.com/services/T00/B00/xxx\"}"));
+    }
+
+    @Test
+    public void validate_rejects_null() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(null));
+    }
+
+    @Test
+    public void validate_rejects_empty() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(""));
+    }
+
+    @Test
+    public void validate_rejects_non_http_url() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate("ftp://example.com"));
+    }
+
+    @Test
+    public void validate_rejects_missing_url_field() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate("{\"channel\": \"#alerts\"}"));
+    }
+
+    // === Send tests ===
+
+    @Test
+    public void send_posts_json_to_url() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+        AtomicReference<String> receivedContentType = new AtomicReference<>();
+
+        HttpServer server = startMockServer(200, receivedBody, receivedContentType);
+        int port = server.getAddress().getPort();
+
+        try {
+            ChangeNotification notification = createTestNotification(
+                "{\"url\": \"http://localhost:" + port + "/webhook\"}",
+                null,
+                null
+            );
+
+            plugin.send(notification);
+
+            assertNotNull(receivedBody.get(), "Server should have received a request");
+            assertEquals("application/json", receivedContentType.get());
+
+            JsonNode payload = MAPPER.readTree(receivedBody.get());
+            assertEquals("test-folder", payload.get("folder").asText());
+            assertEquals("threshold-node", payload.get("nodeName").asText());
+            assertEquals("ft", payload.get("nodeType").asText());
+            assertEquals(1, payload.get("changeCount").asInt());
+            assertTrue(payload.has("text"), "Payload should contain a text field");
+            assertTrue(payload.has("changes"), "Payload should contain changes array");
+            assertEquals(1, payload.get("changes").size());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void send_includes_auth_header() throws Exception {
+        AtomicReference<String> receivedAuth = new AtomicReference<>();
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/webhook", exchange -> {
+            receivedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+
+        try {
+            ChangeNotification notification = createTestNotification(
+                "{\"url\": \"http://localhost:" + port + "/webhook\"}",
+                "{\"authHeader\": \"Bearer test-token-123\"}",
+                null
+            );
+
+            plugin.send(notification);
+
+            assertEquals("Bearer test-token-123", receivedAuth.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void send_applies_custom_template() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+
+        HttpServer server = startMockServer(200, receivedBody, new AtomicReference<>());
+        int port = server.getAddress().getPort();
+
+        try {
+            ChangeNotification notification = createTestNotification(
+                "{\"url\": \"http://localhost:" + port + "/webhook\"}",
+                null,
+                "Regression in *{folderName}* by {nodeName}: {changeCount} change(s). cc @perf-team"
+            );
+
+            plugin.send(notification);
+
+            JsonNode payload = MAPPER.readTree(receivedBody.get());
+            assertEquals(
+                "Regression in *test-folder* by threshold-node: 1 change(s). cc @perf-team",
+                payload.get("text").asText()
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void send_uses_default_message_when_no_template() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+
+        HttpServer server = startMockServer(200, receivedBody, new AtomicReference<>());
+        int port = server.getAddress().getPort();
+
+        try {
+            ChangeNotification notification = createTestNotification(
+                "{\"url\": \"http://localhost:" + port + "/webhook\"}",
+                null,
+                null
+            );
+
+            plugin.send(notification);
+
+            JsonNode payload = MAPPER.readTree(receivedBody.get());
+            String text = payload.get("text").asText();
+            assertTrue(text.contains("test-folder"), "Default message should contain folder name");
+            assertTrue(text.contains("threshold-node"), "Default message should contain node name");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void send_throws_on_http_error() throws Exception {
+        HttpServer server = startMockServer(500, new AtomicReference<>(), new AtomicReference<>());
+        int port = server.getAddress().getPort();
+
+        try {
+            ChangeNotification notification = createTestNotification(
+                "{\"url\": \"http://localhost:" + port + "/webhook\"}",
+                null,
+                null
+            );
+
+            RuntimeException ex = assertThrows(RuntimeException.class, () -> plugin.send(notification));
+            assertTrue(ex.getMessage().contains("500"), "Exception should mention HTTP status code");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void send_accepts_plain_url_config() throws Exception {
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+
+        HttpServer server = startMockServer(200, receivedBody, new AtomicReference<>());
+        int port = server.getAddress().getPort();
+
+        try {
+            // Plain URL instead of JSON config
+            ChangeNotification notification = createTestNotification(
+                "http://localhost:" + port + "/webhook",
+                null,
+                null
+            );
+
+            plugin.send(notification);
+            assertNotNull(receivedBody.get(), "Server should have received a request");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    public void method_returns_webhook() {
+        assertEquals(NotificationMethod.WEBHOOK, plugin.method());
+    }
+
+    // === Helpers ===
+
+    private ChangeNotification createTestNotification(String configData, String secrets, String template) {
+        ObjectNode detectionData = MAPPER.createObjectNode();
+        detectionData.set("value", new DoubleNode(95.3));
+        detectionData.set("bound", new DoubleNode(90.0));
+        detectionData.put("direction", "above");
+
+        ObjectNode fingerprint = MAPPER.createObjectNode();
+        fingerprint.put("testName", "perf-test");
+
+        ChangeDetail detail = new ChangeDetail(42L, detectionData, fingerprint);
+
+        return new ChangeNotification(
+            "test-folder", 1L, "threshold-node", "ft",
+            List.of(detail), configData, secrets, template
+        );
+    }
+
+    private HttpServer startMockServer(int responseCode,
+                                        AtomicReference<String> receivedBody,
+                                        AtomicReference<String> receivedContentType) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/webhook", exchange -> {
+            receivedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+            receivedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            exchange.sendResponseHeaders(responseCode, -1);
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+}


### PR DESCRIPTION
Implements the first notification channel: HTTP POST webhook. Sends a JSON payload containing folder name, detection node info, change details, and a formatted text message to a configured URL.

Features:
- Accepts URL via JSON config ({"url": "https://..."}) or plain URL
- Optional Authorization header via secrets ({"authHeader": "Bearer ..."})
- Custom message templates with {folderName}, {nodeName}, {nodeType}, {changeCount} placeholders
- Slack incoming webhook compatible (uses 'text' field in payload)
- Config validation: requires valid http/https URL
- 10s connect timeout, 30s request timeout
- Throws on HTTP 4xx/5xx responses for NotificationLog failure tracking

Tests (14):
- Validation: valid JSON config, plain URL, https, null, empty, non-http scheme, missing url field
- Send: JSON payload structure, auth header, custom template, default message, HTTP error handling, plain URL config
- Method identity check