### PR TITLE
improve visualization of large node graphs

### DIFF
--- a/src/main/webui/src/app/App.css
+++ b/src/main/webui/src/app/App.css
@@ -1,0 +1,3 @@
+.cds--tooltip-content {
+  max-width: none;
+}

--- a/src/main/webui/src/app/components/NodeGraphVisualizer.tsx
+++ b/src/main/webui/src/app/components/NodeGraphVisualizer.tsx
@@ -2,14 +2,14 @@ import type { Node, NodeGroup } from '@client/types.gen.ts';
 import type { GraphLabel, NodeLabel } from '@dagrejs/dagre';
 import type { Edge, EdgeProps, Node as FlowNode } from '@xyflow/react';
 
-import { blue50, gray40, gray70, gray90, green50, red60, yellow30 } from '@carbon/colors';
+import { blue50, gray40, gray90, green50, red60, yellow30, teal50 } from '@carbon/colors';
 import { Code, Compare, FingerprintRecognition, FlowData, ForkNode, Home, Login, Rule, Script } from '@carbon/icons-react';
 import { Tooltip } from '@carbon/react';
 import dagre from '@dagrejs/dagre';
 import { Graph } from '@dagrejs/graphlib';
-import { BaseEdge, Controls, getSmoothStepPath, Handle, MarkerType, Position, ReactFlow } from '@xyflow/react';
+import { BaseEdge, Controls, getSmoothStepPath, Handle, MarkerType, Position, ReactFlow, useReactFlow } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { ComponentType, useMemo } from 'react';
+import { ComponentType, useCallback, useEffect, useMemo, useState } from 'react';
 
 const TYPE_COLORS: Record<string, string> = {
   ROOT: yellow30,
@@ -17,7 +17,8 @@ const TYPE_COLORS: Record<string, string> = {
   FINGERPRINT: blue50,
   FIXED_THRESHOLD: red60,
   RELATIVE_DIFFERENCE: red60,
-  USER_INPUT: green50,
+  JS: green50,
+  USER_INPUT: teal50,
 };
 
 const TYPE_ICONS: Record<string, ComponentType<{ size?: number }>> = {
@@ -34,12 +35,18 @@ const TYPE_ICONS: Record<string, ComponentType<{ size?: number }>> = {
   USER_INPUT: Login,
 };
 
-function prettyOperation(op: string): string {
+function nodeColor(type?: string): string {
+  return TYPE_COLORS[type ?? ''] ?? gray40;
+}
+
+function prettyOperation(op: string) {
+  let text = op;
   try {
-    return JSON.stringify(JSON.parse(op), null, 2);
+    text = JSON.stringify(JSON.parse(op), null, 2);
   } catch {
-    return op;
+    /* not JSON, use raw */
   }
+  return <pre style={{ textAlign: 'left', fontSize: 7, maxWidth: 3 * NODE_WIDTH, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>{text}</pre>;
 }
 
 const NODE_WIDTH = 200;
@@ -55,15 +62,15 @@ const FixedOffsetEdge = ({ sourceX, sourceY, targetX, targetY, sourcePosition, t
     targetY,
     sourcePosition,
     targetPosition,
-    stepPosition: 0,
+    stepPosition: 0.1,
     offset: EDGE_OFFSET,
     borderRadius: EDGE_OFFSET,
   });
   return <BaseEdge path={path} markerStart={markerStart} markerEnd={markerEnd} style={style} />;
 };
 
-const PipelineNode = ({ data }: { data: { name: string; operation?: string; nodeType?: string } }) => {
-  const borderColor = TYPE_COLORS[data.nodeType ?? ''] ?? gray40;
+const PipelineNode = ({ data }: { data: { name: string; operation?: string; nodeType?: string; sourceIds?: string[]; dimmed?: boolean } }) => {
+  const color = nodeColor(data.nodeType);
   const Icon = (data.nodeType ? TYPE_ICONS[data.nodeType] : undefined) ?? FlowData;
   return (
     <div
@@ -73,26 +80,30 @@ const PipelineNode = ({ data }: { data: { name: string; operation?: string; node
         padding: '6px 12px',
         fontSize: 10,
         textAlign: 'center',
-        border: `1px solid ${borderColor}`,
+        border: `1px solid ${color}`,
         borderRadius: 10,
         background: gray90,
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'center',
         position: 'relative',
+        opacity: data.dimmed ? 0.2 : 1,
+        transition: 'opacity 1s',
       }}
     >
-      {data.nodeType !== 'ROOT' && <Handle type="target" position={Position.Top} />}
-      <div style={{ position: 'absolute', top: 5, right: 5, color: borderColor }}>
-        <Icon size={15} />
+      {data.nodeType !== 'ROOT' && <Handle type="target" position={Position.Left} />}
+      <div style={{ position: 'absolute', top: 5, right: 5, color }}>
+        <Tooltip align="top-right" enterDelayMs={1000} label={prettyOperation(data.nodeType ?? '')}>
+          <Icon size={15} />
+        </Tooltip>
       </div>
       <div style={{ fontWeight: 'bolder' }}>{data.name}</div>
       {data.operation && (
-        <Tooltip enterDelayMs={1000} label={<pre style={{ textAlign: 'left', fontSize: 7 }}>{prettyOperation(data.operation)}</pre>}>
-          <div style={{ opacity: 0.7, marginTop: 5, fontSize: 8, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{data.operation}</div>
+        <Tooltip align="bottom" enterDelayMs={1000} label={prettyOperation(data.operation)}>
+          <div style={{ opacity: 0.7, marginTop: 5, fontSize: 7, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{data.operation}</div>
         </Tooltip>
       )}
-      <Handle type="source" position={Position.Bottom} />
+      <Handle type="source" position={Position.Right} />
     </div>
   );
 };
@@ -126,19 +137,29 @@ function buildGraph(nodeGroup: NodeGroup): { nodes: FlowNode[]; edges: Edge[] } 
   const allNodes = [...nodeMap.values()];
 
   const graph = new Graph<GraphLabel, NodeLabel, Record<string, never>>();
-  graph.setGraph({ align: 'DL' });
+  graph.setGraph({ align: 'DL', rankdir: 'LR', rankalign: 'center', ranksep: NODE_WIDTH, nodesep: NODE_HEIGHT / 2, edgesep: NODE_HEIGHT / 4 });
   graph.setDefaultEdgeLabel(() => ({}));
 
   const edges: Edge[] = [];
 
   allNodes.forEach((node) => {
     graph.setNode(node.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    const edgeColor = nodeColor(node.type);
     node.sources?.forEach((src) => {
       if (!nodeMap.has(src.id)) return;
       const key = `${src.id}-${node.id}`;
       if (!graph.hasEdge(src.id, node.id)) {
         graph.setEdge(src.id, node.id);
-        edges.push({ id: key, source: src.id, target: node.id, animated: true, markerEnd: { type: MarkerType.ArrowClosed, color: gray70 }, type: 'fixedStep' });
+        edges.push({
+          id: key,
+          source: src.id,
+          target: node.id,
+          animated: true,
+          style: { stroke: edgeColor },
+          markerEnd: { type: MarkerType.ArrowClosed, color: edgeColor },
+          data: { color: edgeColor },
+          type: 'fixedStep',
+        });
       }
     });
   });
@@ -154,15 +175,61 @@ function buildGraph(nodeGroup: NodeGroup): { nodes: FlowNode[]; edges: Edge[] } 
         y: Math.round(((nodePosition.y ?? 0) - NODE_HEIGHT / 2) / GRID_UNIT) * GRID_UNIT,
       },
       type: 'pipeline',
-      data: { name: node.name ?? 'root', operation: node.operation, nodeType: node.type },
+      data: {
+        name: node.name ?? 'root',
+        operation: node.operation,
+        nodeType: node.type,
+        sourceIds: node.sources?.map((s) => s.id),
+      },
     };
   });
 
   return { nodes, edges };
 }
 
+const HighlightManager = ({ selectedId }: { selectedId?: string }) => {
+  const { setNodes, setEdges, getNodes } = useReactFlow();
+
+  useEffect(() => {
+    const selected = getNodes().find((n) => n.id === selectedId);
+    const sourceIds = new Set((selected?.data as { sourceIds?: string[] } | undefined)?.sourceIds ?? []);
+    const relatedIds = new Set([...sourceIds, selectedId]);
+
+    setNodes((nodes) =>
+      nodes.map((n) => ({
+        ...n,
+        data: {
+          ...n.data,
+          dimmed: selected !== undefined && !relatedIds.has(n.id),
+        },
+      })),
+    );
+
+    setEdges((edges) =>
+      edges.map((e) => {
+        const isHighlighted = selected !== undefined && e.target === selectedId && sourceIds.has(e.source);
+        return {
+          ...e,
+          style: { stroke: e.style?.stroke, strokeWidth: isHighlighted ? 3 : 1, opacity: selected === undefined || isHighlighted ? 1 : 0 },
+        };
+      }),
+    );
+  }, [selectedId, getNodes, setNodes, setEdges]);
+
+  return null;
+};
+
 export const NodeGraphVisualizer = ({ nodeGroup }: { nodeGroup: NodeGroup }) => {
   const { nodes, edges } = useMemo(() => buildGraph(nodeGroup), [nodeGroup]);
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+
+  const onNodeClick = useCallback((_: unknown, node: FlowNode) => {
+    setSelectedId((prev) => (prev === node.id ? undefined : node.id));
+  }, []);
+  const onPaneClick = useCallback(() => {
+    setSelectedId(undefined);
+  }, []);
+
   if (nodes.length === 0) {
     return <p>No nodes defined</p>;
   }
@@ -174,12 +241,17 @@ export const NodeGraphVisualizer = ({ nodeGroup }: { nodeGroup: NodeGroup }) => 
         defaultEdges={edges}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        onNodeClick={onNodeClick}
+        onPaneClick={onPaneClick}
         fitView
         snapToGrid
         snapGrid={[GRID_UNIT, GRID_UNIT]}
+        minZoom={0.1}
+        maxZoom={2}
         colorMode="dark"
         nodesConnectable={false}
       >
+        <HighlightManager selectedId={selectedId} />
         <Controls position="top-right" showInteractive={false} />
       </ReactFlow>
     </div>


### PR DESCRIPTION
this adds 4 major changes to better deal with huge node graphs:
- improve the tooltip for the node operation
- layout from left to right instead of top to bottom
- edges colored according to node type
- highlight a single node and it's sources

<img width="1851" height="869" alt="image" src="https://github.com/user-attachments/assets/18cf3225-f02b-4252-884e-85dfc3b4a6d2" />

