### PR TITLE
use closure table for entity source relationships

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -3,9 +3,13 @@ package io.hyperfoil.tools.h5m.entity;
 import com.fasterxml.jackson.annotation.*;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.hyperfoil.tools.h5m.provided.H5mEntityListener;
 import io.hyperfoil.tools.h5m.queue.KahnDagSort;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import org.hibernate.annotations.*;
+import org.hibernate.dialect.PostgreSQLDialect;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -13,6 +17,7 @@ import java.util.stream.Collectors;
 
 @Entity(name = "node")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@EntityListeners( H5mEntityListener.class )
 @DiscriminatorColumn(name = "type", discriminatorType =  DiscriminatorType.STRING)
 public abstract class NodeEntity extends PanacheEntity implements Comparable<NodeEntity> {
 
@@ -42,11 +47,112 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
     @JoinTable(
             name="node_edge",
             joinColumns = @JoinColumn(name = "child_id"),
-            inverseJoinColumns = @JoinColumn(name = "parent_id"),
-            uniqueConstraints = @UniqueConstraint(columnNames = {"child_id", "parent_id"}),
-            indexes = @Index(name = "idx_node_edge_parent", columnList = "parent_id")
+            inverseJoinColumns = @JoinColumn(name = "parent_id", updatable = false, insertable = false),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"child_id", "parent_id", "depth"})
+            //indexes = @Index(name = "idx_node_edge_parent", columnList = "parent_id")
     )
     @OrderColumn(name = "idx")
+    @SQLInsert(sql="""
+        WITH insert_edge (child_id,idx,parent_id) AS (VALUES(?,?,?)),
+        found AS (
+            SELECT l.parent_id, r.child_id, l.depth + r.depth + 1 AS depth, r.count AS count, r.idx AS idx
+            FROM
+                ( SELECT ne.parent_id, ne.depth FROM node_edge ne JOIN insert_edge ie ON ne.child_id = ie.parent_id) l
+            CROSS JOIN
+                ( SELECT ne.child_id, ne.depth, ie.idx, ne.count FROM node_edge ne JOIN insert_edge ie ON ne.parent_id = ie.child_id) r
+        )
+        INSERT INTO node_edge (parent_id,child_id,idx,depth,count)
+        SELECT parent_id,child_id,idx,depth,count FROM found
+        WHERE true
+        ON CONFLICT (child_id, parent_id, depth)
+        DO UPDATE SET count = node_edge.count + 1
+        """)
+
+    @SQLJoinTableRestriction("depth = 1")
+    @SQLDeleteAll(sql = """
+        delete from node_edge where child_id = ? and child_id != parent_id
+        """)
+    @SQLDelete(sql= """
+        with from_hibernate_delete (child_id,idx) as ( values(?,?) ),
+        target_edge as (select ne.child_id,ne.parent_id,ne.depth,ne.count from node_edge ne join from_hibernate_delete fh on ne.child_id = fh.child_id and ne.idx = fh.idx where ne.depth = 1),
+        selected_edge as (
+          select l.parent_id as parent_id, r.child_id as child_id, l.depth + r.depth + 1 as depth
+          from ( select ne.* from node_edge ne join target_edge te on ne.child_id = te.parent_id) l
+          cross join
+          ( select ne.* from node_edge ne join target_edge te on ne.parent_id = te.child_id) r
+        )
+        update node_edge set count = count - 1 where (parent_id,child_id,depth) in (select parent_id, child_id, depth from selected_edge);
+        """
+    )
+    @SQLUpdate(
+        table = "node_edge",
+        sql= """
+        with from_hibernate_update (parent_id,child_id,idx) as (values(?,?,?)),
+        existing (parent_id,child_id,idx) as (select ne.parent_id,ne.child_id,ne.idx from node_edge ne join from_hibernate_update hu on ne.child_id = hu.child_id and ne.idx = hu.idx where ne.depth = 1),
+        --delete the existing 
+        delete_target_edge as (select ne.child_id,ne.parent_id,ne.depth,ne.count from node_edge ne join existing e on ne.child_id = e.child_id and ne.idx = e.idx where ne.depth = 1),
+        delete_selected_edge as (
+          select l.parent_id as parent_id, r.child_id as child_id, l.depth + r.depth + 1 as depth
+          from ( select ne.* from node_edge ne join delete_target_edge te on ne.child_id = te.parent_id) l
+          cross join
+          ( select ne.* from node_edge ne join delete_target_edge te on ne.parent_id = te.child_id) r
+        ),
+        delete_rows (parent_id,child_id,idx,depth,count) as (select parent_id,child_id,idx,depth,count-1 as count from node_edge where (parent_id,child_id,depth) in (select parent_id, child_id, depth from delete_selected_edge)),
+        insert_found (parent_id,child_id,idx,depth,count) AS (
+            SELECT l.parent_id, r.child_id, r.idx AS idx, l.depth + r.depth + 1 AS depth, r.count AS count
+            FROM
+                ( SELECT ne.parent_id, ne.depth FROM node_edge ne JOIN from_hibernate_update fh ON ne.child_id = fh.parent_id) l
+            CROSS JOIN
+                ( SELECT ne.child_id, ne.depth, fh.idx, ne.count FROM node_edge ne JOIN from_hibernate_update fh ON ne.parent_id = fh.child_id) r
+        )
+        INSERT INTO node_edge (parent_id,child_id,idx,depth,count)
+            SELECT 
+                coalesce(d.parent_id,i.parent_id) as parent_id ,
+                coalesce(d.child_id,i.child_id) as child_id ,
+                coalesce(d.idx,i.idx) as idx,
+                coalesce(d.depth,i.depth) as depth, 
+                case when d.count is null then i.count when i.count is null then d.count when d.count = i.count then d.count else -1 end as count 
+            from delete_rows d full outer join insert_found i on d.parent_id = i.parent_id and d.child_id = i.child_id and d.depth = i.depth           
+        WHERE case when d.count is null then i.count when i.count is null then d.count when d.count = i.count then d.count else -1 end >= 0
+        ON CONFLICT (child_id, parent_id, depth)
+        DO UPDATE SET count = EXCLUDED.count
+    """)
+    @DialectOverride.SQLUpdate(
+            dialect = PostgreSQLDialect.class,
+            override = @SQLUpdate(
+                    table = "node_edge",
+                    sql= """
+        with from_hibernate_update (parent_id,child_id,idx) as (values(?,?,?)),
+        existing (parent_id,child_id,idx) as (select ne.parent_id,ne.child_id,ne.idx from node_edge ne join from_hibernate_update hu on ne.child_id = hu.child_id and ne.idx = hu.idx where ne.depth = 1),
+        --delete the existing 
+        delete_target_edge as (select ne.child_id,ne.parent_id,ne.depth,ne.count from node_edge ne join existing e on ne.child_id = e.child_id and ne.idx = e.idx where ne.depth = 1),
+        delete_selected_edge as (
+          select l.parent_id as parent_id, r.child_id as child_id, l.depth + r.depth + 1 as depth
+          from ( select ne.* from node_edge ne join delete_target_edge te on ne.child_id = te.parent_id) l
+          cross join
+          ( select ne.* from node_edge ne join delete_target_edge te on ne.parent_id = te.child_id) r
+        ),
+        delete_rows (parent_id,child_id,idx,depth,count) as (select parent_id,child_id,idx,depth,count-1 as count from node_edge where (parent_id,child_id,depth) in (select parent_id, child_id, depth from delete_selected_edge)),
+        insert_found (parent_id,child_id,idx,depth,count) AS (
+            SELECT l.parent_id, r.child_id, r.idx AS idx, l.depth + r.depth + 1 AS depth, r.count AS count
+            FROM
+                ( SELECT ne.parent_id, ne.depth FROM node_edge ne JOIN from_hibernate_update fh ON ne.child_id = fh.parent_id) l
+            CROSS JOIN
+                ( SELECT ne.child_id, ne.depth, fh.idx, ne.count FROM node_edge ne JOIN from_hibernate_update fh ON ne.parent_id = fh.child_id) r
+        )
+        INSERT INTO node_edge (parent_id,child_id,idx,depth,count)
+            SELECT 
+                coalesce(d.parent_id,i.parent_id) as parent_id ,
+                coalesce(d.child_id,i.child_id) as child_id ,
+                coalesce(d.idx,i.idx) as idx,
+                coalesce(d.depth,i.depth) as depth, 
+                case when d.count is null then i.count when i.count is null then d.count when d.count = i.count then d.count else -1 end as count 
+            from delete_rows d full outer join insert_found i on d.parent_id = i.parent_id and d.child_id = i.child_id and d.depth = i.depth           
+        WHERE true
+        ON CONFLICT (child_id, parent_id, depth)
+        DO UPDATE SET count = EXCLUDED.count
+            """)
+    )
     public List<NodeEntity> sources;
 
     public List<NodeEntity> getSources() {return sources;}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.hyperfoil.tools.h5m.provided.H5mEntityListener;
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import org.hibernate.annotations.BatchSize;
+import jakarta.persistence.CascadeType;
+import org.hibernate.annotations.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Mutability;
@@ -21,9 +24,10 @@ import java.util.stream.Collectors;
 
 @Entity(name = "value")
 @Table(indexes = {
-    @Index(name = "idx_value_node_id", columnList = "node_id"),
-    @Index(name = "idx_value_folder_id", columnList = "folder_id")
+    //@Index(name = "idx_value_node_id", columnList = "node_id"),
+    //@Index(name = "idx_value_folder_id", columnList = "folder_id")
 })
