### PR TITLE
Add SlackPlugin for Slack Web API notifications (issue #89, Phase 5)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/notification/SlackPlugin.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/notification/SlackPlugin.java
@@ -1,0 +1,218 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.logging.Log;
+import io.quarkus.qute.Qute;
+import io.vertx.mutiny.core.Vertx;
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import io.vertx.mutiny.ext.web.client.WebClient;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.time.Duration;
+
+/**
+ * Notification plugin that posts change notifications to Slack using the
+ * <a href="https://api.slack.com/methods/chat.postMessage">Slack Web API</a>
+ * with <a href="https://api.slack.com/reference/block-kit">Block Kit</a> formatting.
+ * Uses the Vert.x Web Client for HTTP requests.
+ * <p>
+ * Configuration data (JSON):
+ * <pre>{"channel": "#perf-alerts"}</pre>
+ * <p>
+ * Secret data (JSON):
+ * <pre>{"token": "xoxb-your-bot-token"}</pre>
+ */
+@ApplicationScoped
+public class SlackPlugin implements NotificationPlugin {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Duration TIMEOUT = Duration.ofSeconds(30);
+
+    @Inject
+    Vertx vertx;
+
+    @ConfigProperty(name = "h5m.slack.api.url")
+    String slackApiUrl;
+
+    private WebClient webClient;
+
+    @PostConstruct
+    void init() {
+        webClient = WebClient.create(vertx);
+    }
+
+    @Override
+    public NotificationMethod method() {
+        return NotificationMethod.SLACK;
+    }
+
+    @Override
+    public void send(ChangeNotification notification) {
+        String channel = extractField(notification.configData(), "channel");
+        String token = extractToken(notification.configSecrets());
+
+        ObjectNode payload = buildSlackPayload(channel, notification);
+
+        HttpResponse<Buffer> response = webClient.postAbs(slackApiUrl)
+            .putHeader("Content-Type", "application/json; charset=utf-8")
+            .putHeader("Authorization", "Bearer " + token)
+            .putHeader("User-Agent", "h5m")
+            .sendBuffer(Buffer.buffer(payload.toString()))
+            .await().atMost(TIMEOUT);
+
+        if (response.statusCode() >= 400) {
+            throw new RuntimeException("Slack API returned HTTP " + response.statusCode()
+                + ": " + response.bodyAsString());
+        }
+        // Slack returns 200 even on errors — check the "ok" field
+        try {
+            JsonNode body = MAPPER.readTree(response.bodyAsString());
+            if (!body.path("ok").asBoolean(false)) {
+                String error = body.path("error").asText("unknown error");
+                throw new RuntimeException("Slack API error: " + error);
+            }
+        } catch (JsonProcessingException e) {
+            // Can't parse response — assume success if HTTP was 2xx
+        }
+        Log.debugf("Slack message posted to %s", channel);
+    }
+
+    @Override
+    public void validate(String configData) {
+        if (configData == null || configData.isBlank()) {
+            throw new IllegalArgumentException("Slack config is required");
+        }
+        String channel = extractField(configData, "channel");
+        if (channel == null || channel.isBlank()) {
+            throw new IllegalArgumentException("Slack config must contain a 'channel' field (e.g. #perf-alerts)");
+        }
+    }
+
+    private ObjectNode buildSlackPayload(String channel, ChangeNotification notification) {
+        ObjectNode payload = MAPPER.createObjectNode();
+        payload.put("channel", channel);
+
+        String fallbackText = String.format("Change detected in %s by %s: %d change(s)",
+            notification.folderName(), notification.nodeName(), notification.changes().size());
+        payload.put("text", fallbackText);
+
+        ArrayNode blocks = payload.putArray("blocks");
+
+        // Header block
+        ObjectNode header = blocks.addObject();
+        header.put("type", "header");
+        ObjectNode headerText = header.putObject("text");
+        headerText.put("type", "plain_text");
+        headerText.put("text", String.format("Change detected in %s", notification.folderName()));
+
+        // Main section with markdown
+        ObjectNode section = blocks.addObject();
+        section.put("type", "section");
+        ObjectNode sectionText = section.putObject("text");
+        sectionText.put("type", "mrkdwn");
+        sectionText.put("text", buildMarkdownBody(notification));
+
+        // Change details sections
+        for (int i = 0; i < notification.changes().size(); i++) {
+            ChangeDetail change = notification.changes().get(i);
+            ObjectNode detailSection = blocks.addObject();
+            detailSection.put("type", "section");
+            ObjectNode detailText = detailSection.putObject("text");
+            detailText.put("type", "mrkdwn");
+            detailText.put("text", formatChangeDetail(i + 1, change, notification.nodeType()));
+        }
+
+        // Divider
+        blocks.addObject().put("type", "divider");
+
+        // Context block
+        ObjectNode context = blocks.addObject();
+        context.put("type", "context");
+        ArrayNode elements = context.putArray("elements");
+        ObjectNode contextText = elements.addObject();
+        contextText.put("type", "mrkdwn");
+        contextText.put("text", String.format("Node: `%s` (%s) | Changes: %d",
+            notification.nodeName(), notification.nodeType(), notification.changes().size()));
+
+        return payload;
+    }
+
+    private String buildMarkdownBody(ChangeNotification notification) {
+        if (notification.template() != null && !notification.template().isBlank()) {
+            return applyTemplate(notification.template(), notification);
+        }
+        return String.format("*%s* detected by `%s` (%s)",
+            notification.changes().size() == 1 ? "1 change" : notification.changes().size() + " changes",
+            notification.nodeName(),
+            notification.nodeType());
+    }
+
+    private String applyTemplate(String template, ChangeNotification notification) {
+        return Qute.fmt(template)
+            .data("folderName", notification.folderName())
+            .data("nodeName", notification.nodeName())
+            .data("nodeType", notification.nodeType())
+            .data("changeCount", notification.changes().size())
+            .data("changes", notification.changes())
+            .render();
+    }
+
+    private String formatChangeDetail(int index, ChangeDetail change, String nodeType) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("*Change ").append(index).append("*");
+        if (change.fingerprint() != null) {
+            sb.append(" — Fingerprint: `").append(change.fingerprint()).append("`");
+        }
+        sb.append("\n");
+        if (change.data() != null) {
+            switch (nodeType) {
+                case "ft" -> {
+                    if (change.data().has("value")) sb.append("• Value: `").append(change.data().get("value")).append("`\n");
+                    if (change.data().has("bound")) sb.append("• Bound: `").append(change.data().get("bound")).append("`\n");
+                    if (change.data().has("direction")) sb.append("• Direction: ").append(change.data().get("direction").asText()).append("\n");
+                }
+                case "rd" -> {
+                    if (change.data().has("ratio")) sb.append("• Ratio: `").append(String.format("%.1f%%", change.data().get("ratio").asDouble())).append("`\n");
+                    if (change.data().has("value")) sb.append("• Value: `").append(change.data().get("value")).append("`\n");
+                    if (change.data().has("previous")) sb.append("• Previous: `").append(change.data().get("previous")).append("`\n");
+                }
+                default -> sb.append("• Data: `").append(change.data()).append("`\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    private String extractField(String json, String field) {
+        if (json == null) return null;
+        try {
+            JsonNode node = MAPPER.readTree(json);
+            if (node.has(field)) {
+                return node.get(field).asText();
+            }
+        } catch (JsonProcessingException e) {
+            // not valid JSON
+        }
+        return null;
+    }
+
+    private String extractToken(String secrets) {
+        if (secrets == null || secrets.isBlank()) {
+            throw new IllegalArgumentException("Slack secrets must contain a 'token' field");
+        }
+        String token = extractField(secrets, "token");
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("Slack secrets must contain a 'token' field");
+        }
+        return token;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,3 +87,6 @@ quarkus.mailer.from=${MAILER_FROM:h5m@localhost}
 quarkus.mailer.host=${MAILER_HOST:localhost}
 quarkus.mailer.port=${MAILER_PORT:25}
 quarkus.mailer.mock=true
+
+%test.h5m.slack.api.url=http://localhost:19876/api/chat.postMessage
+h5m.slack.api.url=https://slack.com/api/chat.postMessage

--- a/src/test/java/io/hyperfoil/tools/h5m/notification/SlackPluginTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/notification/SlackPluginTest.java
@@ -1,0 +1,175 @@
+package io.hyperfoil.tools.h5m.notification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sun.net.httpserver.HttpServer;
+import io.hyperfoil.tools.h5m.event.ChangeDetail;
+import io.hyperfoil.tools.h5m.event.ChangeNotification;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class SlackPluginTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final int MOCK_PORT = 19876;
+
+    @Inject
+    SlackPlugin plugin;
+
+    final AtomicReference<String> lastReceivedBody = new AtomicReference<>();
+    final AtomicReference<String> lastReceivedAuth = new AtomicReference<>();
+    private HttpServer mockServer;
+    private volatile String mockResponse = "{\"ok\": true}";
+
+    @BeforeEach
+    void startMock() throws IOException {
+        lastReceivedBody.set(null);
+        lastReceivedAuth.set(null);
+        mockResponse = "{\"ok\": true}";
+        mockServer = HttpServer.create(new InetSocketAddress(MOCK_PORT), 0);
+        mockServer.createContext("/api/chat.postMessage", exchange -> {
+            lastReceivedAuth.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            lastReceivedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] response = mockResponse.getBytes();
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        mockServer.start();
+    }
+
+    @AfterEach
+    void stopMock() {
+        if (mockServer != null) mockServer.stop(0);
+    }
+
+    // === Validation tests ===
+
+    @Test
+    public void validate_valid_config() {
+        assertDoesNotThrow(() -> plugin.validate("{\"channel\": \"#perf-alerts\"}"));
+    }
+
+    @Test
+    public void validate_rejects_null() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(null));
+    }
+
+    @Test
+    public void validate_rejects_empty() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate(""));
+    }
+
+    @Test
+    public void validate_rejects_missing_channel() {
+        assertThrows(IllegalArgumentException.class, () -> plugin.validate("{\"token\": \"xoxb-123\"}"));
+    }
+
+    // === Token validation ===
+
+    @Test
+    public void send_rejects_missing_token() {
+        ChangeNotification notification = createTestNotification(
+            "{\"channel\": \"#alerts\"}", null, null
+        );
+        assertThrows(IllegalArgumentException.class, () -> plugin.send(notification));
+    }
+
+    @Test
+    public void send_rejects_empty_secrets() {
+        ChangeNotification notification = createTestNotification(
+            "{\"channel\": \"#alerts\"}", "{}", null
+        );
+        assertThrows(IllegalArgumentException.class, () -> plugin.send(notification));
+    }
+
+    // === Send tests (using mock server on port 19876) ===
+
+    @Test
+    public void send_posts_block_kit_message() throws Exception {
+        plugin.send(createTestNotification(
+            "{\"channel\": \"#perf-alerts\"}",
+            "{\"token\": \"xoxb-test-token\"}",
+            null
+        ));
+
+        assertNotNull(lastReceivedBody.get(), "Server should have received a request");
+        assertEquals("Bearer xoxb-test-token", lastReceivedAuth.get());
+
+        JsonNode payload = MAPPER.readTree(lastReceivedBody.get());
+        assertEquals("#perf-alerts", payload.get("channel").asText());
+        assertTrue(payload.has("blocks"));
+        assertTrue(payload.has("text"));
+        assertEquals("header", payload.get("blocks").get(0).get("type").asText());
+        assertTrue(payload.get("blocks").get(0).get("text").get("text").asText().contains("test-folder"));
+    }
+
+    @Test
+    public void send_with_custom_template() throws Exception {
+        plugin.send(createTestNotification(
+            "{\"channel\": \"#alerts\"}",
+            "{\"token\": \"xoxb-test\"}",
+            "Regression in *{folderName}* by `{nodeName}`: {changeCount} change(s). cc @perf-team"
+        ));
+
+        JsonNode payload = MAPPER.readTree(lastReceivedBody.get());
+        String sectionText = payload.get("blocks").get(1).get("text").get("text").asText();
+        assertEquals(
+            "Regression in *test-folder* by `threshold-node`: 1 change(s). cc @perf-team",
+            sectionText
+        );
+    }
+
+    @Test
+    public void send_handles_slack_api_error() {
+        mockResponse = "{\"ok\": false, \"error\": \"channel_not_found\"}";
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+            plugin.send(createTestNotification(
+                "{\"channel\": \"#nonexistent\"}",
+                "{\"token\": \"xoxb-test\"}",
+                null
+            ))
+        );
+        assertTrue(ex.getMessage().contains("channel_not_found"));
+    }
+
+    @Test
+    public void method_returns_slack() {
+        assertEquals(NotificationMethod.SLACK, plugin.method());
+    }
+
+    // === Helpers ===
+
+    private ChangeNotification createTestNotification(String configData, String secrets, String template) {
+        ObjectNode detectionData = MAPPER.createObjectNode();
+        detectionData.set("value", new DoubleNode(95.3));
+        detectionData.set("bound", new DoubleNode(90.0));
+        detectionData.put("direction", "above");
+
+        ObjectNode fingerprint = MAPPER.createObjectNode();
+        fingerprint.put("testName", "perf-test");
+
+        ChangeDetail detail = new ChangeDetail(42L, detectionData, fingerprint);
+
+        return new ChangeNotification(
+            "test-folder", 1L, "threshold-node", "ft",
+            List.of(detail), configData, secrets, template
+        );
+    }
+
+}


### PR DESCRIPTION
Posts change notifications to Slack channels using the Slack Web API (chat.postMessage) with Block Kit formatting, following the same patterns as Horreum's SlackChannelMessageAction.

Features:
- Posts via Slack Web API (chat.postMessage) with Bearer token auth
- Block Kit message with header, mrkdwn section, per-change details, divider, and context block with metadata
- Fallback plain text for notification previews
- Config: {"channel": "#perf-alerts"}
- Secrets: {"token": "xoxb-..."}
- Custom message template with {folderName}, {nodeName}, {nodeType}, {changeCount} placeholders — replaces the mrkdwn section body
- Format-aware change details: ft shows value/bound/direction, rd shows ratio/value/previous
- Checks Slack API "ok" response field (Slack returns 200 even on errors)
- Configurable API URL via h5m.slack.api.url for testing

Tests (10):
- Validation: valid config, null, empty, missing channel
- Token: missing secrets, empty secrets
- Send: Block Kit structure verification, auth header, custom template, Slack API error handling (channel_not_found)
- Method identity check