### PR TITLE
Fix lazy init NPE in work execution and add node values endpoint

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
@@ -31,4 +31,12 @@ public interface ValueServiceInterface {
      */
     List<JsonNode> getGroupedValues(Long nodeId);
 
+    /**
+     * Retrieves all values produced by a specific node.
+     *
+     * @param nodeId The ID of the node.
+     * @return A list of values for the given node.
+     */
+    List<Value> getNodeValues(Long nodeId);
+
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
@@ -44,4 +44,12 @@ public class ValueResource {
     public List<JsonNode> getGroupedValues(@PathParam("nodeId") Long nodeId) {
         return valueService.getGroupedValues(nodeId);
     }
+
+    @GET
+    @Path("node/{nodeId}")
+    @PermitAll
+    @Operation(description = "Get all values produced by a specific node")
+    public List<Value> getNodeValues(@PathParam("nodeId") Long nodeId) {
+        return valueService.getNodeValues(nodeId);
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -554,6 +554,14 @@ public class ValueService implements ValueServiceInterface {
         return ValueEntity.find("node.id",node.id).list();
     }
 
+    @Override
+    @Transactional
+    public List<Value> getNodeValues(Long nodeId){
+        CycleAvoidingContext cycleContext = new CycleAvoidingContext();
+        List<ValueEntity> entities = ValueEntity.find("node.id", nodeId).list();
+        return entities.stream().map(entity -> apiMapper.toValue(entity, cycleContext)).toList();
+    }
+
 
     @Transactional
     public int deleteDescendantValues(ValueEntity root, NodeEntity node){

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -176,6 +176,11 @@ public class WorkService implements WorkServiceInterface {
                 //error conditions?
                 //work.activeNode == null is not yet a validation condition but it could be for post processing tasks?
             }
+            // Eagerly initialize lazy-loaded data fields to avoid LazyInitializationException
+            // when accessed later in calculateValues (ValueEntity.data is @Basic(fetch = LAZY))
+            for (ValueEntity sv : work.sourceValues) {
+                Hibernate.initialize(sv.data);
+            }
             //looping over values works for Jq / Js nodes but what about cross test comparison
             //calculateValue should probably accept all sourceValues and leave it to the node function to decide
             List<ValueEntity> calculated = nodeService.calculateValues(work.activeNode,work.sourceValues);

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -6,6 +6,7 @@ import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.hyperfoil.tools.h5m.svc.WorkService;
 import io.restassured.specification.RequestSpecification;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -26,6 +27,9 @@ public class RestEndpointTest extends FreshDb {
 
     @Inject
     TransactionManager tm;
+
+    @Inject
+    WorkService workService;
 
     private void createFolder(String name) {
         given()
@@ -381,7 +385,7 @@ public class RestEndpointTest extends FreshDb {
     // -- End-to-end: upload + computed values --
 
     @Test
-    public void upload_and_verify_jq_values_via_rest() {
+    public void upload_and_verify_jq_values_via_rest() throws InterruptedException {
         createFolder("e2e-test");
         Long groupId = getGroupId("e2e-test");
         Long jqNodeId = createNode(groupId, "extract", ".key");
@@ -395,17 +399,20 @@ public class RestEndpointTest extends FreshDb {
                 .then()
                 .statusCode(204);
 
-        // The root node gets an auto-generated ID from folder creation;
-        // query the group to find the root node for descendant lookup
-        String nodesResponse = given()
-                .queryParam("name", "extract")
-                .queryParam("groupId", groupId)
-                .when().get("/api/node/find")
+        // Wait for the work queue to finish processing the upload
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(workService.isIdle(), "Work queue should be idle after processing");
+
+        // Verify the JQ node computed a value from the uploaded data via REST
+        given()
+                .when().get("/api/value/node/" + jqNodeId)
                 .then()
                 .statusCode(200)
-                .extract().asString();
-
-        assertTrue(nodesResponse.contains("extract"), "JQ node should be findable via REST");
+                .body("size()", greaterThan(0))
+                .body("[0].data", equalTo("hello"));
     }
 
     // -- OpenAPI spec --


### PR DESCRIPTION
Fix NullPointerException in WorkService.execute() where ValueEntity.data
(@Basic fetch=LAZY) was not initialized when accessed from the work queue
thread. Add Hibernate.initialize() for source values after loading Work.

Add GET /api/value/node/{nodeId} endpoint to retrieve all values produced
by a specific node. Update the upload e2e test to wait for work queue
completion and verify computed values via the new endpoint.