### PR TITLE
Add View data model for folder data presentation (issue #105, Phase 1)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/View.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/View.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.tools.h5m.api;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "A configured view that defines which node values to display as columns")
+public record View(
+        @Schema(description = "Unique view ID") Long id,
+        @Schema(description = "View name") @NotEmpty String name,
+        @Schema(description = "Folder ID this view belongs to") Long folderId,
+        @Schema(description = "Ordered list of column definitions") List<ViewComponent> components) {
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/ViewComponent.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/ViewComponent.java
@@ -1,0 +1,13 @@
+package io.hyperfoil.tools.h5m.api;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "A single column definition in a view")
+public record ViewComponent(
+        @Schema(description = "Unique component ID") Long id,
+        @Schema(description = "Node ID whose values this column displays") Long nodeId,
+        @Schema(description = "Node name") String nodeName,
+        @Schema(description = "Node type") String nodeType,
+        @Schema(description = "Column header display text") String headerName,
+        @Schema(description = "Column display position (lower = left)") int headerOrder) {
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
@@ -15,6 +15,9 @@ public class FolderEntity extends PanacheEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     public Team team;
 
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
+    public java.util.List<ViewEntity> views = new java.util.ArrayList<>();
+
     @Override
     public final boolean equals(Object o) {
         if (!(o instanceof FolderEntity that)) {

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ViewComponentEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ViewComponentEntity.java
@@ -1,0 +1,41 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+@Entity(name = "folder_view_component")
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"view_id", "header_name"}))
+public class ViewComponentEntity extends PanacheEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "view_id")
+    public ViewEntity view;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "node_id")
+    public NodeEntity node;
+
+    @NotNull
+    @Column(name = "header_name")
+    public String headerName;
+
+    @Column(name = "header_order")
+    public int headerOrder;
+
+    public ViewComponentEntity() {}
+
+    public ViewComponentEntity(ViewEntity view, NodeEntity node, String headerName, int headerOrder) {
+        this.view = view;
+        this.node = node;
+        this.headerName = headerName;
+        this.headerOrder = headerOrder;
+    }
+
+    @Override
+    public String toString() {
+        return "ViewComponentEntity<" + id + ">[ headerName=" + headerName
+            + ", headerOrder=" + headerOrder
+            + ", nodeId=" + (node != null ? node.id : null) + " ]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ViewEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ViewEntity.java
@@ -1,0 +1,36 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity(name = "folder_view")
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"folder_id", "name"}))
+public class ViewEntity extends PanacheEntity {
+
+    @NotNull
+    public String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id")
+    public FolderEntity folder;
+
+    @OneToMany(mappedBy = "view", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("headerOrder ASC")
+    public List<ViewComponentEntity> components = new ArrayList<>();
+
+    public ViewEntity() {}
+
+    public ViewEntity(String name, FolderEntity folder) {
+        this.name = name;
+        this.folder = folder;
+    }
+
+    @Override
+    public String toString() {
+        return "ViewEntity<" + id + ">[ name=" + name + ", components=" + components.size() + " ]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
@@ -1,13 +1,12 @@
 package io.hyperfoil.tools.h5m.entity.mapper;
 
-import io.hyperfoil.tools.h5m.api.Folder;
-import io.hyperfoil.tools.h5m.api.Node;
-import io.hyperfoil.tools.h5m.api.NodeGroup;
-import io.hyperfoil.tools.h5m.api.Value;
+import io.hyperfoil.tools.h5m.api.*;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.ViewEntity;
+import io.hyperfoil.tools.h5m.entity.ViewComponentEntity;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -26,5 +25,13 @@ public interface ApiMapper {
     NodeGroup toNodeGroup(NodeGroupEntity nodeGroup, @Context CycleAvoidingContext context);
 
     Value toValue(ValueEntity value, @Context CycleAvoidingContext context);
+
+    @Mapping(target = "folderId", source = "folder.id")
+    View toView(ViewEntity view);
+
+    @Mapping(target = "nodeId", source = "node.id")
+    @Mapping(target = "nodeName", source = "node.name")
+    @Mapping(target = "nodeType", expression = "java(component.node != null ? component.node.type().name() : null)")
+    ViewComponent toViewComponent(ViewComponentEntity component);
 
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
@@ -28,6 +28,8 @@ public class FreshDb {
             try(Statement stmt = conn.createStatement()){
 
                 if(dbKind.equals("postgresql")){
+                    stmt.executeUpdate("TRUNCATE TABLE folder_view_component CASCADE");
+                    stmt.executeUpdate("TRUNCATE TABLE folder_view CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE notification_log CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE notification_config CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE api_key CASCADE");
@@ -45,6 +47,8 @@ public class FreshDb {
                     stmt.executeUpdate("TRUNCATE TABLE h5m_user CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE team CASCADE");
                 }else if (dbKind.equals("sqlite")){
+                    stmt.executeUpdate("DELETE from folder_view_component");
+                    stmt.executeUpdate("DELETE from folder_view");
                     stmt.executeUpdate("DELETE from notification_log");
                     stmt.executeUpdate("DELETE from notification_config");
                     stmt.executeUpdate("DELETE from api_key");


### PR DESCRIPTION
Add ViewEntity and ViewComponentEntity for configuring which node values appear as columns when browsing folder uploads. A view defines an ordered list of components, each referencing a node by FK with a custom header name and display position.

- ViewEntity: name + folder FK + ordered components
- ViewComponentEntity: node FK + headerName + headerOrder
- API records: View, ViewComponent
- ApiMapper: toView() and toViewComponent() mappings
- FolderEntity: views relationship (cascade ALL, orphan removal)
- FreshDb: truncation for new tables