+@EntityListeners( H5mEntityListener.class )
 public class ValueEntity extends PanacheEntity {
 
     @Column(columnDefinition = "JSONB")
@@ -65,10 +69,71 @@ public class ValueEntity extends PanacheEntity {
             name="value_edge",
             joinColumns = @JoinColumn(name = "child_id"),
             inverseJoinColumns = @JoinColumn(name = "parent_id"),
-            uniqueConstraints = @UniqueConstraint(columnNames = {"child_id", "parent_id"}),
-            indexes = @Index(name = "idx_value_edge_parent", columnList = "parent_id")
+            uniqueConstraints = @UniqueConstraint(columnNames = {"child_id", "parent_id", "depth"})
+            //indexes = @Index(name = "idx_value_edge_parent", columnList = "parent_id")
     )
     @OrderColumn(name = "idx")
+    @SQLInsert(sql="""
+        WITH insert_edge (child_id,idx,parent_id) AS (VALUES(?,?,?)),
+        found AS (
+            SELECT l.parent_id, r.child_id, l.depth + r.depth + 1 AS depth, r.count AS count, r.idx AS idx
+            FROM
+                ( SELECT ve.parent_id, ve.depth FROM value_edge ve JOIN insert_edge ie ON ve.child_id = ie.parent_id) l
+            CROSS JOIN
+                ( SELECT ve.child_id, ve.depth, ie.idx, ve.count FROM value_edge ve JOIN insert_edge ie ON ve.parent_id = ie.child_id) r
+        )
+        INSERT INTO value_edge (parent_id,child_id,idx,depth,count)
+        SELECT parent_id,child_id,idx,depth,count FROM found
+        WHERE true
+        ON CONFLICT (child_id, parent_id, depth)
+        DO UPDATE SET count = value_edge.count + 1
+        """)
+    @SQLDeleteAll(sql = """
+        delete from value_edge where child_id = ? and parent_id != child_id
+        """)
+    @SQLDelete(sql = """
+        with from_hibernate_delete (child_id,idx) as ( values(?,?) ),
+        target_edge as (select ve.child_id,ve.parent_id,ve.depth,ve.count from value_edge ve join from_hibernate_delete fh on ve.child_id = fh.child_id and ve.idx = fh.idx where ve.depth = 1),
+        selected_edge as (
+          select l.parent_id as parent_id, r.child_id as child_id, l.depth + r.depth + 1 as depth
+          from ( select ve.* from value_edge ve join target_edge te on ve.child_id = te.parent_id) l
+          cross join
+          ( select ve.* from value_edge ve join target_edge te on ve.parent_id = te.child_id) r
+        )
+        update value_edge set count = count - 1 where (parent_id,child_id,depth) in (select parent_id, child_id, depth from selected_edge);
+    """)
+    @SQLUpdate(sql= """
+        with from_hibernate_update (parent_id,child_id,idx) as (values(?,?,?)),
+        existing (parent_id,child_id,idx) as (select ne.parent_id,ne.child_id,ne.idx from vale_edge ne join from_hibernate_update hu on ne.child_id = hu.child_id and ne.idx = hu.idx where ne.depth = 1),
+        --delete the existing 
+        delete_target_edge as (select ne.child_id,ne.parent_id,ne.depth,ne.count from value_edge ne join existing e on ne.child_id = e.child_id and ne.idx = e.idx where ne.depth = 1),
+        delete_selected_edge as (
+          select l.parent_id as parent_id, r.child_id as child_id, l.depth + r.depth + 1 as depth
+          from ( select ne.* from value_edge ne join delete_target_edge te on ne.child_id = te.parent_id) l
+          cross join
+          ( select ne.* from value_edge ne join delete_target_edge te on ne.parent_id = te.child_id) r
+        ),
+        delete_rows (parent_id,child_id,idx,depth,count) as (select parent_id,child_id,idx,depth,count-1 as count from value_edge where (parent_id,child_id,depth) in (select parent_id, child_id, depth from delete_selected_edge)),
+        insert_found (parent_id,child_id,idx,depth,count) AS (
+            SELECT l.parent_id, r.child_id, r.idx AS idx, l.depth + r.depth + 1 AS depth, r.count AS count
+            FROM
+                ( SELECT ne.parent_id, ne.depth FROM value_edge ne JOIN from_hibernate_update fh ON ne.child_id = fh.parent_id) l
+            CROSS JOIN
+                ( SELECT ne.child_id, ne.depth, fh.idx, ne.count FROM value_edge ne JOIN from_hibernate_update fh ON ne.parent_id = fh.child_id) r
+        )
+        INSERT INTO value_edge (parent_id,child_id,idx,depth,count)
+            SELECT 
+                coalesce(d.parent_id,i.parent_id) as parent_id ,
+                coalesce(d.child_id,i.child_id) as child_id ,
+                coalesce(d.idx,i.idx) as idx,
+                coalesce(d.depth,i.depth) as depth, 
+                case when d.count is null then i.count when i.count is null then d.count when d.count = i.count then d.count else -1 end as count 
+            from delete_rows d full outer join insert_found i on d.parent_id = i.parent_id and d.child_id = i.child_id and d.depth = i.depth           
+        WHERE case when d.count is null then i.count when i.count is null then d.count when d.count = i.count then d.count else -1 end >= 0
+        ON CONFLICT (child_id, parent_id, depth)
+        DO UPDATE SET count = EXCLUDED.count
+    """)
+    @SQLJoinTableRestriction("depth = 1")
     public List<ValueEntity> sources;
 
     public ValueEntity(){

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -104,7 +104,7 @@ public class ValueEntity extends PanacheEntity {
     """)
     @SQLUpdate(sql= """
         with from_hibernate_update (parent_id,child_id,idx) as (values(?,?,?)),
-        existing (parent_id,child_id,idx) as (select ne.parent_id,ne.child_id,ne.idx from vale_edge ne join from_hibernate_update hu on ne.child_id = hu.child_id and ne.idx = hu.idx where ne.depth = 1),
+        existing (parent_id,child_id,idx) as (select ne.parent_id,ne.child_id,ne.idx from value_edge ne join from_hibernate_update hu on ne.child_id = hu.child_id and ne.idx = hu.idx where ne.depth = 1),
         --delete the existing 
         delete_target_edge as (select ne.child_id,ne.parent_id,ne.depth,ne.count from value_edge ne join existing e on ne.child_id = e.child_id and ne.idx = e.idx where ne.depth = 1),
         delete_selected_edge as (

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/JqNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/JqNode.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import org.hibernate.annotations.SQLInsert;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/io/hyperfoil/tools/h5m/provided/DatasourceConfiguration.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/provided/DatasourceConfiguration.java
@@ -2,6 +2,7 @@ package io.hyperfoil.tools.h5m.provided;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.supplier.AgroalPropertiesReader;
+import io.quarkus.agroal.runtime.OpenTelemetryAgroalDataSource;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
@@ -14,9 +15,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,9 +24,6 @@ import java.util.Map;
 
 @ApplicationScoped
 public class DatasourceConfiguration {
-
-    @ConfigProperty(name = "h5m.foo",defaultValue = "1")
-    int foo;
 
     @ConfigProperty(name = "quarkus.datasource.db-kind",defaultValue = "sqlite")
     String dbKind;
@@ -68,7 +65,189 @@ public class DatasourceConfiguration {
         return rtrn;
     }
 
-    public void initDb(Connection connection){
+    public void initDb(Connection connection) {
+        switch(dbKind){
+            case "sqlite":
+                initSqlite(connection);
+                try(Statement statement = connection.createStatement()){
+                    //create node_edge before Hibernate so we have the extra column(s)
+                    statement.executeUpdate(
+                            """
+                            CREATE TABLE IF NOT EXISTS node (type varchar(31) not null check ((type in ('ft','sql','user','nata','ecma','rd','root','split','sqlall','fp','jq'))), id bigint not null, multi_type tinyint check ((multi_type between 0 and 1)), name varchar(255), operation TEXT, scalar_method tinyint check ((scalar_method between 0 and 1)), group_id bigint, original_group_id bigint, original_node_id bigint, previous_version_id bigint, target_group_id bigint, primary key (id));
+                            CREATE TABLE IF NOT EXISTS node_edge (
+                                child_id bigint not null,
+                                parent_id bigint not null,
+                                idx integer not null,
+                                depth int not null default 0,
+                                count int not null default 1,
+                                primary key (child_id, parent_id, depth), -- removed idx from pkey because idx only matters when depth = 1
+                                FOREIGN KEY (child_id) REFERENCES node(id),
+                                FOREIGN KEY (parent_id) REFERENCES node(id)
+                            );
+                            CREATE TRIGGER IF NOT EXISTS new_node AFTER INSERT ON node FOR EACH ROW BEGIN insert into node_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1); END;
+                            CREATE TRIGGER IF NOT EXISTS delete_node_edge_zero_count AFTER UPDATE OF count ON node_edge FOR EACH ROW WHEN NEW.count = 0 BEGIN DELETE FROM node_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id; END;
+                            
+                            CREATE TABLE IF NOT EXISTS value ( id bigint not null, created_at timestamp, data JSONB, idx integer not null, last_updated timestamp, folder_id bigint, node_id bigint, primary key (id) );
+                            CREATE INDEX IF NOT EXISTS idx_value_node_id on value (node_id);
+                            CREATE INDEX IF NOT EXISTS idx_value_folder_id on value (folder_id);
+                            CREATE TABLE IF NOT EXISTS value_edge (
+                                child_id bigint not null,
+                                parent_id bigint not null,
+                                idx integer not null,
+                                depth int not null default 0,
+                                count int not null default 1,
+                                primary key (child_id,parent_id, depth),
+                                FOREIGN KEY (child_id) REFERENCES value(id),
+                                FOREIGN KEY (parent_id) REFERENCES value(id)
+                            );
+                            CREATE TRIGGER IF NOT EXISTS new_value AFTER INSERT ON value FOR EACH ROW BEGIN insert into value_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1); END;
+                            CREATE TRIGGER IF NOT EXISTS delete_value_edge_zero_count AFTER UPDATE OF count ON value_edge FOR EACH ROW WHEN NEW.count = 0 BEGIN DELETE FROM value_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id; END;
+                            """
+                    );
+                }catch (SQLException e){
+                    e.printStackTrace();
+                    //org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (no such table: node_edge)
+                    //org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (duplicate column name: depth)
+                }
+
+                break;
+            case "postgresql":
+                initPostgresql(connection);
+                try(Statement statement = connection.createStatement()){
+                    //create node_edge before Hibernate so we have the extra column(s)
+                    statement.executeUpdate(
+                            """
+                            CREATE TABLE IF NOT EXISTS public.node_group (
+                                id bigint NOT NULL,
+                                name character varying(255),
+                                root_id bigint NOT NULL
+                            );
+                            CREATE TABLE IF NOT EXISTS public.node (
+                                type character varying(31) NOT NULL,
+                                id bigint NOT NULL,
+                                multi_type smallint,
+                                name character varying(255),
+                                operation text,
+                                scalar_method smallint,
+                                group_id bigint,
+                                original_group_id bigint,
+                                original_node_id bigint,
+                                previous_version_id bigint,
+                                target_group_id bigint,
+                                CONSTRAINT node_multi_type_check CHECK (((multi_type >= 0) AND (multi_type <= 1))),
+                                CONSTRAINT node_scalar_method_check CHECK (((scalar_method >= 0) AND (scalar_method <= 1))),
+                                CONSTRAINT node_type_check CHECK (((type)::text = ANY ((ARRAY['ecma'::character varying, 'sql'::character varying, 'ft'::character varying, 'split'::character varying, 'fp'::character varying, 'root'::character varying, 'rd'::character varying, 'nata'::character varying, 'sqlall'::character varying, 'jq'::character varying, 'user'::character varying])::text[])))
+                            );
+                            -- primary keys
+                            ALTER TABLE ONLY public.node
+                               ADD CONSTRAINT node_pkey PRIMARY KEY (id);
+                            ALTER TABLE ONLY public.node_group
+                               ADD CONSTRAINT node_group_pkey PRIMARY KEY (id);
+                            
+                            -- ALTER TABLE ONLY public.node
+                            --     ADD CONSTRAINT fk5q83pe2ykwrhttlcrsmavkjnc FOREIGN KEY (original_node_id) REFERENCES public.node(id);
+                            -- ALTER TABLE ONLY public.node
+                            --     ADD CONSTRAINT fk8rvkseq9cm83glo7ov3h8j3n5 FOREIGN KEY (group_id) REFERENCES public.node_group(id);
+                            -- ALTER TABLE ONLY public.node
+                            --     ADD CONSTRAINT fkb4xxtogxdms0o3x3aby7b679r FOREIGN KEY (target_group_id) REFERENCES public.node_group(id);
+                            -- ALTER TABLE ONLY public.node
+                            --     ADD CONSTRAINT fkdgf1fskepiyfuyn83f4sl8r20 FOREIGN KEY (original_group_id) REFERENCES public.node_group(id);
+                            -- ALTER TABLE ONLY public.node
+                            --     ADD CONSTRAINT fkn7cvmyn1gccd8dtwvvrq5t66h FOREIGN KEY (previous_version_id) REFERENCES public.node(id);
+                            
+                            
+                            -- ALTER TABLE ONLY public.node_group
+                            --     ADD CONSTRAINT uk615m1ibxcfjw9yldgh9j5pv8t UNIQUE (root_id);
+                            -- ALTER TABLE ONLY public.node_group
+                            --     ADD CONSTRAINT fkfuo3mtoqnu9b2avmi6lokag7c FOREIGN KEY (root_id) REFERENCES public.node(id);
+
+                            
+                            CREATE TABLE IF NOT EXISTS node_edge (
+                                child_id bigint not null,
+                                parent_id bigint not null,
+                                idx integer not null,
+                                depth int not null default 0,
+                                count int not null default 1,
+                                primary key (child_id, parent_id, depth), -- removed idx from pkey because idx only matters when depth = 1
+                                FOREIGN KEY (child_id) REFERENCES node(id),
+                                FOREIGN KEY (parent_id) REFERENCES node(id)
+                            );
+                            create INDEX IF NOT EXISTS idx_node_edge_parent on node_edge (parent_id);
+                            create INDEX IF NOT EXISTS idx_node_edge_child on node_edge (child_id);
+                            -- CREATE TRIGGER IF NOT EXISTS new_node AFTER INSERT ON node FOR EACH ROW BEGIN insert into node_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1); END;
+                            create or replace function new_node_fn()
+                                RETURNS TRIGGER AS $$
+                                BEGIN
+                                insert into node_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1);
+                                RETURN NEW;
+                                END;
+                            $$ LANGUAGE plpgsql;
+                            CREATE or replace TRIGGER new_node_trigger AFTER INSERT ON node FOR EACH ROW EXECUTE FUNCTION new_node_fn();
+                                  
+                            -- CREATE TRIGGER IF NOT EXISTS delete_node_edge_zero_count AFTER UPDATE OF count ON node_edge FOR EACH ROW WHEN NEW.count = 0 BEGIN DELETE FROM node_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id; END;
+                            create or replace function delete_node_edge_zero_count_fn()
+                                RETURNS TRIGGER AS $$
+                                BEGIN
+                                DELETE FROM node_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id;
+                                RETURN NEW;
+                                END;
+                            $$ LANGUAGE plpgsql;
+                            create or replace TRIGGER delete_node_edge_zero_count_trigger AFTER UPDATE on node_edge FOR EACH ROW WHEN (NEW.count = 0) EXECUTE FUNCTION delete_node_edge_zero_count_fn();
+                            
+                            CREATE TABLE IF NOT EXISTS value ( id bigint not null, created_at timestamp, data JSONB, idx integer not null, last_updated timestamp, folder_id bigint, node_id bigint, primary key (id) );
+                            CREATE INDEX IF NOT EXISTS idx_value_node_id on value (node_id);
+                            CREATE INDEX IF NOT EXISTS idx_value_folder_id on value (folder_id);
+                            CREATE TABLE IF NOT EXISTS value_edge (
+                                child_id bigint not null,
+                                parent_id bigint not null,
+                                idx integer not null,
+                                depth int not null default 0,
+                                count int not null default 1,
+                                primary key (child_id,parent_id, depth),
+                                FOREIGN KEY (child_id) REFERENCES value(id),
+                                FOREIGN KEY (parent_id) REFERENCES value(id)
+                            );
+                            CREATE INDEX IF NOT EXISTS idx_value_edge_parent on value_edge (parent_id);
+                            -- CREATE TRIGGER IF NOT EXISTS new_value AFTER INSERT ON value FOR EACH ROW BEGIN insert into value_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1); END;
+                            create or replace function new_value_fn()
+                                RETURNS TRIGGER AS $$
+                                BEGIN
+                                insert into value_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1);
+                                RETURN NEW;
+                                END;
+                            $$ LANGUAGE plpgsql;
+                            CREATE or replace TRIGGER new_value_trigger AFTER INSERT ON value FOR EACH ROW EXECUTE FUNCTION new_value_fn();
+                            -- CREATE TRIGGER IF NOT EXISTS delete_value_edge_zero_count AFTER UPDATE OF count ON value_edge FOR EACH ROW WHEN NEW.count = 0 BEGIN DELETE FROM value_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id; END;
+                            create or replace function delete_value_edge_zero_count_fn()
+                                RETURNS TRIGGER AS $$
+                                BEGIN
+                                DELETE FROM value_edge WHERE child_id = NEW.child_id and parent_id = NEW.parent_id;
+                                RETURN NEW;
+                                END;
+                            $$ LANGUAGE plpgsql;
+                            create or replace TRIGGER delete_value_edge_zero_count_trigger AFTER UPDATE on value_edge FOR EACH ROW WHEN (NEW.count = 0) EXECUTE FUNCTION delete_value_edge_zero_count_fn();
+                            """
+                    );
+                }catch (SQLException e){
+                    e.printStackTrace();
+                    //org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (no such table: node_edge)
+                    //org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (duplicate column name: depth)
+                }
+                break;
+        }
+        //org.postgresql.util.PSQLException: ERROR: type "tinyint" does not exist: multi_type tinyint, scalar_method tinyint
+//        try(Statement statement = connection.createStatement()){
+//            statement.executeUpdate(
+//                    """
+//                    alter table value_edge add column depth int not null default 0;
+//                    """
+//            );
+//        }catch (SQLException e){
+//            //likely due to the column already existing
+//        }
+
+    }
+    public void initSqlite(Connection connection){
         try (Statement statement = connection.createStatement()) {
             //tuning from https://phiresky.github.io/blog/2020/sqlite-performance-tuning/
             statement.executeUpdate(
@@ -76,6 +255,8 @@ public class DatasourceConfiguration {
             pragma journal_mode = WAL;
             pragma synchronous = normal;
             pragma temp_store = memory;
+            pragma foreign_keys = on;
+            
             """);
 /*            try(ResultSet rs = statement.executeQuery("SELECT name FROM sqlite_master")){
                 while(rs.next()){
@@ -86,6 +267,7 @@ public class DatasourceConfiguration {
             throw new RuntimeException(e);
         }
     }
+    public void initPostgresql(Connection connection){}
 
     public void closeAgroalDataSource(@Disposes AgroalDataSource dataSource){
         if(dbKind.equals("postgresql")){
@@ -124,13 +306,11 @@ public class DatasourceConfiguration {
         AgroalDataSource ds  = AgroalDataSource.from(new AgroalPropertiesReader()
                 .readProperties(props)
                 .get());
-        if("sqlite".equalsIgnoreCase(dbKind)){
-            try(Connection connection = ds.getConnection()){
-                initDb(connection);
-            }
+
+        try(Connection connection = ds.getConnection()){
+            initDb(connection);
         }
         return ds;
     }
-
 
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/provided/H5mEntityListener.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/provided/H5mEntityListener.java
@@ -1,0 +1,103 @@
+package io.hyperfoil.tools.h5m.provided;
+
+import io.agroal.api.AgroalDataSource;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreRemove;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+@ApplicationScoped
+//@PersistenceUnitExtension
+public class H5mEntityListener {
+
+    @Inject
+    AgroalDataSource agroalDataSource;
+
+    @Inject
+    SessionFactory sessionFactory;
+
+    @Inject
+    EntityManager em;
+
+
+    /*
+        Runs after the persist but before the txn commits so we couldn't access the node row in the db and were getting constraint violations inserting into node_edge
+        There *has to* be a way to insert into node_edge using the new entity.id as part of the same txn...
+        Until then we're using triggers on node
+     */
+    @PostPersist
+    public void onPersist(PanacheEntity entity) {
+
+
+        Session session = em.unwrap(org.hibernate.Session.class);
+
+
+
+        String sql = switch (entity){
+            case NodeEntity n -> "insert into node_edge (parent_id,child_id,idx,depth,count) values(?,?,0,0,1)";
+            case ValueEntity v -> "insert into value_edge (parent_id,child_id,idx,depth) values(?,?,0,0)";
+            default -> "";
+        };
+
+        if(!sql.isEmpty()){
+//            try(Session session = sessionFactory.openSession()){
+//                session.createNativeMutationQuery(sql)
+//                        .setParameter(1,entity.id)
+//                        .setParameter(2,entity.id)
+//                        .executeUpdate();
+//            }
+
+/*            try(Connection connection = agroalDataSource.getConnection()){
+                try(PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setLong(1, entity.id);
+                    statement.setLong(2, entity.id);
+                    long start = System.currentTimeMillis();
+                    int count = statement.executeUpdate();
+                    long end = System.currentTimeMillis();
+                    System.out.println("onPersist "+(end-start)+"ms ->"+count);
+                }
+            } catch (SQLException e) {
+                //TODO log error instead of throwing runtime exception
+                throw new RuntimeException(e);
+            }*/
+        }else{
+            //todo log error
+        }
+    }
+
+    @PreRemove
+    public void onRemove(PanacheEntity entity) {
+        String sql = switch (entity){
+            case NodeEntity n -> "delete from node_edge where child_id=?";
+            case ValueEntity v -> "delete from value_edge where child_id=?";
+            default -> "";
+        };
+        if(!sql.isEmpty()){
+
+            try(Connection connection = agroalDataSource.getConnection()){
+                
+                try(PreparedStatement statement = connection.prepareStatement(sql)) {
+                    statement.setLong(1, entity.id);
+                    int count = statement.executeUpdate();
+                }
+            } catch (SQLException e) {
+                //TODO log error instead of throwing runtime exception
+                throw new RuntimeException(e);
+            }
+        }else{
+            //todo log error
+        }
+
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/EdgeQueries.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/EdgeQueries.java
@@ -13,7 +13,7 @@ class EdgeQueries {
 
     static long getParentCount(EntityManager em, String edgeTable, Long childId) {
         return ((Number) em.createNativeQuery(
-                "SELECT COUNT(*) FROM " + edgeTable + " WHERE child_id = :childId"
+                "SELECT COUNT(*) FROM " + edgeTable + " WHERE child_id = :childId and depth = 1"
         ).setParameter("childId", childId).getSingleResult()).longValue();
     }
 
@@ -21,7 +21,7 @@ class EdgeQueries {
     static Map<Long, Long> getParentCounts(EntityManager em, String edgeTable, List<Long> childIds) {
         if (childIds.isEmpty()) return Map.of();
         List<Object[]> rows = em.createNativeQuery(
-                "SELECT child_id, COUNT(*) FROM " + edgeTable + " WHERE child_id IN (:childIds) GROUP BY child_id"
+                "SELECT child_id, COUNT(*) FROM " + edgeTable + " WHERE child_id IN (:childIds) and depth = 1 GROUP BY child_id"
         ).setParameter("childIds", childIds).getResultList();
         Map<Long, Long> result = new HashMap<>();
         for (Object[] row : rows) {
@@ -30,15 +30,35 @@ class EdgeQueries {
         return result;
     }
 
+    /**
+     * delete ALL the edges (regardless of count) where parentId is the parent
+     * @param em
+     * @param edgeTable
+     * @param parentId
+     */
     static void deleteParentEdges(EntityManager em, String edgeTable, Long parentId) {
-        em.createNativeQuery("DELETE FROM " + edgeTable + " WHERE parent_id = :parentId")
-                .setParameter("parentId", parentId)
+        em.createNativeQuery(
+                """
+                delete from EDGE_TABLE where parent_id = :parent_id
+                """.replaceAll("EDGE_TABLE",edgeTable)
+                )
+                .setParameter("parent_id", parentId)
                 .executeUpdate();
     }
 
+    /**
+     * delete ALL the edges (regardless of count) where childId is the child
+     * @param em
+     * @param edgeTable
+     * @param childId
+     */
     static void deleteChildEdges(EntityManager em, String edgeTable, Long childId) {
-        em.createNativeQuery("DELETE FROM " + edgeTable + " WHERE child_id = :childId")
-                .setParameter("childId", childId)
+        em.createNativeQuery(
+                """
+                delete from EDGE_TABLE where child_id = :child_id
+                """.replaceAll("EDGE_TABLE",edgeTable)
+                )
+                .setParameter("child_id", childId)
                 .executeUpdate();
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -90,6 +90,59 @@ public class NodeService implements NodeServiceInterface {
         return node;
     }
 
+    @Transactional
+    public boolean dependsOnCte(NodeEntity a,NodeEntity b){
+        int count = em.createNativeQuery("""
+            with recursive ancestor(vid) as (
+                select ne.child_id as nid 
+                    from node_edge ne where ne.child_id = :nodeAId
+                union
+                select ne.parent_id as nid
+                    from node_edge ne join ancestor a on a.vid = ne.child_id
+                    where ne.depth = 1 --adding depth check becasue of closure use in node_edge table
+            )
+            select 1 from ancestor where vid = :nodeBId
+        """).setParameter("nodeAId",a.getId())
+            .setParameter("nodeBId",b.getId())
+            .getResultList().size();
+
+        return  count > 0;
+    }
+
+    @Transactional
+    public boolean dependsOn(NodeEntity a,NodeEntity b){
+        int count = em.createNativeQuery(
+            """
+            select 1 from node_edge where child_id=:nodeAId and parent_id=:nodeBId and child_id != parent_id
+            """)
+                .setParameter("nodeAId",a.getId())
+                .setParameter("nodeBId",b.getId())
+                .getResultList().size();
+        return count > 0;
+    }
+    @Transactional
+    public boolean dependsOnAny(NodeEntity a, Collection<NodeEntity> b){
+        int count = em.createNativeQuery(
+            """
+                select 1 from node_edge where child_id=:nodeAId and parent_id in (:ids)
+            """
+        ).setParameter("nodeAId",a.getId())
+                .setParameter("ids",b.stream().map(NodeEntity::getId).collect(Collectors.toSet()))
+                .getResultList().size();
+        return count > 0;
+    }
+    @Transactional
+    public boolean dependsOnAny(Collection<NodeEntity> a, Collection<NodeEntity> b){
+        int count = em.createNativeQuery(
+                """
+                select 1 from node_edge where child_id in (:a_ids) and parent_id in (:b_ids)
+                """
+        ).setParameter("a_ids",a.stream().map(NodeEntity::getId).collect(Collectors.toSet()))
+                .setParameter("b_ids",b.stream().map(NodeEntity::getId).collect(Collectors.toSet()))
+                .getResultList().size();
+        return count > 0;
+    }
+
     @Override
     @Transactional
     public Long create(String name, Long groupId, NodeType type, String operation){
@@ -167,8 +220,8 @@ public class NodeService implements NodeServiceInterface {
             NodeEntity existing = NodeEntity.findById(node.id);
             if(!existing.name.equals(node.name)){
                 List<NodeEntity> toChange = em.createNativeQuery(
-                        "select n.* from node n join node_edge ne on n.id = ne.child_id where ne.parent_id=? and n.type='ecma'"
-                , NodeEntity.class).setParameter(1,node.id).getResultList();
+                        "select n.* from node n join node_edge ne on n.id = ne.child_id where ne.parent_id=? and n.type='ecma' and ne.depth = 1"
+                ,NodeEntity.class).setParameter(1,node.id).getResultList();
                 Map<String,String> changes = Map.of(existing.name,node.name);
                 for(NodeEntity n : toChange){
                     n.operation = renameParameters(n.operation, changes);
@@ -181,13 +234,15 @@ public class NodeService implements NodeServiceInterface {
     }
 
     @Transactional
-    public List<NodeEntity> getDependentNodes(NodeEntity n){
-        return em.createQuery(
-                "SELECT DISTINCT n FROM node n LEFT JOIN FETCH n.sources JOIN n.sources s WHERE s.id = :sourceId",
-                NodeEntity.class
-        ).setParameter("sourceId", n.id).getResultList();
+    public List<NodeEntity> getDirectDependents(NodeEntity n){
+        List<NodeEntity> rtrn = em.createNativeQuery("""
+            select * from node where id in (select child_id from node_edge where parent_id = :parentId and depth = 1)
+        """,NodeEntity.class).setParameter("parentId",n.getId()).getResultList();
+        rtrn.forEach(r->r.sources.size());//lazy hack
+        return rtrn;
     }
 
+    //TODO this is probably not closure compatible
     @Transactional
     public long getNodeParentCount(NodeEntity node){
         return EdgeQueries.getParentCount(em, "node_edge", node.id);
@@ -204,7 +259,7 @@ public class NodeService implements NodeServiceInterface {
         if(nodeId!=null) {
             NodeEntity node = NodeEntity.findById(nodeId);
             if(node == null) return;
-            List<NodeEntity> dependents = getDependentNodes(node);
+            List<NodeEntity> dependents = getDirectDependents(node);
             for(NodeEntity dependent : dependents){
                 long parentCount = getNodeParentCount(dependent);
                 if(parentCount <= 1){
@@ -241,7 +296,6 @@ public class NodeService implements NodeServiceInterface {
         }
 
         int maxNodeValuesLength = nodeValues.values().stream().map(Collection::size).max(Integer::compareTo).orElse(0);
-
         //the two cases where we do not need to worry about MultiIterationType
         if(maxNodeValuesLength == 1 || node.sources.size() == 1){//if we don't need to worry about NxN or byLength
             //to ensure sequence

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -47,8 +47,8 @@ public class ValueService implements ValueServiceInterface {
     @Override
     @Transactional
     public void purgeValues(){
+        em.createNativeQuery("delete from value_edge").executeUpdate();
         em.createNativeQuery("delete from Value").executeUpdate();
-
     }
 
     @Transactional
@@ -66,7 +66,11 @@ public class ValueService implements ValueServiceInterface {
 
     @Transactional
     public List<ValueEntity> getDependentValues(ValueEntity v){
-        return ValueEntity.list("SELECT DISTINCT v FROM value v JOIN v.sources s WHERE s.id = ?1",v.id);
+        //return ValueEntity.list("SELECT DISTINCT v FROM value v JOIN v.sources s WHERE s.id = ?1",v.id);
+        List<ValueEntity> rtrn = em.createNativeQuery("""
+            select * from value where id in (select child_id from value_edge where parent_id = :parentId and depth = 1)
+        """,ValueEntity.class).setParameter("parentId", v.id).getResultList();
+        return rtrn;
     }
 
     @Transactional
@@ -78,6 +82,7 @@ public class ValueService implements ValueServiceInterface {
     public Map<Long, Long> getParentCounts(List<Long> childIds){
         return EdgeQueries.getParentCounts(em, "value_edge", childIds);
     }
+
 
     @Transactional
     public void delete(ValueEntity value){
@@ -120,7 +125,8 @@ public class ValueService implements ValueServiceInterface {
      * @param root
      * @return
      */
-    public List<ValueEntity> getDescendantValues(ValueEntity root){
+    //does not work in closure table impl.
+    public List<ValueEntity> getDescendantValuesCte(ValueEntity root){
         List<ValueEntity> rtrn = new ArrayList<>();
         //noinspection unchecked
         rtrn.addAll(em.createNativeQuery(
@@ -136,13 +142,22 @@ public class ValueService implements ValueServiceInterface {
         ).setParameter("rootId", root.id).getResultList());
         return rtrn;
     }
+    public List<ValueEntity> getDescendantValues(ValueEntity root){
+        List<ValueEntity> rtrn = new ArrayList<>();
+        rtrn.addAll(em.createNativeQuery(
+            """
+            select v.* from value v JOIN value_edge ve ON v.id = ve.child_id where ve.parent_id = :rootId and ve.depth > 0
+            """,ValueEntity.class
+        ).setParameter("rootId",root.id).getResultList());
+        return rtrn;
+    }
 
 
     public List<ValueEntity> getDirectDescendantValues(ValueEntity root, NodeEntity node){
         List<ValueEntity> rtrn = new ArrayList<>();
         rtrn.addAll(em.createNativeQuery(
         """
-           SELECT * from Value v RIGHT JOIN value_edge ve ON ve.child_id = v.id WHERE v.node_id = :nodeId AND ve.parent_id = :rootId
+           SELECT v.* from Value v RIGHT JOIN value_edge ve ON ve.child_id = v.id WHERE v.node_id = :nodeId AND ve.parent_id = :rootId AND ve.depth = 1
            """
         ).setParameter("rootId", root.id).setParameter("nodeId",node.id).getResultList());
         return rtrn;
@@ -156,76 +171,6 @@ public class ValueService implements ValueServiceInterface {
         source = NodeEntity.findById(source.id);
         return findMatchingFingerprint(source,source.group.root,fingerprint,null,null,-1,-1,true);
     }
-    /*
-     * Finds the values for a relative node Source where a descendant created the expected fingerprint value, now it works on siblings and cousins
-     * we want this to also find sibling and cousin values but that probably requires another traversal
-     * sorting by a value is useful if that value is our timestamp but we also need that value
-     */
-    @Transactional
-    public List<ValueEntity> findMatchingFingerprint_unused(NodeEntity source, ValueEntity fingerprint, NodeEntity sort){
-        List<ValueEntity> rtrn = new ArrayList<>(em.createNativeQuery(
-            switch(dbKind){
-                case "sqlite"->
-                    """
-                    with recursive ancestor(vid) as (
-                        select v.id as vid 
-                            from value v where v.node_id = :nodeId and v.data = :data
-                        union 
-                        select v.id as vid 
-                            from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
-                    ),
-                    sorter(vid,sortable) as (
-                        select v.id as vid,v.data as sortable 
-                            from value v where v.node_id = :sortId
-                        union
-                        select v.id as vid, s.sortable as sortable
-                            from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
-                    ),
-                    descendant(vid,sortable) as (
-                       select v.id as vid, s.sortable as sortable
-                         from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid join node n on n.id = v.node_id where n.type = 'root' --only the root values from ancestor with sorter
-                       union
-                       select v.id as vid, d.sortable as sortable
-                             from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
-                    )                        
-                    select * from value v join descendant d on v.id=d.vid where v.node_id=:sourceId order by sortable asc;
-                    """;
-                case "postgresql"->
-                    """
-                    with recursive ancestor(vid) as (
-                        select v.id as vid 
-                            from value v where v.node_id = :nodeId and v.data = cast( :data as jsonb)
-                        union 
-                        select v.id as vid 
-                            from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
-                    ),
-                    sorter(vid,sortable) as (
-                        select v.id as vid,v.data as sortable 
-                            from value v where v.node_id = :sortId
-                        union
-                        select v.id as vid, s.sortable as sortable
-                            from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
-                    ),
-                    descendant(vid,sortable) as (
-                       select v.id as vid, s.sortable as sortable
-                         from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid join node n on n.id = v.node_id where n.type = 'root' --only the root values from ancestor with sorter
-                       union
-                       select v.id as vid, d.sortable as sortable
-                             from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
-                    )                        
-                    select * from value v join descendant d on v.id=d.vid where v.node_id=:sourceId order by sortable asc;                    
-                    """;
-                default -> "";
-            }, ValueEntity.class)
-                                                   .setParameter("nodeId", fingerprint.node.id)
-                                                   .setParameter("data", fingerprint.data.toString())
-                                                   .setParameter("sourceId", source.id)
-                                                   .setParameter("sortId",sort.id)
-                                                   .getResultList());
-        return rtrn;
-    }
-
-    //
 
     //this is to support getting the necessary values for change detection across all values
     @Transactional
@@ -235,6 +180,19 @@ public class ValueService implements ValueServiceInterface {
     public List<ValueEntity> findMatchingFingerprint(NodeEntity source, NodeEntity groupBy, ValueEntity fingerprint, NodeEntity sort){
         return findMatchingFingerprint(source,groupBy,fingerprint,sort,null,-1,-1,true);
     }
+
+    @Transactional
+    public boolean dependsOn(ValueEntity a, ValueEntity b){
+        int count = em.createNativeQuery(
+            """
+            select 1 from value_edge where child_id=:valueAId and parent_id=:valueBId
+            """
+        ).setParameter("valueAId",a.getId())
+                .setParameter("valueBId",b.getId())
+                .getResultList().size();
+        return count > 0;
+    }
+
 
     //TODO I want a way to specify a required ancestor value for the resulting values
     @Transactional
@@ -250,32 +208,31 @@ public class ValueService implements ValueServiceInterface {
         if(ancestorValue!=null){
             sql +=
                 """
-                with recursive valueDescendants(vid) as (
-                    select ve.child_id as vid from value_edge ve where ve.parent_id = :ancestorValueId
-                    union
-                    select ve.child_id as vid from value_edge ve join valueDescendants vd on vd.vid = ve.parent_id
+                with valueDescendants(vid) as (
+                    select ve.child_id as vid from value_edge ve where ve.parent_id = :ancestorValueId and ve.depth > 0
                 ),
                 """;
         }
         sql = sql + switch (dbKind){
             case "sqlite"->
                     """
-                        ANCESTOR_PREFIX ancestor(vid) as (
-                            select v.id as vid
-                                from value v where v.node_id = :nodeId and v.data = :fingerprint VALUE_ANCESTOR_CRITERIA
-                            union
-                            select v.id as vid
-                                from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
-                        ),
+                    ANCESTOR_PREFIX ancestor(vid) as (
+                        select ve.parent_id
+                        from value_edge ve join value v on v.id = ve.child_id
+                        where v.node_id = :nodeId and ve.depth > 0 and v.data = :fingerprint VALUE_ANCESTOR_CRITERIA
+                    ),
                     """;
             case "postgresql"->
                     """
                     ANCESTOR_PREFIX ancestor(vid) as (
-                        select v.id as vid
-                            from value v where v.node_id = :nodeId and v.data = cast( :fingerprint as jsonb) VALUE_ANCESTOR_CRITERIA
-                        union 
-                        select v.id as vid 
-                            from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
+                        select ve.parent_id
+                        from value_edge ve join value v on v.id = ve.child_id
+                        where v.node_id = :nodeId and ve.depth > 0 and v.data = cast( :fingerprint as jsonb) VALUE_ANCESTOR_CRITERIA
+                        -- select v.id as vid
+                        --     from value v where v.node_id = :nodeId and v.data = cast( :fingerprint as jsonb) VALUE_ANCESTOR_CRITERIA
+                        -- union 
+                        -- select v.id as vid 
+                        --     from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
                     ),
                     """;
             default -> "";
@@ -286,45 +243,60 @@ public class ValueService implements ValueServiceInterface {
 
         if(domainValue!=null || domainNode!=null) { //we have a sortable domain value
             String domainValueComp = switch (dbKind){
-                case "sqlite"-> "and v.data GTLT :domain";
-                case "postgresql"-> "and v.data GTLT cast( :domain as jsonb)";
+                case "sqlite"-> "and s.data GTLT :domain";
+                case "postgresql"-> "and s.data GTLT cast( :domain as jsonb)";
                 default -> "";
             };
+            //sorter is ancestor_id,sortable value
+            //descendant is child of ancestor_id where node_id = groupBy with sortable
+            //selecting v.node_id = sourceId that is in descendant
+            //sorter = child_id and sourceId = childOf of edge where parent_id = goupBy
+            //select v.* from value v join value_edge ev on v.id = ev.child_id join
             sql += switch (dbKind) {
                 case "sqlite" -> """
+                        -- gets the sortable data with the id of each ancestor                         
                         sorter(vid,sortable) as (
-                            select v.id as vid,v.data as sortable
-                                from value v where v.node_id = :sortId DOMAIN_VALUE_COMP
-                            union
-                            select v.id as vid, s.sortable as sortable
-                                from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
+                            select v.id as vid, s.data as sortable from value_edge ve join value v on v.id = ve.parent_id join value s on s.id = ve.child_id 
+                                where v.node_id = :groupById and s.node_id = :sortId  DOMAIN_VALUE_COMP
+                            -- select v.id as vid,v.data as sortable
+                            --     from value v where v.node_id = :sortId DOMAIN_VALUE_COMP
+                            -- union
+                            -- select v.id as vid, s.sortable as sortable
+                            --     from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
                         ),
+                        -- gets the id of descendants of groupById that are also ancestors of the target node type from sorter  
                         descendant(vid,sortable) as (
                            select v.id as vid, s.sortable as sortable
-                             from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid
-                             where v.node_id = :groupById --limit descendants to values from the grouping node
-                           union
-                           select v.id as vid, d.sortable as sortable
-                                 from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
+                             from value v join value_edge ve on v.id = ve.child_id join ancestor a on a.vid = ve.parent_id join sorter s on s.vid = ve.parent_id
+                           -- select v.id as vid, s.sortable as sortable
+                           --   from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid
+                           --   where v.node_id = :groupById --limit descendants to values from the grouping node
+                           -- union
+                           -- select v.id as vid, d.sortable as sortable
+                           --       from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
                         )
                         select * from value v join descendant d on v.id=d.vid 
                             where v.node_id=:sourceId order by sortable ORDER_DIRECTION
                         """;
                 case "postgresql" -> """
                         sorter(vid,sortable) as (
-                            select v.id as vid,v.data as sortable
-                                from value v where v.node_id = :sortId DOMAIN_VALUE_COMP
-                            union
-                            select v.id as vid, s.sortable as sortable
-                                from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
+                            select v.id as vid, s.data as sortable from value_edge ve join value v on v.id = ve.parent_id join value s on s.id = ve.child_id
+                                where v.node_id = :groupById and s.node_id = :sortId  DOMAIN_VALUE_COMP  
+                            -- select v.id as vid,v.data as sortable
+                            --     from value v where v.node_id = :sortId DOMAIN_VALUE_COMP
+                            -- union
+                            -- select v.id as vid, s.sortable as sortable
+                            --     from value v join value_edge ve on v.id = ve.parent_id join sorter s on s.vid = ve.child_id
                         ),
                         descendant(vid,sortable) as (
                            select v.id as vid, s.sortable as sortable
-                             from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid
-                             where v.node_id = :groupById --limit descendants to values from the grouping node
-                           union
-                           select v.id as vid, d.sortable as sortable
-                                 from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
+                             from value v join value_edge ve on v.id = ve.child_id join ancestor a on a.vid = ve.parent_id join sorter s on s.vid = ve.parent_id   
+                           -- select v.id as vid, s.sortable as sortable
+                           --   from value v join sorter s on v.id = s.vid join ancestor a on v.id = a.vid
+                           --   where v.node_id = :groupById --limit descendants to values from the grouping node
+                           -- union
+                           -- select v.id as vid, d.sortable as sortable
+                           --       from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
                         )
                         select * from value v join descendant d on v.id=d.vid
                             where v.node_id=:sourceId order by sortable ORDER_DIRECTION
@@ -339,11 +311,17 @@ public class ValueService implements ValueServiceInterface {
                         """
                         descendant(vid) as (
                            select v.id as vid
-                             from value v join ancestor a on v.id = a.vid
-                             where v.node_id = :groupById --limit descendants to values from the grouping node
-                           union
-                           select v.id as vid
-                                 from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
+                             from value v 
+                              join value_edge ve on v.id = ve.child_id 
+                              join value va on ve.parent_id = va.id
+                              join ancestor a on a.vid = ve.parent_id    
+                                  where va.node_id = :groupById and ve.child_id != ve.parent_id                                  
+                           -- select v.id as vid
+                           --   from value v join ancestor a on v.id = a.vid
+                           --   where v.node_id = :groupById --limit descendants to values from the grouping node
+                           -- union
+                           -- select v.id as vid
+                           --       from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
                         )
                         select * from value v join descendant d on v.id=d.vid
                             where v.node_id=:sourceId order by created_at ORDER_DIRECTION
@@ -352,11 +330,17 @@ public class ValueService implements ValueServiceInterface {
                         """
                         descendant(vid) as (
                            select v.id as vid
-                             from value v join ancestor a on v.id = a.vid
-                             where v.node_id = :groupById --limit descendants to values from the grouping node
-                           union
-                           select v.id as vid
-                                 from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
+                             from value v 
+                              join value_edge ve on v.id = ve.child_id 
+                              join value va on ve.parent_id = va.id
+                              join ancestor a on a.vid = ve.parent_id    
+                                  where va.node_id = :groupById and ve.child_id != ve.parent_id
+                           -- select v.id as vid
+                           --   from value v join ancestor a on v.id = a.vid
+                           --   where v.node_id = :groupById --limit descendants to values from the grouping node
+                           -- union
+                           -- select v.id as vid
+                           --       from value v join value_edge ve on v.id = ve.child_id join descendant d on d.vid = ve.parent_id
                         )                        
                         select * from value v join descendant d on v.id=d.vid
                             where v.node_id=:sourceId order by created_at ORDER_DIRECTION
@@ -404,23 +388,14 @@ public class ValueService implements ValueServiceInterface {
         }
         return rtrn;
     }
-
+    /* get all ancestors of value that were created by node */
     public List<ValueEntity> getAncestor(ValueEntity value, NodeEntity node){
         List<ValueEntity> rtrn = new ArrayList<>();
         rtrn.addAll(em.createNativeQuery("""
-            with recursive ancestor(vid) as (
-                select v.id as vid 
-                    from value v where v.id = :valueId
-                union 
-                select v.id as vid 
-                    from value v join value_edge ve on v.id = ve.parent_id join ancestor a on a.vid = ve.child_id
-            )
-            select v.* from Value v join ancestor a on v.id = a.vid where v.node_id = :nodeId
-        """, ValueEntity.class).setParameter("nodeId", node.id).setParameter("valueId",value.id).getResultList());
+        select distinct v.* from Value v join value_edge ve on v.id = ve.parent_id where ve.child_id = :valueId and v.node_id = :nodeId
+        """,ValueEntity.class).setParameter("nodeId", node.id).setParameter("valueId",value.id).getResultList());
         return rtrn;
     }
-
-
 
     /**
      * Returns grouped values for a node, optionally filtered to specific node IDs.
@@ -433,39 +408,44 @@ public class ValueService implements ValueServiceInterface {
     @Override
     @Transactional
     public List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds){
-        String nodeFilter = filterNodeIds != null ? "where node_id in (:nodeIds)" : "";
+        String nodeFilter = filterNodeIds != null ? "and node_id in (:nodeIds)" : "";
         var query = em.unwrap(Session.class).createNativeQuery(
             switch(dbKind) {
                 case "sqlite" ->
                     """
-                    with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
-                            from value_edge ve left join value v on ve.child_id = v.id
-                            where ve.parent_id in (select id from value where node_id = :nodeId)
-                        union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data
-                            from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
-                    ), bynode as (
-                        select node_id,root_id,json_group_array(json(data)) as data
-                            from tree NODE_FILTER group by node_id,root_id order by idx
+                    with roots(root_id) as ( select v.id as rootId from value v where v.node_id = :nodeId),
+                    bynode(node_id,root_id,data) as ( 
+                        select node_id,root_id,json_group_array(json(v.data)) as data
+                            from roots r left join value_edge ve on r.root_id = ve.parent_id join value v on v.id = ve.child_id
+                            where ve.depth > 0
+                            NODE_FILTER
+                            group by node_id,root_id order by v.idx
                     )
                     select json_group_object(n.name,json( ( case when json_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
-                        from bynode b join node n on b.node_id = n.id group by root_id;
+                    from bynode b join node n on b.node_id = n.id group by root_id;
                     """.replace("NODE_FILTER", nodeFilter);
                 case "postgresql" ->
                     """
-                    with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
-                            from value_edge ve left join value v on ve.child_id = v.id
-                            where ve.parent_id in (select id from value where node_id = :nodeId)
-                        union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data
-                            from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
-                    ), bynode as (
-                        select node_id,root_id,jsonb_agg(to_jsonb(data)) as data
-                            from tree NODE_FILTER group by node_id,root_id,idx order by idx
+                    with roots(root_id) as ( select v.id as rootId from value v where v.node_id = :nodeId),
+                    bynode(node_id,root_id,data) as ( 
+                        select node_id,root_id,jsonb_agg(v.data) as data
+                            from roots r left join value_edge ve on r.root_id = ve.parent_id join value v on v.id = ve.child_id
+                            where ve.depth > 0
+                            NODE_FILTER
+                            group by node_id,root_id,v.idx order by v.idx
                     )
-                    select jsonb_object_agg(n.name,to_jsonb( ( case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
+                    -- with recursive tree(id,node_id,root_id,idx,data) as (
+                    --     select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data 
+                    --         from value_edge ve left join value v on ve.child_id = v.id 
+                    --         where ve.parent_id in (select id from value where node_id = :nodeId)
+                    --     union
+                    --     select v.id,v.node_id,t.root_id,v.idx,v.data 
+                    --         from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
+                    -- ), bynode as (
+                    --     select node_id,root_id,jsonb_agg(to_jsonb(data)) as data 
+                    --         from tree group by node_id,root_id,idx order by idx
+                    -- )
+                    select jsonb_object_agg(n.name,to_jsonb( ( case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data 
                     from bynode b join node n on b.node_id = n.id group by root_id;
                     """.replace("NODE_FILTER", nodeFilter);
                 default -> "";
@@ -492,13 +472,12 @@ public class ValueService implements ValueServiceInterface {
         CycleAvoidingContext cycleContext = new CycleAvoidingContext();
         return em.unwrap(Session.class).createNativeQuery(
                 """
-                WITH RECURSIVE sourceRecursive (v_id) AS (
-                     SELECT ve.child_id from value_edge ve where ve.parent_id in (select v.id from value v where v.node_id = :nodeId)
-                     UNION ALL
-                     SELECT ve.child_id from value_edge ve JOIN sourceRecursive sr ON ve.parent_id = sr.v_id
-                )
-                SELECT distinct * FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id
-                """, ValueEntity.class
+            select distinct v.* 
+            from value v 
+                left join value_edge ve on v.id = ve.child_id 
+                left join value vn on vn.id = ve.parent_id 
+            where vn.node_id = :nodeId and ve.depth > 0
+            """, ValueEntity.class
         ).setParameter("nodeId",nodeId).getResultStream().map(entity -> apiMapper.toValue(entity, cycleContext)).toList();
     }
     /**
@@ -508,7 +487,7 @@ public class ValueService implements ValueServiceInterface {
      * @return
      */
     @Transactional
-    public List<ValueEntity> getDescendantValues(ValueEntity root, NodeEntity node){
+    public List<ValueEntity> getDescendantValuesCte(ValueEntity root, NodeEntity node){
 
         List<ValueEntity> rtrn = new ArrayList<>();
         //noinspection unchecked
@@ -523,6 +502,17 @@ public class ValueService implements ValueServiceInterface {
                 SELECT distinct v.* FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id WHERE v.node_id = :nodeId
                 """, ValueEntity.class
         ).setParameter("rootId", root.id).setParameter("nodeId",node.id).getResultList());
+        return rtrn;
+    }
+    @Transactional
+    public List<ValueEntity> getDescendantValues(ValueEntity root, NodeEntity node){
+        List<ValueEntity> rtrn = new ArrayList<>();
+        rtrn.addAll(em.createNativeQuery(
+            """
+            select distinct v.* from value v JOIN value_edge ve on ve.child_id = v.id where ve.parent_id = :rootId and v.node_id = :nodeId and ve.depth > 0
+            """
+                ,ValueEntity.class)
+                .setParameter("rootId",root.id).setParameter("nodeId",node.id).getResultList());
         return rtrn;
     }
 
@@ -540,6 +530,8 @@ public class ValueService implements ValueServiceInterface {
         return found.stream().collect(Collectors.toMap(ValueEntity::getPath,v->v));
     }
 
+
+
     /**
      * Batch-fetch descendant values for multiple nodes in a single recursive CTE query.
      * Replaces N separate getDescendantValues(root, node) calls with one query.
@@ -555,12 +547,13 @@ public class ValueService implements ValueServiceInterface {
             nodeIds.add(nodes.get(i).getId());
         }
         List<ValueEntity> all = em.createNativeQuery("""
-                WITH RECURSIVE sourceRecursive (v_id) AS (
-                    SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId
-                    UNION ALL
-                    SELECT ve.child_id from value_edge ve JOIN sourceRecursive sr ON ve.parent_id = sr.v_id
-                )
-                SELECT distinct v.* FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id WHERE v.node_id IN (:nodeIds)
+                select v.* from value v join value_edge ve on v.id = ve.child_id where ve.parent_id = :rootId and v.node_id IN (:nodeIds) and ve.child_id != ve.parent_id
+                -- WITH RECURSIVE sourceRecursive (v_id) AS (
+                --     SELECT ve.child_id from value_edge ve where ve.parent_id = :rootId
+                --     UNION ALL
+                --     SELECT ve.child_id from value_edge ve JOIN sourceRecursive sr ON ve.parent_id = sr.v_id
+                -- )
+                -- SELECT distinct v.* FROM value v JOIN sourceRecursive sr ON v.id = sr.v_id WHERE v.node_id IN (:nodeIds)
                 ORDER BY v.idx asc
                 """, ValueEntity.class)
                                   .setParameter("rootId", root.id)
@@ -631,11 +624,12 @@ public class ValueService implements ValueServiceInterface {
         EdgeQueries.deleteChildEdges(em, "value_edge", valueId);
         em.createNativeQuery("DELETE FROM value WHERE id = :id")
                 .setParameter("id", valueId).executeUpdate();
+
     }
 
     private boolean hasExternalParent(ValueEntity value, Set<Long> deletionSet){
         List<?> externalParents = em.createNativeQuery(
-            "SELECT 1 FROM value_edge WHERE child_id = :childId AND parent_id NOT IN (:deletionSet)"
+            "SELECT 1 FROM value_edge WHERE child_id = :childId AND parent_id NOT IN (:deletionSet) and depth = 1"
         ).setParameter("childId", value.id)
          .setParameter("deletionSet", deletionSet)
          .setMaxResults(1)

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -322,7 +322,7 @@ public class WorkService implements WorkServiceInterface {
                     //we need to trigger more calculations? perhaps for a recalculation we do?
                     // Cascade work inherits sourceValues, so tracker association
                     // is derived automatically via findTrackers()
-                    List<Work> cascadeWork = nodeService.getDependentNodes(node).stream()
+                    List<Work> cascadeWork = nodeService.getDirectDependents(node).stream()
                             .map(n -> new Work(n, n.sources, sourceValues))
                             .toList();
                     create(cascadeWork);
@@ -363,4 +363,12 @@ public class WorkService implements WorkServiceInterface {
         }
     }
 
+    //does work A depend on work B?
+    @Transactional
+    public boolean dependsOn(Work a, Work b){
+        return dependsOn(a,b,false);
+    }
+    public boolean dependsOn(Work a, Work b,boolean cumulative){
+        return a.dependsOn(b);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 
 #quarkus.native.additional-build-args=-H:+DashboardJson
 
+%prod.quarkus.hibernate-orm.sql-load-script=import.sql
+quarkus.hibernate-orm.sql-load-script=import.sql
+
 #quarkus.datasource.db-kind=duckdb
 #quarkus.datasource.db-version=1.0.0
 
@@ -24,6 +27,9 @@ quarkus.datasource.jdbc.max-size=10
 quarkus.analytics.disabled=false
 
 #quarkus.hibernate-orm.log.sql=true
+#quarkus.hibernate-orm.log.format-sql=true
+#quarkus.hibernate-orm.log.bind-parameters=true
+
 quarkus.hibernate-orm.schema-management.strategy = update
 quarkus.hibernate-orm.fetch.batch-size=100
 quarkus.hibernate-orm.jdbc.statement-batch-size=100
@@ -58,7 +64,8 @@ quarkus.quinoa.enable-spa-routing=true
 
 #this disables the INFO messages from the cli
 quarkus.log.category."io.quarkus".level=ERROR
-quarkus.log.category."org.hibernate".level=ERROR
+#quarkus.log.category."org.hibernate".level=ERROR
+quarkus.log.category."io.micrometer.core.instrument.MeterRegistry".level=ERROR
 
 quarkus.log.category."org.hibernate.SQL_SLOW".level=INFO
 quarkus.hibernate-orm.log.queries-slower-than-ms=100
@@ -66,6 +73,7 @@ quarkus.hibernate-orm.log.queries-slower-than-ms=100
 #for debugging production jar
 #10m timeout
 quarkus.transaction-manager.default-transaction-timeout=PT10m
+quarkus.datasource.jdbc.transaction-requirement=strict
 
 # Security - disabled by default (local/CLI mode)
 h5m.security.enabled=false

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,9 +1,1 @@
--- This file allow to write SQL commands that will be emitted in test and dev.
--- The commands are commented as their support depends of the database
--- insert into myentity (id, field) values(1, 'field-1');
--- insert into myentity (id, field) values(2, 'field-2');
--- insert into myentity (id, field) values(3, 'field-3');
--- alter sequence myentity_seq restart with 4;
-pragma journal_mode = WAL;
-pragma synchronous = normal;
-pragma temp_store = memory;
+CREATE TRIGGER IF NOT EXISTS new_node AFTER INSERT ON node FOR EACH ROW BEGIN insert into node_edge (parent_id,child_id,idx,depth,count) values(NEW.id,NEW.id,0,0,1); END;

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
@@ -59,6 +59,46 @@ public class H5mTest {
         assertEquals(0,result.exitCode());
     }
 
+
+
+    @Test
+    public void qsb_jq(QuarkusMainLauncher launcher){
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add","folder",testName},
+                new String[]{"add","jq","to",testName,"runtimeName","[.results | to_entries[] | .key]"},
+                new String[]{"add","jq","to",testName,"rssStartup","[.results | to_entries[] | .key]"},
+                new String[]{"add","jq","to",testName,"maxRss","[.results[].load.avMaxRss]"},
+                new String[]{"add","jq","to",testName,"avBuildTime","[.results[].build.avBuildTime]"},
+                new String[]{"add","jq","to",testName,"avTimeToFirstRequest","[.results[].startup.avStartTime]"},
+                new String[]{"add","jq","to",testName,"avThroughput","[.results[].load.avThroughput]"},
+                new String[]{"add","jq","to",testName,"rssFirstRequest","[.results[].rss.avFirstRequestRss]"},
+                new String[]{"add","jq","to",testName,"maxThroughputDensity","[.results[].load.maxThroughputDensity]"},
+                new String[]{"add","jq","to",testName,"buildId",".env.BUILD_ID"},
+                new String[]{"add","jq","to",testName,"buildUrl",".env.BUILD_URL"},
+                new String[]{"add","jq","to",testName,"quarkusVersion",".config.QUARKUS_VERSION"},
+                new String[]{"add","jq","to",testName,"springVersion",".config.SPRING_BOOT_VERSION"},
+                new String[]{"add","js","to",testName,"dataset","function* dataset({runtimeName, rssStartup, maxRss, avBuildTime, avTimeToFirstRequest, avThroughput, rssFirstRequest, maxThroughputDensity, buildId, buildUrl, quarkusVersion, springVersion}){ var map = runtimeName.map((name, i) => ({ runtime: name.split('-')[0], buildType: name.split('-')[1], rssStartup: rssStartup[i], maxRss: maxRss[i], avBuildTime: avBuildTime[i], avTimeToFirstRequest: avTimeToFirstRequest[i], avThroughput: avThroughput[i], rssFirstRequest: rssFirstRequest[i], maxThroughputDensity: maxThroughputDensity[i], buildId: buildId, buildUrl: buildUrl, version: ((name.split('-')[0].substring(0, 6) == 'spring' ) ? springVersion: quarkusVersion ) })) for (var item of map){ yield item; } }"},
+                new String[]{"add","jq","to",testName,"avBuildTime","{dataset}:.avBuildTime"},
+                new String[]{"add","jq","to",testName,"avThroughput","{dataset}:.avThroughput"},
+                new String[]{"add","jq","to",testName,"avTimeToFirstRequest","{dataset}:.avTimeToFirstRequest"},
+                new String[]{"add","jq","to",testName,"build","{dataset}:.buildId"},
+                new String[]{"add","jq","to",testName,"buildType","{dataset}:.buildType"},
+                new String[]{"add","jq","to",testName,"maxRss","{dataset}:.maxRss"},
+                new String[]{"add","jq","to",testName,"maxThroughputDensity","{dataset}:.maxThroughputDensity"},
+                new String[]{"add","jq","to",testName,"rssFirstRequest","{dataset}:.rssFirstRequest"},
+                new String[]{"add","jq","to",testName,"rssStartup","{dataset}:.rssStartup"},
+                new String[]{"add","jq","to",testName,"runtime","{dataset}:.runtime"},
+                new String[]{"add","jq","to",testName,"version","{dataset}:.version"}
+        );
+        results.forEach(result->{
+            assertEquals(0,result.exitCode(),result.getOutput());
+        });
+    }
+
     @Test
     public void list(QuarkusMainLauncher launcher) {
         LaunchResult result = launcher.launch("list");
@@ -316,6 +356,26 @@ public class H5mTest {
     }
 
     @Test
+    public void closure_path(QuarkusMainLauncher launcher) throws IOException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add","folder",testName},
+                new String[]{"add","jq","to",testName,"foo",".foo"},
+                new String[]{"add","jq","to",testName,"bar","{foo}:.bar"},
+                new String[]{"add","jq","to",testName,"biz","{bar}:.biz"},
+                new String[]{"list",testName,"nodes"}
+        );
+
+        results.forEach(result->{
+            assertEquals(0,result.exitCode(),result.getOutput());
+        });
+
+    }
+
+    @Test
     public void upload_list_values(QuarkusMainLauncher launcher) throws IOException {
         String testName = StackWalker.getInstance()
                 .walk(s -> s.skip(0).findFirst())
@@ -481,6 +541,47 @@ public class H5mTest {
         assertTrue(result.getOutput().contains(" {\"biz\":\"buz\"} "),"result should contain .bar:" +result.getOutput());
         assertTrue(result.getOutput().contains(" buz "),"result should contain .bar:" +result.getOutput());
     }
+
+    @Test
+    public void upload_split(QuarkusMainLauncher launcher) throws IOException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        Path folder = Files.createTempDirectory("h5m");
+        Path filePath = Files.writeString(Files.createTempFile(folder,"h5m",".json").toAbsolutePath(),
+                """
+                {
+                  "foo":[
+                    {
+                      "name": "primero",
+                      "bar": {
+                        "biz": ["one","first"]
+                      }
+                    },{
+                      "name": "segundo",
+                      "bar": {
+                        "biz": ["two","second"]
+                      }
+                    }
+                  ]
+                }
+                """
+        );
+        //filePath.toFile().deleteOnExit();
+        List<LaunchResult> results = run(launcher,
+                new String[]{"add","folder",testName},
+                new String[]{"add","jq","to",testName,"foo",".foo[]"},//this should act like a dataset
+                new String[]{"add","jq","to",testName,"name","{foo}:.name"},
+                new String[]{"upload",folder.toString(),"to",testName},
+                new String[]{"list","value","from",testName}
+        );
+        results.forEach(result->{
+            assertEquals(0,result.exitCode(),result.getOutput());
+        });
+    }
+
+
     @Test
     public void upload_list_values_by_node(QuarkusMainLauncher launcher) throws IOException {
         String testName = StackWalker.getInstance()

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
@@ -1,20 +1,34 @@
 package io.hyperfoil.tools.h5m.entity;
 
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.api.Node;
+import io.hyperfoil.tools.h5m.api.NodeGroup;
+import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.hyperfoil.tools.h5m.entity.node.JsNode;
+import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.hyperfoil.tools.yaup.HashedSets;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.*;
+import org.hibernate.query.NativeQuery;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
-public class NodeTest {
+public class NodeTest extends FreshDb {
 
     @Inject
     EntityManager em;
+
+    @Inject
+    TransactionManager tm;
+
 
     @Test
     public void compareTo(){
@@ -136,5 +150,334 @@ public class NodeTest {
         }catch(StackOverflowError e){
             fail("infinite recursion in Node.equals");
         }
+    }
+
+    record ClosureEntry (long parentId,long childId,int idx,int depth,int count){};
+    private List<ClosureEntry> loadClosureTable(){
+        List<ClosureEntry> rtrn = new ArrayList<>();
+        NativeQuery query = (NativeQuery) em.createNativeQuery("select parent_id,child_id,idx,depth,count from node_edge order by parent_id asc");
+        List<Object[]> found = query
+                .unwrap(NativeQuery.class)
+                .addScalar("parent_id", Long.class)
+                .addScalar("child_id", Long.class)
+                .addScalar("idx", Integer.class)
+                .addScalar("depth", Integer.class)
+                .addScalar("count", Integer.class)
+                .getResultList();
+        for(int i=0; i<found.size();i++) {
+            Object[] obj = found.get(i);
+            Long parentId = (Long) obj[0];
+            Long childId = (Long) obj[1];
+            Integer idx = (Integer) obj[2];
+            Integer depth = (Integer) obj[3];
+            Integer count = (Integer) obj[4];
+            rtrn.add(new ClosureEntry(parentId,childId,idx,depth,count));
+        }
+        return rtrn;
+    }
+    private HashedSets<Long,Long> loadClosureReferences(){
+        HashedSets<Long,Long> map = new HashedSets<>();
+        List<ClosureEntry> table = loadClosureTable();
+        table.stream().filter(ce->ce.count>0).forEach(e -> {map.put(e.parentId,e.childId);});
+        return map;
+    }
+
+    private String printClosureTable(){
+        StringBuilder sb = new StringBuilder();
+        List<ClosureEntry> table = loadClosureTable();
+        sb.append("-- closure table --\n");
+
+        table.forEach((c)->{
+            NodeEntity parent = NodeEntity.findById(c.parentId);
+            NodeEntity child = NodeEntity.findById(c.childId);
+            sb.append(parent.name+"("+parent.id+") -> "+child.name+"("+child.id+") idx="+c.idx+" depth="+c.depth+" count="+c.count+"\n");
+        });
+        return sb.toString();
+    }
+
+
+
+    @Test
+    public void closure_create_self_reference() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new JqNode();
+        root.name="root";
+        root.persist();
+        tm.commit();
+
+        HashedSets<Long,Long> edges = loadClosureReferences();
+
+        assertEquals(1,edges.size(),"expect a self reference in closure table");
+        assertTrue(edges.has(root.id),"expect to find root in edges");
+        assertEquals(1,edges.get(root.id).size(),"root should only have one reference");
+        assertTrue(edges.get(root.id).contains(root.id),"root should self reference");
+    }
+
+    @Test
+    public void closure_create_child_reference() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.name="root";
+        root.persist();
+        NodeEntity a1 = new JsNode("a1",".a1");
+        a1.persist();
+        a1.sources=List.of(root);
+        a1.persist();
+        tm.commit();
+
+
+
+        HashedSets<Long,Long> table = loadClosureReferences();
+
+        assertNotNull(table);
+        assertFalse(table.isEmpty());
+
+        assertEquals(2,table.size(),"expect two top level entries for table");
+        assertTrue(table.has(root.id),"expect to find root in table");
+        assertEquals(2,table.get(root.id).size(),"root should have 2 references");
+        assertTrue(table.get(root.id).contains(root.id),"root should self reference: "+table.get(root.id));
+        assertTrue(table.get(root.id).contains(a1.id),"root should have a1 reference");
+        assertTrue(table.has(a1.id),"expect to find a1 in table");
+        assertEquals(1,table.get(a1.id).size(),"a1 should have 1 reference");
+        assertTrue(table.get(a1.id).contains(a1.id),"a1 should self reference");
+
+        List<ClosureEntry> entries =  loadClosureTable();
+        assertEquals(1,entries.stream().mapToInt(e->e.count).max().orElse(-1),"max count is 1");
+    }
+
+    @Test
+    public void closure_create_grandchild_reference() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.name="root";
+        root.persist();
+        NodeEntity a1 = new JsNode("a1",".a1",List.of(root));
+        a1.persist();
+        NodeEntity a2 = new JsNode("a2",".a2",List.of(a1));
+        a2.persist();
+        tm.commit();
+
+        HashedSets<Long,Long> table = loadClosureReferences();
+        List<ClosureEntry> entries = loadClosureTable();
+
+        assertNotNull(table);
+        assertFalse(table.isEmpty());
+        assertTrue(table.has(root.id),"expect to find root in table");
+        assertEquals(3,table.get(root.id).size(),"root should have 3 references");
+        assertTrue(table.get(root.id).contains(root.id),"root should self reference");
+        assertTrue(table.get(root.id).contains(a1.id),"root should have a1 reference");
+        int rootToA1Depth = entries.stream().filter(e->e.parentId==root.id && e.childId==a1.id).map(e->e.depth()).findFirst().orElse(-1);
+        assertEquals(1,rootToA1Depth,"a1 should be 1 deep from root");
+        assertTrue(table.get(root.id).contains(a2.id),"root should have a2 reference");
+        int rootToA2Depth = entries.stream().filter(e->e.parentId==root.id && e.childId==a2.id).map(e->e.depth()).findFirst().orElse(-1);
+        assertEquals(2,rootToA2Depth,"a2 should be 2 deep from root");
+        assertTrue(table.has(a1.id),"expect to find a1 in table");
+        assertEquals(2,table.get(a1.id).size(),"a1 should have 2 references");
+        assertTrue(table.get(a1.id).contains(a1.id),"a1 should self reference");
+        assertTrue(table.get(a1.id).contains(a2.id),"a1 should have a2 reference");
+
+        assertEquals(1,entries.stream().mapToInt(e->e.count).max().orElse(-1),"max count is 1");
+
+    }
+    @Test
+    public void closure_increase_count_for_shared_reference() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.name="root";
+        root.persist();
+        NodeEntity a1 = new JsNode("a1",".a1",List.of(root));
+        a1.persist();
+        NodeEntity b1 = new JsNode("b1",".b2",List.of(root));
+        b1.persist();
+        NodeEntity ab = new JsNode("ab",".ab",List.of(a1,b1));
+        ab.persist();
+        tm.commit();
+
+        List<ClosureEntry> entries = loadClosureTable();
+
+        ClosureEntry rootToAB = entries.stream().filter(e->e.parentId==root.id && e.childId==ab.id).findFirst().orElse(null);
+        assertNotNull(rootToAB,"path should exist from root to ab");
+        assertEquals(2,rootToAB.count,"root should have 2 paths to it from root");
+
+        ClosureEntry a1ToAB = entries.stream().filter(e->e.parentId==a1.id && e.childId==ab.id).findFirst().orElse(null);
+        assertNotNull(a1ToAB,"path should exist from a1 to ab");
+        assertEquals(0,a1ToAB.idx,"a1 to ab should be at index=0");
+        ClosureEntry b1ToAB = entries.stream().filter(e->e.parentId==b1.id && e.childId==ab.id).findFirst().orElse(null);
+        assertNotNull(b1ToAB,"path should exist from b1 to ab");
+        assertEquals(1,b1ToAB.count,"b1 to ab should be at index=1");
+    }
+
+
+    @Test
+    public void closure_delete_not_remove_shared_grandchild() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        /*
+              root
+           ┌──┼──┐
+           a1 │  b1
+           a2 │  b2
+           └──┼──┚
+              ab
+         */
+        root.name="root";
+        root.persist();
+        NodeEntity a1 = new JsNode("a1",".a1",List.of(root));
+        a1.persist();
+        NodeEntity a2 = new JsNode("a2",".a2",List.of(a1));
+        a2.persist();
+        NodeEntity b1 = new JqNode("b1",".b1",List.of(root));
+        b1.persist();
+        NodeEntity b2 = new JqNode("b2",".b2",List.of(b1));
+        b2.persist();
+        NodeEntity ab = new JqNode("ab",".ab",List.of(a2,b2,root));
+        ab.persist();
+        tm.commit();
+
+        HashedSets<Long,Long> map = loadClosureReferences();
+
+        assertTrue(map.has(root.id),"table should contain root");
+        assertTrue(map.get(root.id).contains(ab.id),"root should reach ab");
+        assertTrue(map.has(a1.id),"table should contain a1");
+        assertTrue(map.get(a1.id).contains(ab.id),"a1 should reach ab");
+        assertTrue(map.has(a2.id),"table should contain a2");
+        assertTrue(map.get(a2.id).contains(ab.id),"a2 should reach ab");
+        assertTrue(map.has(b1.id),"table should contain b1");
+        assertTrue(map.get(b1.id).contains(ab.id),"b1 should reach ab");
+        assertTrue(map.has(b2.id),"table should contain b2");
+        assertTrue(map.get(b2.id).contains(ab.id),"b2 should reach ab");
+        assertTrue(map.has(ab.id),"table should contain ab");
+        assertTrue(map.get(ab.id).contains(ab.id),"ab should reach ab");
+
+        tm.begin();
+        NodeEntity fetchAB = NodeEntity.findById(ab.id);
+        NodeEntity fetchA2 = NodeEntity.findById(a2.id);
+        assertTrue(fetchAB.sources.contains(fetchA2),"fetched ab should contain a2 source");
+        int idx = fetchAB.sources.indexOf(fetchA2);
+        fetchAB.sources.remove(idx);
+        fetchAB.persist();
+        tm.commit();
+
+        /*
+              root
+           ┌──┼──┐
+           a1 │  b1
+           a2 │  b2
+              ├──┚
+              ab
+        */
+        map = loadClosureReferences();
+        assertTrue(map.has(root.id),"table should contain root");
+        assertTrue(map.get(root.id).contains(ab.id),"root should reach ab");
+        assertTrue(map.has(a1.id),"table should contain a1");
+        assertFalse(map.get(a1.id).contains(ab.id),"a1 should not reach ab\n"+printClosureTable());
+        assertTrue(map.has(a2.id),"table should contain a2");
+        assertFalse(map.get(a2.id).contains(ab.id),"a2 should not reach ab");
+        assertTrue(map.has(b1.id),"table should contain b1");
+        assertTrue(map.get(b1.id).contains(ab.id),"b1 should reach ab");
+        assertTrue(map.has(b2.id),"table should contain b2");
+        assertTrue(map.get(b2.id).contains(ab.id),"b2 should reach ab");
+        assertTrue(map.has(ab.id),"table should contain ab");
+        assertTrue(map.get(ab.id).contains(ab.id),"ab should reach ab");
+    }
+
+    @Test
+    public void closure_delete_not_remove_shared_child() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.name = "root";
+        root.persist();
+        NodeEntity n1 = new JqNode("n1",".n1",root);
+        n1.persist();
+        NodeEntity n2 = new JqNode("n2",".n2",root);
+        n2.persist();
+        NodeEntity n3 = new JqNode("n3",".n3",List.of(n1,n2));
+        n3.persist();
+        tm.commit();
+
+        HashedSets<Long,Long> map = loadClosureReferences();
+        assertEquals(4,map.size());
+        assertTrue(map.has(root.id),"root node should be in closure table");
+        assertEquals(4,map.get(root.id).size(),"root node should have 4 entries: "+map.get(root.id));
+        assertTrue(map.get(root.id).containsAll(List.of(root.id,n1.id,n2.id,n3.id)),"root missing an expected closure entry: "+map.get(root.id));
+        assertTrue(map.has(n1.id),"n1 should be in closure table");
+        assertEquals(2,map.get(n1.id).size(),"n1 should have 2 entries: "+map.get(n1.id));
+        assertTrue(map.get(n1.id).containsAll(List.of(n1.id,n3.id)),"n1 missing an expected closure entry: "+map.get(n1.id));
+        assertTrue(map.has(n2.id),"n2 should be in closure table");
+        assertEquals(2,map.get(n2.id).size(),"n2 should have 2 entries: "+map.get(n2.id));
+        assertTrue(map.get(n2.id).containsAll(List.of(n2.id,n3.id)),"n2 missing an expected closure entry: "+map.get(n2.id));
+        assertTrue(map.has(n3.id),"n3 should be in closure table");
+        assertEquals(1,map.get(n3.id).size(),"n3 should have 1 entry: "+map.get(n3.id));
+        assertTrue(map.get(n3.id).contains(n3.id),"n3 missing an expected closure entry: "+map.get(n3.id));
+
+        //removing n1 from n3 sources
+
+        tm.begin();
+        NodeEntity fetchN1 = NodeEntity.findById(n1.getId());
+        assertNotNull(fetchN1);
+        NodeEntity fetchN3 = NodeEntity.findById(n3.getId());
+        assertNotNull(fetchN3);
+        assertTrue(fetchN3.sources.contains(fetchN1));
+        fetchN3.sources.remove(fetchN1);
+        fetchN3.persist();
+        tm.commit();
+
+        map = loadClosureReferences();
+        assertEquals(4,map.size());
+        assertTrue(map.has(root.id),"root node should be in closure table");
+        assertEquals(4,map.get(root.id).size(),"root node should have 4 entries: "+map.get(root.id)+" expecting "+root.id+", "+n1.id+", "+n2.id+", "+n3.id);
+        assertTrue(map.get(root.id).containsAll(List.of(root.id,n1.id,n2.id,n3.id)),"root missing an expected closure entry: "+map.get(root.id));
+        assertTrue(map.has(n1.id),"n1 should be in closure table");
+        assertEquals(1,map.get(n1.id).size(),"n1 should have 2 entries: "+map.get(n1.id));
+        assertTrue(map.get(n1.id).containsAll(List.of(n1.id)),"n1 missing an expected closure entry: "+map.get(n1.id));
+        assertTrue(map.has(n2.id),"n2 should be in closure table");
+        assertEquals(2,map.get(n2.id).size(),"n2 should have 2 entries: "+map.get(n2.id));
+        assertTrue(map.get(n2.id).containsAll(List.of(n2.id,n3.id)),"n2 missing an expected closure entry: "+map.get(n2.id));
+        assertTrue(map.has(n3.id),"n3 should be in closure table");
+        assertEquals(1,map.get(n3.id).size(),"n3 should have 1 entry: "+map.get(n3.id));
+        assertTrue(map.get(n3.id).contains(n3.id),"n3 missing an expected closure entry: "+map.get(n3.id));
+
+    }
+
+    @Test
+    public void create_node() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new JqNode("root");
+        root.persist();
+        tm.commit();
+    }
+
+    @Test
+    public void multi_generation_dependency() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        try {
+            tm.begin();
+            NodeEntity root = new RootNode();
+            root.persist();
+            NodeEntity a = new JqNode("a");
+            a.sources = List.of(root);
+            a.persist();
+            NodeEntity ab = new JqNode("ab");
+            ab.sources = List.of(a);
+            ab.persist();
+            NodeEntity ac = new JqNode("ac");
+            ac.sources = List.of(a);
+            ac.persist();
+            NodeEntity abc = new JqNode("abc");
+            abc.sources = List.of(ab, ac );
+            abc.persist();
+            tm.commit();
+
+            NodeEntity found = NodeEntity.findById(abc.getId());
+            assertNotNull(found);
+
+            System.out.println(found.sources);
+
+            assertEquals(2,found.sources.size(),"expect to find 2 sources: "+found.sources);
+
+        }catch(Exception e){
+            fail(e.getMessage(),e);
+        }
+
+
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/ValueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/ValueTest.java
@@ -1,0 +1,58 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@QuarkusTest
+public class ValueTest extends FreshDb {
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    EntityManager em;
+
+    @Test
+    public void sources() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        RootNode root = new RootNode();
+        root.persist();
+
+        NodeEntity node = new JqNode("foo");
+        node.sources=List.of(root);
+        node.persist();
+
+        NodeEntity bar = new JqNode("bar");
+        bar.sources=List.of(root,node);
+        bar.persist();
+
+        ValueEntity rootValue = new ValueEntity(null,root);
+        rootValue.persist();
+
+        ValueEntity nodeValue01 = new ValueEntity(null,node);
+        nodeValue01.sources= List.of(rootValue);
+        nodeValue01.persist();
+
+        ValueEntity nodeValue02 = new ValueEntity(null,node);
+        nodeValue02.sources= List.of(rootValue);
+        nodeValue02.persist();
+
+        ValueEntity barValue01 = new ValueEntity(null,bar);
+        barValue01.sources= List.of(nodeValue01,nodeValue02);
+        barValue01.persist();
+
+        tm.commit();
+
+        ValueEntity found = ValueEntity.findById(barValue01.id);
+
+        System.out.println(found.sources);
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
@@ -131,6 +131,7 @@ public class WorkQueueTest extends FreshDb {
         q.addWorks(List.of(aWork, bWork, cWork));
 
         Runnable firstRunnable = q.poll();
+        assertNotNull(firstRunnable);
         assertFalse(q.isPending(aWork),"a should be removed from the q");
 
         Runnable polled = q.poll();

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -173,7 +173,46 @@ public class NodeServiceTest extends FreshDb {
         assertEquals(new TextNode("foo"),data);
         System.out.println(data);
     }
+    @Test
+    public void dependsOnCte() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        ObjectMapper mapper = new ObjectMapper();
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.name="root";
+        rootNode.persist();
+        JqNode first = new JqNode("first",".first",rootNode);
+        first.persist();
+        JqNode second = new JqNode("second",".second",first);
+        second.persist();
+        JqNode third = new JqNode("third",".third",second);
+        third.persist();
+        tm.commit();
 
+        assertTrue(nodeService.dependsOnCte(third,first),"third should depend on first");
+        assertTrue(nodeService.dependsOnCte(second,first),"second depends on first");
+        assertFalse(nodeService.dependsOnCte(first,second),"first should not depend on second");
+        assertFalse(nodeService.dependsOnCte(first,third),"first should not depend on third");
+    }
+    @Test
+    public void dependsOn() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        ObjectMapper mapper = new ObjectMapper();
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.name="root";
+        rootNode.persist();
+        JqNode first = new JqNode("first",".first",rootNode);
+        first.persist();
+        JqNode second = new JqNode("second",".second",first);
+        second.persist();
+        JqNode third = new JqNode("third",".third",second);
+        third.persist();
+        tm.commit();
+
+        assertTrue(nodeService.dependsOn(third,first),"third should depend on first");
+        assertTrue(nodeService.dependsOn(second,first),"second depends on first");
+        assertFalse(nodeService.dependsOn(first,second),"first should not depend on second");
+        assertFalse(nodeService.dependsOn(first,third),"first should not depend on third");
+    }
 
     @Test
     public void calculateJsValue_no_source() throws IOException {
@@ -551,16 +590,21 @@ public class NodeServiceTest extends FreshDb {
     }
 
     @Test
-    public void getDependentNodes() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+    public void getDirectDependents() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
         tm.begin();
         RootNode root = new RootNode();
+        root.persist();
         NodeEntity n1 = nodeService.create(new JqNode("n1","n1",root));
+        n1.persist();
         NodeEntity n11 = nodeService.create(new JqNode("n11","n11",n1));
+        n11.persist();
         NodeEntity n12 = nodeService.create(new JqNode("n12","n12",n1));
+        n12.persist();
         NodeEntity n121 = nodeService.create(new JqNode("n121","n121",n12));
+        n121.persist();
         tm.commit();
 
-        List<NodeEntity> found = nodeService.getDependentNodes(n1);
+        List<NodeEntity> found = nodeService.getDirectDependents(n1);
         assertNotNull(found);
         assertEquals(2,found.size(),"should find two nodes: "+found);
         assertTrue(found.contains(n11),"should find node11 "+n11+" : "+found);
@@ -576,16 +620,14 @@ public class NodeServiceTest extends FreshDb {
         NodeEntity upload = new JqNode();//should be a different type of node?
         upload.name="upload";
         upload.persist();
-        ValueEntity v1 = new ValueEntity();
-        v1.node = root;
-        v1.data = mapper.readTree("""
+        ValueEntity v1 = new ValueEntity(null,upload,mapper.readTree("""
                 {
                   "foo": [ { "key": "one"}, { "key" : "two" } ],
                   "bar": [ { "k": "uno" }, { "k": "dos"}, { "k" : "tres"} ],
                   "biz": "cat",
                   "buz": "dog"
                 }
-                """);
+                """));
         v1.persist();
         tm.commit();
 
@@ -1653,8 +1695,8 @@ public class NodeServiceTest extends FreshDb {
 
         List<ValueEntity> exclusiveR1 = nodeService.calculateFixedThresholdValues(ftExclusive, root1, 0);
         List<ValueEntity> exclusiveR2 = nodeService.calculateFixedThresholdValues(ftExclusive, root2, 0);
-        assertEquals(1, exclusiveR1.size(), "minInclusive=false: value 10 should violate min=10");
-        assertEquals(1, exclusiveR2.size(), "maxInclusive=false: value 100 should violate max=100");
+        assertEquals(1, exclusiveR1.size(), "minInclusive=false: value 10 should violate min=10:\n"+exclusiveR1);
+        assertEquals(1, exclusiveR2.size(), "maxInclusive=false: value 100 should violate max=100:\n"+exclusiveR2);
 
         // mixed: minInclusive=false, maxInclusive=true → only min boundary violates
         FixedThreshold ftMixed = new FixedThreshold();

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -68,7 +68,38 @@ public class ValueServiceTest extends FreshDb {
         ValueEntity found = ValueEntity.findById(rootValue.id);
         assertNotNull(found);
     }
+    @Test
+    public void dependsOn() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        ObjectMapper mapper = new ObjectMapper();
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.name="root";
+        rootNode.persist();
+        ValueEntity rootValue = new ValueEntity(null,rootNode,new TextNode("root"));
+        rootValue.persist();
+        JqNode first = new JqNode("first",".first",rootNode);
+        first.persist();
+        ValueEntity firstValue = new ValueEntity(null,first,new TextNode("first"));
+        firstValue.sources=List.of(rootValue);
+        firstValue.persist();
+        JqNode second = new JqNode("second",".second",first);
+        second.persist();
+        ValueEntity secondValue = new ValueEntity(null,second,new TextNode("second"));
+        secondValue.sources=List.of(firstValue);
+        secondValue.persist();
+        JqNode third = new JqNode("third",".third",second);
+        third.persist();
+        ValueEntity thirdValue = new ValueEntity(null,third,new TextNode("third"));
+        thirdValue.sources=List.of(secondValue);
+        thirdValue.persist();
+        tm.commit();
 
+        assertTrue(valueService.dependsOn(firstValue,firstValue),"a value should depend on itself");
+        assertTrue(valueService.dependsOn(thirdValue,firstValue),"third should depend on first");
+        assertTrue(valueService.dependsOn(secondValue,firstValue),"second should depend on first");
+        assertFalse(valueService.dependsOn(firstValue,thirdValue),"first should not depend on third");
+
+    }
 
     @Test
     public void delete_does_not_cascade_to_shared_child() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
@@ -259,8 +290,11 @@ public class ValueServiceTest extends FreshDb {
         sharedChild.persist();
         tm.commit();
 
-        tm.begin();
+
         int purged = valueService.purge(aValue);
+
+
+        tm.begin();
         long aCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
                 .setParameter("id", aValue.id).getSingleResult()).longValue();
         long childCount = ((Number) em.createNativeQuery("SELECT COUNT(*) FROM value WHERE id = :id")
@@ -614,6 +648,36 @@ public class ValueServiceTest extends FreshDb {
 
     }
     @Test
+    public void findMatchingFIngerprint_from_ancestor_value() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, JsonProcessingException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.name="root";
+        rootNode.persist();
+        NodeEntity aNode = new JqNode("a",".a",rootNode);
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b",".b",rootNode);
+        bNode.persist();
+        ObjectMapper objectMapper = new ObjectMapper();
+        ValueEntity root1 = new ValueEntity(null,rootNode,objectMapper.readTree("{ \"a\": \"a\", \"b\": \"b1\"}"));
+        root1.persist();
+        ValueEntity a1 = new ValueEntity(null,aNode,root1.data.get("a"),List.of(root1));
+        a1.persist();
+        ValueEntity b1 = new ValueEntity(null,bNode,root1.data.get("b"),List.of(root1));
+        b1.persist();
+        ValueEntity root2 = new ValueEntity(null,rootNode,objectMapper.readTree("{ \"a\": \"a\", \"b\": \"b2\"}"));
+        root2.persist();
+        ValueEntity a2 = new ValueEntity(null,aNode,root2.data.get("a"),List.of(root2));
+        a2.persist();
+        ValueEntity b2 = new ValueEntity(null,bNode,root2.data.get("b"),List.of(root2));
+        b2.persist();
+        tm.commit();
+
+        List<ValueEntity> found = valueService.findMatchingFingerprint(bNode,rootNode,a2,null,null,root2,-1,-1,true);
+
+        assertEquals(1,found.size(),found.toString());
+
+    }
+    @Test
     public void findMatchingFingerprint_sibling() throws SystemException, NotSupportedException, JsonProcessingException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         tm.begin();
         NodeEntity rootNode = new RootNode();
@@ -776,7 +840,6 @@ public class ValueServiceTest extends FreshDb {
         caValue02.persist();
 
         tm.commit();
-
 
         List<ValueEntity> found = valueService.findMatchingFingerprint(caNode,rootNode,aValue01,bNode);
 
@@ -980,7 +1043,7 @@ public class ValueServiceTest extends FreshDb {
         abc.sources=List.of(ab,ac,a,root);
         abc.persist();
 
-        ValueEntity vr = new ValueEntity();
+        ValueEntity vr = new ValueEntity(null,root);
         vr.persist();
         ValueEntity va = new ValueEntity();
         va.sources=List.of(vr);
@@ -996,18 +1059,21 @@ public class ValueServiceTest extends FreshDb {
         vabc.persist();
         tm.commit();
 
-        tm.begin();
+
         try{
+            tm.begin();
             ValueEntity found = valueService.byId(vabc.id);
             List<ValueEntity> sources = found.sources;
+            int size = sources.size();
+            tm.commit();
             assertNotNull(sources);
-            assertEquals(4, sources.size());
+            assertEquals(4, size);
 
             assertTrue(sources.indexOf(va) < sources.indexOf(vab),"va should come before vab");
             assertTrue(sources.indexOf(va) < sources.indexOf(vac),"va should come before vac");
             assertTrue(sources.indexOf(vr) < sources.indexOf(va),"vr should come before va");
         }finally {
-            tm.commit();
+
         }
 
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
@@ -1,0 +1,107 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.work.Work;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+public class WorkServiceTest extends FreshDb {
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    WorkService workService;
+
+    @Test
+    public void dependsOn_node_dependency_no_value() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity one = new JqNode("one");
+        one.persist();
+        NodeEntity two = new JqNode("two");
+        two.sources = List.of(one);
+        two.persist();
+
+        Work wOne = new Work(one,null, null);
+        wOne.persist();
+        Work wTwo = new Work(two,null, null);
+        wTwo.persist();
+        tm.commit();
+
+        assertTrue(workService.dependsOn(wTwo,wOne));
+    }
+
+    @Test
+    public void dependsOn_same_work() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity one = new JqNode("one");
+        one.persist();
+        NodeEntity two = new JqNode("two");
+        two.sources = List.of(one);
+        two.persist();
+
+        Work wOne = new Work(one,null, null);
+        wOne.persist();
+        tm.commit();
+
+        assertFalse(workService.dependsOn(wOne,wOne));
+    }
+
+    @Test
+    public void dependsOn_node_dependency_same_value() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new JqNode("root");
+        root.persist();
+        NodeEntity one = new JqNode("one");
+        one.persist();
+        NodeEntity two = new JqNode("two");
+        two.sources = List.of(one);
+        two.persist();
+
+        ValueEntity value = new ValueEntity(null,root);
+        value.persist();
+        Work wOne = new Work(one,null, List.of(value));
+        wOne.persist();
+        Work wTwo = new Work(two,null, List.of(value));
+        wTwo.persist();
+
+        tm.commit();
+        assertTrue(workService.dependsOn(wTwo,wOne));
+    }
+
+    @Test
+    public void dependsOn_node_dependency_different_value() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new JqNode("root");
+        root.persist();
+        NodeEntity one = new JqNode("one");
+        one.persist();
+        NodeEntity two = new JqNode("two");
+        two.sources = List.of(one);
+        two.persist();
+        ValueEntity value1 = new ValueEntity(null,root);
+        value1.persist();
+        ValueEntity value2 = new ValueEntity(null,one);
+        value2.persist();
+
+        Work wOne = new Work(one,null, List.of(value1));
+        wOne.persist();
+        Work wTwo = new Work(two,null, List.of(value2));
+        wTwo.persist();
+
+        tm.commit();
+
+        assertFalse(workService.dependsOn(wTwo,wOne));
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
@@ -1,4 +1,4 @@
-package io.hyperfoil.tools.h5m.svc;
+    package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
@@ -34,9 +34,7 @@ public class WorkServiceTest extends FreshDb {
         two.persist();
 
         Work wOne = new Work(one,null, null);
-        wOne.persist();
         Work wTwo = new Work(two,null, null);
-        wTwo.persist();
         tm.commit();
 
         assertTrue(workService.dependsOn(wTwo,wOne));
@@ -52,7 +50,6 @@ public class WorkServiceTest extends FreshDb {
         two.persist();
 
         Work wOne = new Work(one,null, null);
-        wOne.persist();
         tm.commit();
 
         assertFalse(workService.dependsOn(wOne,wOne));
@@ -72,9 +69,7 @@ public class WorkServiceTest extends FreshDb {
         ValueEntity value = new ValueEntity(null,root);
         value.persist();
         Work wOne = new Work(one,null, List.of(value));
-        wOne.persist();
         Work wTwo = new Work(two,null, List.of(value));
-        wTwo.persist();
 
         tm.commit();
         assertTrue(workService.dependsOn(wTwo,wOne));
@@ -96,9 +91,7 @@ public class WorkServiceTest extends FreshDb {
         value2.persist();
 
         Work wOne = new Work(one,null, List.of(value1));
-        wOne.persist();
         Work wTwo = new Work(two,null, List.of(value2));
-        wTwo.persist();
 
         tm.commit();
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -3,8 +3,10 @@ quarkus.datasource.devservices.enabled=true
 quarkus.datasource.devservices.db-name=quarkus
 quarkus.datasource.devservices.username=quarkus
 quarkus.datasource.devservices.password=quarkus
-quarkus.hibernate-orm.log.sql=false
+quarkus.hibernate-orm.log.sql=true
 quarkus.hibernate-orm.schema-management.strategy = update
+quarkus.hibernate-orm.database.generation.create-schemas=true
+quarkus.hibernate-orm.schema-management.create-schemas=true
 
 # Keep the JDBC pool size at 10 for tests: concurrent test activity (upload
 # thread plus worker thread(s)) can require multiple DB connections for
@@ -19,3 +21,5 @@ h5m.worker.maxPoolSize=5
 # Tests run in local mode - no auth
 h5m.security.enabled=false
 quarkus.oidc.tenant-enabled=false
+
+


### PR DESCRIPTION
This branch aims to change the node_edge and value_edge tables from an edge table to a closure table where each source reference can create multiple rows in the table depending on the depth of the resulting tree. This implementation also uses a `count` column to account for the fact that h5m uses a DAG rather than a directional tree.

The implementation should be feature complete and appears to compare favorably to the main branch. 

The main branch built from `67e4015` loaded 50 runs for test 339 in 17m30s (21 seconds / run)
This branch loaded the same 50 runs in 11m40s (14 seconds / run)

Known issues:
* DatasourceConfiguration overrides the default table creation due to having to custom the node_edge and value_edge columns. This should be resolved when we move to a db schema management tool
* Index entity annotations are commented out and moved to the DatasourceConfiguration
* Multiple primary key exceptions during startup for node table. This too should be resolved when we migrate to a db schema management tool.
```
org.postgresql.util.PSQLException: ERROR: multiple primary keys for table "node" are not allowed
```

Please feel free to build and test the load-legacy performance with this branch and highlight if you see any degradation compared to main. I plan to test with more than 50 runs to better observe the scaling characteristics compared to the default edge table implementation.