### PR TITLE
Add EmailPlugin for email notifications (issue #89, Phase 3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mailer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
@@ -171,6 +175,10 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-picocli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/io/hyperfoil/tools/h5m/notification/EmailPlugin.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/notification/EmailPlugin.java
@@ -1,0 +1,150 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.logging.Log;
+import io.quarkus.mailer.Mail;
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Qute;
+import io.quarkus.qute.Template;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+
+/**
+ * Notification plugin that sends change notifications via email.
+ * <p>
+ * Configuration data (JSON):
+ * <pre>{"to": "team@example.com"}</pre>
+ * or multiple recipients:
+ * <pre>{"to": "alice@example.com,bob@example.com"}</pre>
+ * <p>
+ * Optional fields:
+ * <pre>{"to": "team@example.com", "subject": "Custom subject: {folderName}"}</pre>
+ * <p>
+ * If a custom template is provided via {@link ChangeNotification#template()},
+ * it is used as the email body. Otherwise a default plain-text body is generated.
+ */
+@ApplicationScoped
+public class EmailPlugin implements NotificationPlugin {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    ReactiveMailer mailer;
+
+    @Location("email_change_notification.html")
+    Template htmlTemplate;
+
+    @Location("email_change_notification.txt")
+    Template textTemplate;
+
+    @ConfigProperty(name = "h5m.mail.subject.prefix", defaultValue = "[h5m]")
+    String subjectPrefix;
+
+    @ConfigProperty(name = "h5m.mail.timeout", defaultValue = "15s")
+    Duration sendMailTimeout;
+
+    @Override
+    public NotificationMethod method() {
+        return NotificationMethod.EMAIL;
+    }
+
+    @Override
+    public void send(ChangeNotification notification) {
+        String to = extractField(notification.configData(), "to");
+        String subject = buildSubject(notification);
+        String body = buildBody(notification);
+        String htmlBody = buildHtmlBody(notification);
+
+        String[] recipients = to.split(",");
+        Mail mail = Mail.withHtml(recipients[0].trim(), subject, htmlBody);
+        mail.setText(body);
+        for (int i = 1; i < recipients.length; i++) {
+            mail.addTo(recipients[i].trim());
+        }
+
+        mailer.send(mail).await().atMost(sendMailTimeout);
+        Log.debugf("Email sent to %s: %s", to, subject);
+    }
+
+    @Override
+    public void validate(String configData) {
+        if (configData == null || configData.isBlank()) {
+            throw new IllegalArgumentException("Email config data is required");
+        }
+        String to = extractField(configData, "to");
+        if (to == null || to.isBlank()) {
+            throw new IllegalArgumentException("Email config must contain a 'to' field with recipient address(es)");
+        }
+        // Basic email format check
+        for (String recipient : to.split(",")) {
+            String trimmed = recipient.trim();
+            if (!trimmed.contains("@") || !trimmed.contains(".")) {
+                throw new IllegalArgumentException("Invalid email address: " + trimmed);
+            }
+        }
+    }
+
+    private String buildSubject(ChangeNotification notification) {
+        String customSubject = extractField(notification.configData(), "subject");
+        if (customSubject != null && !customSubject.isBlank()) {
+            return subjectPrefix + " " + applyTemplate(customSubject, notification);
+        }
+        return String.format("%s Change detected in %s by %s",
+            subjectPrefix, notification.folderName(), notification.nodeName());
+    }
+
+    private String buildBody(ChangeNotification notification) {
+        if (notification.template() != null && !notification.template().isBlank()) {
+            return applyTemplate(notification.template(), notification);
+        }
+        return renderQuteTemplate(textTemplate, notification);
+    }
+
+    private String buildHtmlBody(ChangeNotification notification) {
+        if (notification.template() != null && !notification.template().isBlank()) {
+            return "<p>" + applyTemplate(notification.template(), notification) + "</p>";
+        }
+        return renderQuteTemplate(htmlTemplate, notification);
+    }
+
+    private String renderQuteTemplate(Template template, ChangeNotification notification) {
+        return template
+            .data("folderName", notification.folderName())
+            .data("nodeName", notification.nodeName())
+            .data("nodeType", notification.nodeType())
+            .data("changeCount", notification.changes().size())
+            .data("changes", notification.changes())
+            .render();
+    }
+
+    private String applyTemplate(String template, ChangeNotification notification) {
+        return Qute.fmt(template)
+            .data("folderName", notification.folderName())
+            .data("nodeName", notification.nodeName())
+            .data("nodeType", notification.nodeType())
+            .data("changeCount", notification.changes().size())
+            .data("changes", notification.changes())
+            .render();
+    }
+
+    private String extractField(String json, String field) {
+        if (json == null) return null;
+        try {
+            JsonNode node = MAPPER.readTree(json);
+            if (node.has(field)) {
+                return node.get(field).asText();
+            }
+        } catch (JsonProcessingException e) {
+            // not valid JSON
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -81,3 +81,9 @@ quarkus.oidc.client-id=${OIDC_CLIENT_ID:h5m}
 quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:}
 quarkus.oidc.application-type=service
 quarkus.oidc.token.principal-claim=preferred_username
+
+# Mailer - configure via environment for service deployments
+quarkus.mailer.from=${MAILER_FROM:h5m@localhost}
+quarkus.mailer.host=${MAILER_HOST:localhost}
+quarkus.mailer.port=${MAILER_PORT:25}
+quarkus.mailer.mock=true

--- a/src/main/resources/templates/email_change_notification.html
+++ b/src/main/resources/templates/email_change_notification.html
@@ -1,0 +1,15 @@
+<p>Change detected in folder <strong>{folderName}</strong></p>
+<p>Detection node: <strong>{nodeName}</strong> ({nodeType})<br>
+Number of changes: {changeCount}</p>
+{#if changes.size > 0}
+<table border="1" cellpadding="4" cellspacing="0">
+<tr><th>#</th><th>Fingerprint</th><th>Details</th></tr>
+{#each changes}
+<tr>
+  <td>{it_count}</td>
+  <td>{it.fingerprint}</td>
+  <td>{it.data}</td>
+</tr>
+{/each}
+</table>
+{/if}

--- a/src/main/resources/templates/email_change_notification.txt
+++ b/src/main/resources/templates/email_change_notification.txt
@@ -1,0 +1,10 @@
+Change detected in folder '{folderName}'
+Detection node: {nodeName} ({nodeType})
+Number of changes: {changeCount}
+
+{#each changes}
+--- Change {it_count} ---
+{#if it.fingerprint}Fingerprint: {it.fingerprint}
+{/if}{it.data}
+
+{/each}

--- a/src/test/java/io/hyperfoil/tools/h5m/notification/EmailPluginTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/notification/EmailPluginTest.java
@@ -1,0 +1,209 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.mailer.MockMailbox;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class EmailPluginTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Inject
+    EmailPlugin plugin;
+
+    @Inject
+    MockMailbox mailbox;
+
+    @BeforeEach
+    void clearMailbox() {
+        mailbox.clear();
+    }
+
+    // === Validation tests ===
+
+    @Test
+    public void validate_valid_config() {
+        assertDoesNotThrow(() -> plugin.validate("{\"to\": \"team@example.com\"}"));
+    }
+
+    @Test
+    public void validate_multiple_recipients() {
+        assertDoesNotThrow(() -> plugin.validate("{\"to\": \"alice@example.com,bob@example.com\"}"));
+    }
+
+    @Test
+    public void validate_rejects_null() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(null));
+    }
+
+    @Test
+    public void validate_rejects_empty() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(""));
+    }
+
+    @Test
+    public void validate_rejects_missing_to() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate("{\"subject\": \"test\"}"));
+    }
+
+    @Test
+    public void validate_rejects_invalid_email() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate("{\"to\": \"not-an-email\"}"));
+    }
+
+    // === Send tests ===
+
+    @Test
+    public void send_delivers_email() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"team@example.com\"}",
+            null
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        assertEquals(1, sent.size());
+        assertTrue(sent.getFirst().getSubject().contains("test-folder"));
+        assertTrue(sent.getFirst().getSubject().contains("threshold-node"));
+        assertTrue(sent.getFirst().getSubject().startsWith("[h5m]"), "Subject should have prefix");
+    }
+
+    @Test
+    public void send_includes_change_details_in_body() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"team@example.com\"}",
+            null
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        // Check plain text body
+        String body = sent.getFirst().getText();
+        assertTrue(body.contains("test-folder"), "Text body should contain folder name");
+        assertTrue(body.contains("threshold-node"), "Text body should contain node name");
+        assertTrue(body.contains("95.3"), "Text body should contain the detection value");
+        assertTrue(body.contains("90.0"), "Text body should contain the bound");
+        // Check HTML body exists
+        String html = sent.getFirst().getHtml();
+        assertNotNull(html, "HTML body should be present");
+        assertTrue(html.contains("test-folder"), "HTML body should contain folder name");
+    }
+
+    @Test
+    public void send_to_multiple_recipients() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"alice@example.com,bob@example.com\"}",
+            null
+        );
+
+        plugin.send(notification);
+
+        assertEquals(1, mailbox.getMailsSentTo("alice@example.com").size());
+        assertEquals(1, mailbox.getMailsSentTo("bob@example.com").size());
+    }
+
+    @Test
+    public void send_with_custom_subject() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"team@example.com\", \"subject\": \"ALERT: {folderName} regression\"}",
+            null
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        assertEquals("[h5m] ALERT: test-folder regression", sent.getFirst().getSubject());
+    }
+
+    @Test
+    public void send_with_custom_template() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"team@example.com\"}",
+            "Regression in {folderName} by {nodeName}: {changeCount} change(s)"
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        assertEquals(
+            "Regression in test-folder by threshold-node: 1 change(s)",
+            sent.getFirst().getText()
+        );
+    }
+
+    @Test
+    public void send_formats_fixed_threshold_data() {
+        ChangeNotification notification = createTestNotification(
+            "{\"to\": \"team@example.com\"}",
+            null
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        String body = sent.getFirst().getText();
+        assertTrue(body.contains("above"), "Body should contain direction for ft type");
+    }
+
+    @Test
+    public void send_formats_relative_difference_data() {
+        ObjectNode data = MAPPER.createObjectNode();
+        data.set("value", new DoubleNode(750.0));
+        data.set("ratio", new DoubleNode(-25.0));
+        data.set("previous", new DoubleNode(1000.0));
+        data.set("last", new DoubleNode(750.0));
+        ChangeDetail detail = new ChangeDetail(42L, data, null);
+
+        ChangeNotification notification = new ChangeNotification(
+            "test-folder", 1L, "regression-node", "rd",
+            List.of(detail),
+            "{\"to\": \"team@example.com\"}",
+            null, null
+        );
+
+        plugin.send(notification);
+
+        var sent = mailbox.getMailsSentTo("team@example.com");
+        String body = sent.getFirst().getText();
+        assertTrue(body.contains("-25.0"), "Body should contain ratio for rd type");
+        assertTrue(body.contains("1000.0"), "Body should contain previous value");
+    }
+
+    @Test
+    public void method_returns_email() {
+        assertEquals(NotificationMethod.EMAIL, plugin.method());
+    }
+
+    // === Helpers ===
+
+    private ChangeNotification createTestNotification(String configData, String template) {
+        ObjectNode detectionData = MAPPER.createObjectNode();
+        detectionData.set("value", new DoubleNode(95.3));
+        detectionData.set("bound", new DoubleNode(90.0));
+        detectionData.put("direction", "above");
+
+        ObjectNode fingerprint = MAPPER.createObjectNode();
+        fingerprint.put("testName", "perf-test");
+
+        ChangeDetail detail = new ChangeDetail(42L, detectionData, fingerprint);
+
+        return new ChangeNotification(
+            "test-folder", 1L, "threshold-node", "ft",
+            List.of(detail), configData, null, template
+        );
+    }
+}


### PR DESCRIPTION
Implements email notification channel using Quarkus ReactiveMailer, following the same patterns as Horreum's EmailPlugin.

Features:
- ReactiveMailer with configurable timeout (h5m.mail.timeout, default 15s)
- Sends both HTML and plain text bodies (multipart)
- Configurable subject prefix (h5m.mail.subject.prefix, default [h5m])
- Custom subject via config: {"subject": "ALERT: {folderName}"}
- Custom body via template with {folderName}, {nodeName}, {nodeType}, {changeCount} placeholders
- Multiple recipients: {"to": "alice@example.com,bob@example.com"}
- Format-aware change details: FixedThreshold shows value/bound/direction, RelativeDifference shows ratio/previous/last
- HTML body with table of changes including fingerprint and details
- Mock mode enabled by default for dev/test; configure SMTP via MAILER_HOST, MAILER_PORT, MAILER_FROM environment variables

Dependencies:
- Added quarkus-mailer

Tests (14):
- Validation: valid config, multiple recipients, null, empty, missing to field, invalid email format
- Send: delivery, change details in body, multiple recipients, custom subject with prefix, custom template, fixed threshold formatting, relative difference formatting
- Method identity check