### PR TITLE
folder page with node list and node graph

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/Folder.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Folder.java
@@ -6,5 +6,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 @Schema(description = "A folder containing uploaded data")
 public record Folder(
         @Schema(description = "Unique folder ID") Long id,
-        @Schema(description = "Folder name") @NotEmpty String name) {
+        @Schema(description = "Folder name") @NotEmpty String name,
+        @Schema(description = "Node group ID") Long groupId) {
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
@@ -11,7 +11,7 @@ public record Node(
         @Schema(description = "Node name") String name,
         @Schema(description = "Fully qualified domain name") String fqdn,
         @Schema(description = "Node type") NodeType type,
-        @Schema(description = "Parent node group") NodeGroup group,
+        @Schema(description = "Node group ID") Long groupId,
         @Schema(description = "Node operation (jq filter, JS function, etc.)") String operation,
         @Schema(description = "Source dependency nodes") List<Node> sources) {
 
@@ -20,7 +20,7 @@ public record Node(
         if (id != null) {
             return Objects.hash(id, name, type);
         }
-        return Objects.hash(name, type, operation, group != null ? group.id() : null);
+        return Objects.hash(name, type, operation, groupId);
     }
 
     @Override
@@ -32,7 +32,7 @@ public record Node(
             return Objects.equals(name, n.name)
                 && Objects.equals(type, n.type)
                 && Objects.equals(operation, n.operation)
-                && Objects.equals(group != null ? group.id() : null, n.group != null ? n.group.id() : null);
+                && Objects.equals(groupId, n.groupId);
         }
         return false;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeGroupServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeGroupServiceInterface.java
@@ -8,6 +8,14 @@ import io.hyperfoil.tools.h5m.api.NodeGroup;
 public interface NodeGroupServiceInterface {
 
     /**
+     * Retrieves a node group by its ID.
+     *
+     * @param id The ID of the node group.
+     * @return The node group with the given ID.
+     */
+    NodeGroup byId(Long id);
+
+    /**
      * Retrieves a node group by its name.
      *
      * @param groupName The name of the node group.

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
@@ -16,9 +16,11 @@ import org.mapstruct.MappingConstants;
 @Mapper(componentModel = MappingConstants.ComponentModel.JAKARTA)
 public interface ApiMapper {
 
+    @Mapping(target = "groupId", source = "group.id")
     Folder toFolder(FolderEntity folder);
 
     @Mapping(target = "type", expression = "java(node.type())")
+    @Mapping(target = "groupId", source = "group.id")
     Node toNode(NodeEntity node, @Context CycleAvoidingContext context);
 
     NodeGroup toNodeGroup(NodeGroupEntity nodeGroup, @Context CycleAvoidingContext context);

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
@@ -20,6 +20,14 @@ public class NodeGroupResource {
     NodeGroupServiceInterface nodeGroupService;
 
     @GET
+    @Path("id/{id}")
+    @PermitAll
+    @Operation(description = "Retrieve a node group by its ID")
+    public NodeGroup byId(@PathParam("id") Long groupId) {
+        return nodeGroupService.byId(groupId);
+    }
+
+    @GET
     @Path("{name}")
     @PermitAll
     @Operation(description = "Retrieve a node group by its name")

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -68,7 +68,8 @@ public class FolderService implements FolderServiceInterface {
     @Override
     @Transactional
     public Folder byName(String name){
-        return FolderEntity.find("name",name).project(Folder.class).firstResult();
+        FolderEntity entity = FolderEntity.find("name", name).firstResult();
+        return entity != null ? apiMapper.toFolder(entity) : null;
     }
     @Transactional
     public FolderEntity byPath(String path){

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeGroupService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeGroupService.java
@@ -36,6 +36,12 @@ public class NodeGroupService implements NodeGroupServiceInterface {
 
     @Override
     @Transactional
+    public NodeGroup byId(Long id){
+        return apiMapper.toNodeGroup(NodeGroupEntity.findById(id), new CycleAvoidingContext());
+    }
+
+    @Override
+    @Transactional
     public NodeGroup byName(String name){
         return apiMapper.toNodeGroup(NodeGroupEntity.find("name",name).firstResult(), new CycleAvoidingContext());
     }

--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@carbon/react": "^1.107",
+        "@dagrejs/dagre": "^3.0",
         "@ibm/plex-sans": "^1.1",
         "@tanstack/react-query": "^5.100",
         "@tanstack/react-query-devtools": "^5.100",
+        "@xyflow/react": "^12.10",
         "axios": "^1.16",
         "oidc-client-ts": "^3.5",
         "react": "^19.2",
@@ -705,6 +707,21 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2702,6 +2719,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2737,7 +2803,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3161,6 +3227,38 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3745,6 +3843,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -3913,8 +4017,113 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -8576,6 +8785,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.12",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
@@ -9306,6 +9524,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -15,9 +15,11 @@
   },
   "dependencies": {
     "@carbon/react": "^1.107",
+    "@dagrejs/dagre": "^3.0",
     "@ibm/plex-sans": "^1.1",
     "@tanstack/react-query": "^5.100",
     "@tanstack/react-query-devtools": "^5.100",
+    "@xyflow/react": "^12.10",
     "axios": "^1.16",
     "oidc-client-ts": "^3.5",
     "react": "^19.2",

--- a/src/main/webui/src/app/components/NodeGraphVisualizer.tsx
+++ b/src/main/webui/src/app/components/NodeGraphVisualizer.tsx
@@ -1,0 +1,187 @@
+import type { Node, NodeGroup } from '@client/types.gen.ts';
+import type { GraphLabel, NodeLabel } from '@dagrejs/dagre';
+import type { Edge, EdgeProps, Node as FlowNode } from '@xyflow/react';
+
+import { blue50, gray40, gray70, gray90, green50, red60, yellow30 } from '@carbon/colors';
+import { Code, Compare, FingerprintRecognition, FlowData, ForkNode, Home, Login, Rule, Script } from '@carbon/icons-react';
+import { Tooltip } from '@carbon/react';
+import dagre from '@dagrejs/dagre';
+import { Graph } from '@dagrejs/graphlib';
+import { BaseEdge, Controls, getSmoothStepPath, Handle, MarkerType, Position, ReactFlow } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { ComponentType, useMemo } from 'react';
+
+const TYPE_COLORS: Record<string, string> = {
+  ROOT: yellow30,
+  SPLIT: yellow30,
+  FINGERPRINT: blue50,
+  FIXED_THRESHOLD: red60,
+  RELATIVE_DIFFERENCE: red60,
+  USER_INPUT: green50,
+};
+
+const TYPE_ICONS: Record<string, ComponentType<{ size?: number }>> = {
+  ROOT: Home,
+  SPLIT: ForkNode,
+  FINGERPRINT: FingerprintRecognition,
+  FIXED_THRESHOLD: Rule,
+  RELATIVE_DIFFERENCE: Compare,
+  JQ: Script,
+  JSONATA: Script,
+  JS: Code,
+  SQL_JSONPATH_NODE: Script,
+  SQL_JSONPATH_ALL_NODE: Script,
+  USER_INPUT: Login,
+};
+
+function prettyOperation(op: string): string {
+  try {
+    return JSON.stringify(JSON.parse(op), null, 2);
+  } catch {
+    return op;
+  }
+}
+
+const NODE_WIDTH = 200;
+const NODE_HEIGHT = 40;
+const GRID_UNIT = 10;
+const EDGE_OFFSET = 20;
+
+const FixedOffsetEdge = ({ sourceX, sourceY, targetX, targetY, sourcePosition, targetPosition, markerStart, markerEnd, style }: EdgeProps) => {
+  const [path] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    stepPosition: 0,
+    offset: EDGE_OFFSET,
+    borderRadius: EDGE_OFFSET,
+  });
+  return <BaseEdge path={path} markerStart={markerStart} markerEnd={markerEnd} style={style} />;
+};
+
+const PipelineNode = ({ data }: { data: { name: string; operation?: string; nodeType?: string } }) => {
+  const borderColor = TYPE_COLORS[data.nodeType ?? ''] ?? gray40;
+  const Icon = (data.nodeType ? TYPE_ICONS[data.nodeType] : undefined) ?? FlowData;
+  return (
+    <div
+      style={{
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+        padding: '6px 12px',
+        fontSize: 10,
+        textAlign: 'center',
+        border: `1px solid ${borderColor}`,
+        borderRadius: 10,
+        background: gray90,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        position: 'relative',
+      }}
+    >
+      {data.nodeType !== 'ROOT' && <Handle type="target" position={Position.Top} />}
+      <div style={{ position: 'absolute', top: 5, right: 5, color: borderColor }}>
+        <Icon size={15} />
+      </div>
+      <div style={{ fontWeight: 'bolder' }}>{data.name}</div>
+      {data.operation && (
+        <Tooltip enterDelayMs={1000} label={<pre style={{ textAlign: 'left', fontSize: 7 }}>{prettyOperation(data.operation)}</pre>}>
+          <div style={{ opacity: 0.7, marginTop: 5, fontSize: 8, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{data.operation}</div>
+        </Tooltip>
+      )}
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+};
+
+const nodeTypes = { pipeline: PipelineNode };
+const edgeTypes = { fixedStep: FixedOffsetEdge };
+
+interface GraphNode extends Omit<Node, 'id' | 'sources'> {
+  id: string;
+  sources?: { id: string }[];
+}
+
+function collectNodes(node: Node, map: Map<string, GraphNode>) {
+  if (node.id == null || map.has(String(node.id))) return;
+  map.set(String(node.id), {
+    ...node,
+    id: String(node.id),
+    sources: node.sources?.filter((s) => s.id != null).map((s) => ({ id: String(s.id) })),
+  });
+  node.sources?.forEach((s) => {
+    collectNodes(s, map);
+  });
+}
+
+function buildGraph(nodeGroup: NodeGroup): { nodes: FlowNode[]; edges: Edge[] } {
+  const nodeMap = new Map<string, GraphNode>();
+  if (nodeGroup.root) collectNodes(nodeGroup.root, nodeMap);
+  nodeGroup.sources?.forEach((s) => {
+    collectNodes(s, nodeMap);
+  });
+  const allNodes = [...nodeMap.values()];
+
+  const graph = new Graph<GraphLabel, NodeLabel, Record<string, never>>();
+  graph.setGraph({ align: 'DL' });
+  graph.setDefaultEdgeLabel(() => ({}));
+
+  const edges: Edge[] = [];
+
+  allNodes.forEach((node) => {
+    graph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    node.sources?.forEach((src) => {
+      if (!nodeMap.has(src.id)) return;
+      const key = `${src.id}-${node.id}`;
+      if (!graph.hasEdge(src.id, node.id)) {
+        graph.setEdge(src.id, node.id);
+        edges.push({ id: key, source: src.id, target: node.id, animated: true, markerEnd: { type: MarkerType.ArrowClosed, color: gray70 }, type: 'fixedStep' });
+      }
+    });
+  });
+
+  dagre.layout(graph);
+
+  const nodes: FlowNode[] = allNodes.map((node) => {
+    const nodePosition = graph.node(node.id);
+    return {
+      id: node.id,
+      position: {
+        x: Math.round(((nodePosition.x ?? 0) - NODE_WIDTH / 2) / GRID_UNIT) * GRID_UNIT,
+        y: Math.round(((nodePosition.y ?? 0) - NODE_HEIGHT / 2) / GRID_UNIT) * GRID_UNIT,
+      },
+      type: 'pipeline',
+      data: { name: node.name ?? 'root', operation: node.operation, nodeType: node.type },
+    };
+  });
+
+  return { nodes, edges };
+}
+
+export const NodeGraphVisualizer = ({ nodeGroup }: { nodeGroup: NodeGroup }) => {
+  const { nodes, edges } = useMemo(() => buildGraph(nodeGroup), [nodeGroup]);
+  if (nodes.length === 0) {
+    return <p>No nodes defined</p>;
+  }
+
+  return (
+    <div style={{ height: 'calc(100vh - 200px)' }}>
+      <ReactFlow
+        defaultNodes={nodes}
+        defaultEdges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        snapToGrid
+        snapGrid={[GRID_UNIT, GRID_UNIT]}
+        colorMode="dark"
+        nodesConnectable={false}
+      >
+        <Controls position="top-right" showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+};

--- a/src/main/webui/src/app/layout/AppHeader.tsx
+++ b/src/main/webui/src/app/layout/AppHeader.tsx
@@ -1,7 +1,6 @@
 import {
   ErrorBoundary,
   Header,
-  HeaderContainer,
   HeaderGlobalBar,
   HeaderMenuButton,
   HeaderName,
@@ -15,15 +14,17 @@ import {
 } from '@carbon/react';
 import { listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Suspense } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Suspense, useCallback, useState } from 'react';
+import { Outlet, useParams } from 'react-router-dom';
 
 const NavFolders = () => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
+  const { folderId } = useParams<{ folderId: string }>();
+  const activeId = Number(folderId);
   return (
     <SideNavItems>
       {folders.map((folder) => (
-        <SideNavLink key={folder.id} href={`/folder/${String(folder.id)}`}>
+        <SideNavLink key={folder.id} href={`/folder/${String(folder.id)}`} isActive={folder.id === activeId}>
           {folder.name}
         </SideNavLink>
       ))}
@@ -32,40 +33,39 @@ const NavFolders = () => {
 };
 
 export const AppHeader = () => {
+  const { folderId } = useParams<{ folderId: string }>();
+  const [sideNavOpen, setSideNavOpen] = useState(!folderId);
+  const toggleSideNav = useCallback(() => {
+    setSideNavOpen((prev) => !prev);
+  }, []);
   return (
     <>
       <Theme theme="g100">
-        <HeaderContainer
-          render={({ isSideNavExpanded, onClickSideNavExpand }) => (
-            <>
-              <Header aria-label="Carbon App">
-                <SkipToContent />
-                <HeaderMenuButton aria-label="Hamburger menu" onClick={onClickSideNavExpand} isActive={isSideNavExpanded} isCollapsible={true} />
-                <HeaderName prefix="h5m">Horreum</HeaderName>
-                <HeaderGlobalBar />
-              </Header>
-              <SideNav aria-label="Side navigation" expanded={isSideNavExpanded} isPersistent={false} isFixedNav={false}>
-                <ErrorBoundary
-                  fallback={
-                    <div style={{ padding: 'var(--cds-spacing-05)' }}>
-                      <InlineLoading status="error" description="Folder load failed" />
-                    </div>
-                  }
-                >
-                  <Suspense
-                    fallback={
-                      <div style={{ padding: 'var(--cds-spacing-05)' }}>
-                        <SkeletonText paragraph={true} lineCount={50} />
-                      </div>
-                    }
-                  >
-                    <NavFolders />
-                  </Suspense>
-                </ErrorBoundary>
-              </SideNav>
-            </>
-          )}
-        />
+        <Header aria-label="Carbon App">
+          <SkipToContent />
+          <HeaderMenuButton aria-label="Hamburger menu" onClick={toggleSideNav} isActive={sideNavOpen} isCollapsible={true} />
+          <HeaderName prefix="h5m">Horreum</HeaderName>
+          <HeaderGlobalBar />
+        </Header>
+        <SideNav aria-label="Side navigation" expanded={sideNavOpen} isPersistent={false} isFixedNav={false}>
+          <ErrorBoundary
+            fallback={
+              <div style={{ padding: 'var(--cds-spacing-05)' }}>
+                <InlineLoading status="error" description="Folder load failed" />
+              </div>
+            }
+          >
+            <Suspense
+              fallback={
+                <div style={{ padding: 'var(--cds-spacing-05)' }}>
+                  <SkeletonText paragraph={true} lineCount={50} />
+                </div>
+              }
+            >
+              <NavFolders />
+            </Suspense>
+          </ErrorBoundary>
+        </SideNav>
       </Theme>
       <Outlet />
     </>

--- a/src/main/webui/src/app/layout/AppHeader.tsx
+++ b/src/main/webui/src/app/layout/AppHeader.tsx
@@ -16,13 +16,14 @@ import {
 import { listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Suspense } from 'react';
+import { Outlet } from 'react-router-dom';
 
 const NavFolders = () => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
   return (
     <SideNavItems>
       {folders.map((folder) => (
-        <SideNavLink key={folder.id} href={`/${String(folder.id)}`}>
+        <SideNavLink key={folder.id} href={`/folder/${String(folder.id)}`}>
           {folder.name}
         </SideNavLink>
       ))}
@@ -32,38 +33,41 @@ const NavFolders = () => {
 
 export const AppHeader = () => {
   return (
-    <Theme theme="g100">
-      <HeaderContainer
-        render={({ isSideNavExpanded, onClickSideNavExpand }) => (
-          <>
-            <Header aria-label="Carbon App">
-              <SkipToContent />
-              <HeaderMenuButton aria-label="Hamburger menu" onClick={onClickSideNavExpand} isActive={isSideNavExpanded} isCollapsible={true} />
-              <HeaderName prefix="h5m">Horreum</HeaderName>
-              <HeaderGlobalBar />
-            </Header>
-            <SideNav aria-label="Side navigation" expanded={isSideNavExpanded} isPersistent={false} isFixedNav={false}>
-              <ErrorBoundary
-                fallback={
-                  <div style={{ padding: 'var(--cds-spacing-05)' }}>
-                    <InlineLoading status="error" description="Folder load failed" />
-                  </div>
-                }
-              >
-                <Suspense
+    <>
+      <Theme theme="g100">
+        <HeaderContainer
+          render={({ isSideNavExpanded, onClickSideNavExpand }) => (
+            <>
+              <Header aria-label="Carbon App">
+                <SkipToContent />
+                <HeaderMenuButton aria-label="Hamburger menu" onClick={onClickSideNavExpand} isActive={isSideNavExpanded} isCollapsible={true} />
+                <HeaderName prefix="h5m">Horreum</HeaderName>
+                <HeaderGlobalBar />
+              </Header>
+              <SideNav aria-label="Side navigation" expanded={isSideNavExpanded} isPersistent={false} isFixedNav={false}>
+                <ErrorBoundary
                   fallback={
                     <div style={{ padding: 'var(--cds-spacing-05)' }}>
-                      <SkeletonText paragraph={true} lineCount={50} />
+                      <InlineLoading status="error" description="Folder load failed" />
                     </div>
                   }
                 >
-                  <NavFolders />
-                </Suspense>
-              </ErrorBoundary>
-            </SideNav>
-          </>
-        )}
-      />
-    </Theme>
+                  <Suspense
+                    fallback={
+                      <div style={{ padding: 'var(--cds-spacing-05)' }}>
+                        <SkeletonText paragraph={true} lineCount={50} />
+                      </div>
+                    }
+                  >
+                    <NavFolders />
+                  </Suspense>
+                </ErrorBoundary>
+              </SideNav>
+            </>
+          )}
+        />
+      </Theme>
+      <Outlet />
+    </>
   );
 };

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -19,8 +19,8 @@ import {
 } from '@carbon/react';
 import { byIdOptions, listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Suspense } from 'react';
-import { useParams } from 'react-router-dom';
+import { Suspense, useCallback } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 const NodesTab = ({ groupId }: { groupId: number }) => {
   const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
@@ -58,14 +58,22 @@ const GraphVisualizer = ({ groupId }: { groupId: number }) => {
   return <NodeGraphVisualizer nodeGroup={nodeGroup} />;
 };
 
+const TAB_ANCHORS = ['nodes', 'graph'];
+
 const FolderContent = ({ folderId }: { folderId: number }) => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
   const folder = folders.find((f) => f.id === folderId);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const selectedIndex = Math.max(0, TAB_ANCHORS.indexOf(location.hash.slice(1)));
+  const onTabChange = useCallback(({ selectedIndex: i }: { selectedIndex: number }) => {
+    void navigate({ hash: TAB_ANCHORS[i] }, { replace: true });
+  }, [navigate]);
   if (!folder) {
     return <InlineLoading status="error" description="Folder not found" />;
   }
   return (
-    <Tabs>
+    <Tabs selectedIndex={selectedIndex} onChange={onTabChange}>
       <TabList aria-label="Folder tabs">
         <Tab>Nodes</Tab>
         <Tab>Graph</Tab>

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -1,0 +1,98 @@
+import type { Node as ApiNode } from '@client/types.gen.ts';
+
+import {
+  ErrorBoundary,
+  InlineLoading,
+  SkeletonText,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListWrapper,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Tag,
+} from '@carbon/react';
+import { byIdOptions, listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
+
+const NodesTab = ({ groupId }: { groupId: number }) => {
+  const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
+  if (nodeGroup.sources?.length === 0) {
+    return <p>No nodes defined</p>;
+  }
+  return (
+    <StructuredListWrapper>
+      <StructuredListHead>
+        <StructuredListRow head>
+          <StructuredListCell head>Name</StructuredListCell>
+          <StructuredListCell head>Type</StructuredListCell>
+          <StructuredListCell head>FQDN</StructuredListCell>
+          <StructuredListCell head>Operation</StructuredListCell>
+        </StructuredListRow>
+      </StructuredListHead>
+      <StructuredListBody>
+        {nodeGroup.sources?.map((node: ApiNode) => (
+          <StructuredListRow key={node.id}>
+            <StructuredListCell>{node.name}</StructuredListCell>
+            <StructuredListCell>
+              <Tag size="sm">{node.type}</Tag>
+            </StructuredListCell>
+            <StructuredListCell>{node.fqdn}</StructuredListCell>
+            <StructuredListCell>{node.operation}</StructuredListCell>
+          </StructuredListRow>
+        ))}
+      </StructuredListBody>
+    </StructuredListWrapper>
+  );
+};
+
+const FolderContent = ({ folderId }: { folderId: number }) => {
+  const { data: folders } = useSuspenseQuery(listFoldersOptions());
+  const folder = folders.find((f) => f.id === folderId);
+  if (!folder) {
+    return <InlineLoading status="error" description="Folder not found" />;
+  }
+  return (
+    <Tabs>
+      <TabList aria-label="Folder tabs">
+        <Tab>Nodes</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          {folder.groupId != null ? (
+            <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load nodes" />}>
+              <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
+                <NodesTab groupId={folder.groupId} />
+              </Suspense>
+            </ErrorBoundary>
+          ) : (
+            <p>No node group associated with this folder</p>
+          )}
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+};
+
+export const FolderPage = () => {
+  const { folderId } = useParams<{ folderId: string }>();
+  const id = Number(folderId);
+  if (!folderId || isNaN(id)) {
+    return null;
+  }
+  return (
+    <div style={{ padding: 'var(--cds-spacing-05)', marginTop: 'var(--cds-spacing-09)' }}>
+      <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load folder" />}>
+        <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
+          <FolderContent folderId={id} />
+        </Suspense>
+      </ErrorBoundary>
+    </div>
+  );
+};

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -1,5 +1,6 @@
 import type { Node as ApiNode } from '@client/types.gen.ts';
 
+import { NodeGraphVisualizer } from '@app/components/NodeGraphVisualizer';
 import {
   ErrorBoundary,
   InlineLoading,
@@ -52,6 +53,11 @@ const NodesTab = ({ groupId }: { groupId: number }) => {
   );
 };
 
+const GraphVisualizer = ({ groupId }: { groupId: number }) => {
+  const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
+  return <NodeGraphVisualizer nodeGroup={nodeGroup} />;
+};
+
 const FolderContent = ({ folderId }: { folderId: number }) => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
   const folder = folders.find((f) => f.id === folderId);
@@ -62,6 +68,7 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
     <Tabs>
       <TabList aria-label="Folder tabs">
         <Tab>Nodes</Tab>
+        <Tab>Graph</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -69,6 +76,17 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
             <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load nodes" />}>
               <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
                 <NodesTab groupId={folder.groupId} />
+              </Suspense>
+            </ErrorBoundary>
+          ) : (
+            <p>No node group associated with this folder</p>
+          )}
+        </TabPanel>
+        <TabPanel>
+          {folder.groupId != null ? (
+            <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load nodes" />}>
+              <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
+                <GraphVisualizer groupId={folder.groupId} />
               </Suspense>
             </ErrorBoundary>
           ) : (

--- a/src/main/webui/src/app/routes.ts
+++ b/src/main/webui/src/app/routes.ts
@@ -1,10 +1,17 @@
 import { AppHeader } from '@app/layout/AppHeader';
+import { FolderPage } from '@app/pages/FolderPage';
 import { createBrowserRouter } from 'react-router-dom';
 
 const router = createBrowserRouter([
   {
     Component: AppHeader,
-    path: '*',
+    path: '/',
+    children: [
+      {
+        Component: FolderPage,
+        path: 'folder/:folderId',
+      },
+    ],
   },
 ]);
 

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
@@ -1,15 +1,12 @@
 package io.hyperfoil.tools.h5m.entity;
 
-import io.hyperfoil.tools.h5m.api.Node;
-import io.hyperfoil.tools.h5m.api.NodeGroup;
-import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -109,32 +106,27 @@ public class NodeTest {
 
     @Test
     public void hashCode_not_infinite_recursion(){
-        List<Node> groupSources = new ArrayList<>();
-        NodeGroup group = new NodeGroup(-1L,"group",new Node(-1L,"root","root", NodeType.ROOT,null,"",Collections.emptyList()),groupSources);
+        NodeGroupEntity group = new NodeGroupEntity("group");
+        NodeEntity n = new JqNode("node","$.",group.root);
+        group.sources.add(n);
 
-        Node n = new Node(1L,"node","fqdn",NodeType.JQ,group,"$.",List.of(group.root()));
-
-        groupSources.add(n);
         try {
             int hash = n.hashCode();
         }catch(StackOverflowError e){
             fail("infinite recursion in Node.hashCode");
         }
-
     }
 
     @Test
     public void equals_not_infinite_recursion(){
-        List<Node> sources1 = new ArrayList<>();
-        List<Node> sources2 = new ArrayList<>();
-        NodeGroup g1 = new NodeGroup(-1L,"group",new Node(-1L,"root","root", NodeType.ROOT,null,"",Collections.emptyList()),sources1);
-        NodeGroup g2 = new NodeGroup(-1L,"group",new Node(-1L,"root","root", NodeType.ROOT,null,"",Collections.emptyList()),sources2);
+        NodeGroupEntity g1 = new NodeGroupEntity("group");
+        NodeGroupEntity g2 = new NodeGroupEntity("group");
 
-        Node n1 = new Node(1L,"node","fqdn",NodeType.JQ,g1,"$.",Collections.emptyList());
-        Node n2 = new Node(1L,"node","fqdn",NodeType.JQ,g2,"$.",Collections.emptyList());
+        NodeEntity n1 = new JqNode("node","$.");
+        NodeEntity n2 = new JqNode("node","$.");
 
-        sources1.add(n1);
-        sources2.add(n2);
+        g1.sources.add(n1);
+        g2.sources.add(n2);
 
         try{
             n1.equals(n2);


### PR DESCRIPTION
this adds a folder page that consists of two tabs (for now).

the first has the list of nodes. in the future it will evolve to support add new nodes and delete existing nodes.

the second tab provides a wonderful visualization of the node graph, based on `react-flow` library using `dagre` for graph layout.

the graph visualization has some extra features that help identify the node structure: 
- the nodes are color coded and have icons to differentiate between types. 
- the nodes are draggable and snap to a grid. 
- operations have a tooltip with json pretty-printing.
- pan, zoom and zoom controls.

the tabs have URL anchors for navigation. also took the opportunity to improve the sidebar navigation panel a little.

sample: 
<img width="1358" height="639" alt="image" src="https://github.com/user-attachments/assets/5801c98e-5837-466b-8736-ef57df84547f" />
