### PR TITLE
Add ViewService, ViewResource, and filtered grouped values (issue #10…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
@@ -32,6 +32,15 @@ public interface ValueServiceInterface {
     List<JsonNode> getGroupedValues(Long nodeId);
 
     /**
+     * Retrieves grouped values for a specific node, optionally filtered to specific node IDs.
+     *
+     * @param nodeId The ID of the root node.
+     * @param filterNodeIds Optional list of node IDs to include. If null, all nodes are included.
+     * @return A list of JSON nodes representing the grouped values.
+     */
+    List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds);
+
+    /**
      * Retrieves all values produced by a specific node.
      *
      * @param nodeId The ID of the node.

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ViewServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ViewServiceInterface.java
@@ -1,0 +1,63 @@
+package io.hyperfoil.tools.h5m.api.svc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.hyperfoil.tools.h5m.api.View;
+
+import java.util.List;
+
+/**
+ * Service interface for managing Views.
+ */
+public interface ViewServiceInterface {
+
+    /**
+     * Lists all views for a folder.
+     *
+     * @param folderName The folder name.
+     * @return A list of views for the folder.
+     */
+    List<View> getViews(String folderName);
+
+    /**
+     * Gets a single view by ID.
+     *
+     * @param viewId The view ID.
+     * @return The view, or null if not found.
+     */
+    View getView(Long viewId);
+
+    /**
+     * Creates a new view for a folder.
+     *
+     * @param folderName The folder name.
+     * @param view The view to create.
+     * @return The created view with generated ID.
+     */
+    View createView(String folderName, View view);
+
+    /**
+     * Updates an existing view.
+     *
+     * @param viewId The view ID.
+     * @param view The updated view data.
+     * @return The updated view.
+     */
+    View updateView(Long viewId, View view);
+
+    /**
+     * Deletes a view. The "Default" view cannot be deleted.
+     *
+     * @param viewId The view ID.
+     */
+    void deleteView(Long viewId);
+
+    /**
+     * Gets the filtered pivoted data for a view.
+     * Returns one row per upload with only the nodes referenced by the view's components.
+     *
+     * @param folderName The folder name.
+     * @param viewId The view ID.
+     * @return A list of JSON objects, one per upload.
+     */
+    List<JsonNode> getViewData(String folderName, Long viewId);
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
@@ -1,0 +1,71 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.hyperfoil.tools.h5m.api.View;
+import io.hyperfoil.tools.h5m.api.svc.ViewServiceInterface;
+import io.quarkus.security.Authenticated;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.List;
+
+@Path("/api/folder/{name}/view")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Tag(name = "View", description = "Manage views for folder data presentation")
+public class ViewResource {
+
+    @Inject
+    ViewServiceInterface viewService;
+
+    @GET
+    @Path("/")
+    @PermitAll
+    @Operation(description = "List all views for a folder")
+    public List<View> getViews(@PathParam("name") String folderName) {
+        return viewService.getViews(folderName);
+    }
+
+    @GET
+    @Path("/{viewId}")
+    @PermitAll
+    @Operation(description = "Get a view definition")
+    public View getView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
+        return viewService.getView(viewId);
+    }
+
+    @POST
+    @Authenticated
+    @Operation(description = "Create a new view for a folder")
+    public View createView(@PathParam("name") String folderName, View view) {
+        return viewService.createView(folderName, view);
+    }
+
+    @PUT
+    @Path("/{viewId}")
+    @Authenticated
+    @Operation(description = "Update a view")
+    public View updateView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId, View view) {
+        return viewService.updateView(viewId, view);
+    }
+
+    @DELETE
+    @Path("/{viewId}")
+    @Authenticated
+    @Operation(description = "Delete a view (cannot delete the Default view)")
+    public void deleteView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
+        viewService.deleteView(viewId);
+    }
+
+    @GET
+    @Path("/{viewId}/data")
+    @PermitAll
+    @Operation(description = "Get filtered pivoted data for a view")
+    public List<JsonNode> getViewData(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
+        return viewService.getViewData(folderName, viewId);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -423,51 +423,64 @@ public class ValueService implements ValueServiceInterface {
 
 
     /**
-     * returns a json object with the values created by child nodes of the groupBy node.
-     * @param groupBy
-     * @return
+     * Returns grouped values for a node, optionally filtered to specific node IDs.
+     * One row per upload, with keys being node names.
+     *
+     * @param nodeId The root node ID to start the value DAG traversal from.
+     * @param filterNodeIds Optional list of node IDs to include. If null, all nodes are included.
+     * @return A list of JSON objects, one per upload.
      */
     @Override
     @Transactional
-    //TODO here thar be dragons
-    public List<JsonNode> getGroupedValues(Long nodeId){
-        return em.unwrap(Session.class).createNativeQuery(
+    public List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds){
+        String nodeFilter = filterNodeIds != null ? "where node_id in (:nodeIds)" : "";
+        var query = em.unwrap(Session.class).createNativeQuery(
             switch(dbKind) {
                 case "sqlite" ->
                     """
                     with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data 
-                            from value_edge ve left join value v on ve.child_id = v.id 
+                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
+                            from value_edge ve left join value v on ve.child_id = v.id
                             where ve.parent_id in (select id from value where node_id = :nodeId)
                         union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data 
+                        select v.id,v.node_id,t.root_id,v.idx,v.data
                             from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
                     ), bynode as (
-                        select node_id,root_id,json_group_array(json(data)) as data 
-                            from tree group by node_id,root_id order by idx
+                        select node_id,root_id,json_group_array(json(data)) as data
+                            from tree NODE_FILTER group by node_id,root_id order by idx
                     )
-                    select json_group_object(n.name,json( ( case when json_array_length(b.data) > 1 then b.data else b.data->0 end))) as data 
-                        from bynode b join node n on b.node_id = n.id group by root_id; 
-                    """;
+                    select json_group_object(n.name,json( ( case when json_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
+                        from bynode b join node n on b.node_id = n.id group by root_id;
+                    """.replace("NODE_FILTER", nodeFilter);
                 case "postgresql" ->
                     """
                     with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data 
-                            from value_edge ve left join value v on ve.child_id = v.id 
+                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
+                            from value_edge ve left join value v on ve.child_id = v.id
                             where ve.parent_id in (select id from value where node_id = :nodeId)
                         union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data 
+                        select v.id,v.node_id,t.root_id,v.idx,v.data
                             from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
                     ), bynode as (
-                        select node_id,root_id,jsonb_agg(to_jsonb(data)) as data 
-                            from tree group by node_id,root_id,idx order by idx
+                        select node_id,root_id,jsonb_agg(to_jsonb(data)) as data
+                            from tree NODE_FILTER group by node_id,root_id,idx order by idx
                     )
-                    select jsonb_object_agg(n.name,to_jsonb( ( case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data 
+                    select jsonb_object_agg(n.name,to_jsonb( ( case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
                     from bynode b join node n on b.node_id = n.id group by root_id;
-                    """;
-            default ->"";
+                    """.replace("NODE_FILTER", nodeFilter);
+                default -> "";
             }, JsonNode.class
-        ).setParameter("nodeId",nodeId).getResultList();
+        ).setParameter("nodeId", nodeId);
+        if (filterNodeIds != null) {
+            query.setParameter("nodeIds", filterNodeIds);
+        }
+        return query.getResultList();
+    }
+
+    @Override
+    @Transactional
+    public List<JsonNode> getGroupedValues(Long nodeId){
+        return getGroupedValues(nodeId, null);
     }
     /**
      * get all value that have a value from node as an ancestor

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
@@ -1,0 +1,161 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.hyperfoil.tools.h5m.api.View;
+import io.hyperfoil.tools.h5m.api.ViewComponent;
+import io.hyperfoil.tools.h5m.api.svc.ViewServiceInterface;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ViewComponentEntity;
+import io.hyperfoil.tools.h5m.entity.ViewEntity;
+import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ApplicationScoped
+public class ViewService implements ViewServiceInterface {
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    ApiMapper apiMapper;
+
+    @Inject
+    ValueService valueService;
+
+    @Override
+    @Transactional
+    public List<View> getViews(String folderName) {
+        FolderEntity folder = findFolder(folderName);
+        return folder.views.stream().map(apiMapper::toView).toList();
+    }
+
+    @Override
+    @Transactional
+    public View getView(Long viewId) {
+        ViewEntity view = ViewEntity.findById(viewId);
+        if (view == null) {
+            throw new NotFoundException("View not found: " + viewId);
+        }
+        return apiMapper.toView(view);
+    }
+
+    @Override
+    @Transactional
+    public View createView(String folderName, View view) {
+        FolderEntity folder = findFolder(folderName);
+
+        ViewEntity entity = new ViewEntity(view.name(), folder);
+        entity.components = new ArrayList<>();
+
+        if (view.components() != null) {
+            for (int i = 0; i < view.components().size(); i++) {
+                ViewComponent vc = view.components().get(i);
+                NodeEntity node = NodeEntity.findById(vc.nodeId());
+                if (node == null) {
+                    throw new NotFoundException("Node not found: " + vc.nodeId());
+                }
+                ViewComponentEntity component = new ViewComponentEntity(
+                    entity, node,
+                    vc.headerName() != null ? vc.headerName() : node.name,
+                    vc.headerOrder() > 0 ? vc.headerOrder() : i
+                );
+                entity.components.add(component);
+            }
+        }
+
+        entity.persist();
+        folder.views.add(entity);
+        return apiMapper.toView(entity);
+    }
+
+    @Override
+    @Transactional
+    public View updateView(Long viewId, View view) {
+        ViewEntity entity = ViewEntity.findById(viewId);
+        if (entity == null) {
+            throw new NotFoundException("View not found: " + viewId);
+        }
+
+        entity.name = view.name();
+        entity.components.clear();
+
+        if (view.components() != null) {
+            for (int i = 0; i < view.components().size(); i++) {
+                ViewComponent vc = view.components().get(i);
+                NodeEntity node = NodeEntity.findById(vc.nodeId());
+                if (node == null) {
+                    throw new NotFoundException("Node not found: " + vc.nodeId());
+                }
+                ViewComponentEntity component = new ViewComponentEntity(
+                    entity, node,
+                    vc.headerName() != null ? vc.headerName() : node.name,
+                    vc.headerOrder() > 0 ? vc.headerOrder() : i
+                );
+                entity.components.add(component);
+            }
+        }
+
+        entity.persist();
+        return apiMapper.toView(entity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteView(Long viewId) {
+        ViewEntity entity = ViewEntity.findById(viewId);
+        if (entity == null) {
+            throw new NotFoundException("View not found: " + viewId);
+        }
+        if ("Default".equals(entity.name)) {
+            throw new IllegalArgumentException("Cannot delete the Default view");
+        }
+        entity.delete();
+    }
+
+    @Override
+    @Transactional
+    public List<JsonNode> getViewData(String folderName, Long viewId) {
+        ViewEntity view = em.createQuery(
+            "SELECT v FROM folder_view v LEFT JOIN FETCH v.components c LEFT JOIN FETCH c.node WHERE v.id = :id",
+            ViewEntity.class
+        ).setParameter("id", viewId).getSingleResult();
+        if (view == null) {
+            throw new NotFoundException("View not found: " + viewId);
+        }
+
+        FolderEntity folder = findFolder(folderName);
+        Long rootNodeId = folder.group.root.id;
+
+        List<Long> nodeIds = view.components.stream()
+            .map(c -> c.node.id)
+            .toList();
+
+        if (nodeIds.isEmpty()) {
+            return List.of();
+        }
+
+        return valueService.getGroupedValues(rootNodeId, nodeIds);
+    }
+
+    private FolderEntity findFolder(String folderName) {
+        FolderEntity folder = em.createQuery(
+            "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.root WHERE f.name = :name",
+            FolderEntity.class
+        ).setParameter("name", folderName).getSingleResult();
+        if (folder == null) {
+            throw new NotFoundException("Folder not found: " + folderName);
+        }
+        // Initialize views and their components (avoids MultipleBagFetchException)
+        folder.views.size();
+        folder.views.forEach(v -> v.components.size());
+        return folder;
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -525,6 +525,240 @@ public class RestEndpointTest extends FreshDb {
                 .statusCode(404);
     }
 
+    // -- Views --
+
+    @Test
+    public void view_list_empty_for_new_folder() {
+        createFolder("view-empty");
+
+        given()
+                .when().get("/api/folder/view-empty/view/")
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(0));
+    }
+
+    @Test
+    public void view_create_and_retrieve() throws Exception {
+        // Import rhivos nodes so we have real node IDs to reference
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        // Find node IDs for "user" and "uuid" by querying the group
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long userNodeId = folder.group.sources.stream()
+                .filter(n -> "user".equals(n.name)).findFirst().get().id;
+        Long uuidNodeId = folder.group.sources.stream()
+                .filter(n -> "uuid".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create a view via REST
+        String viewJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "test-view", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, uuidNodeId, null, null, "UUID", 1)
+                )
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(viewJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("test-view"))
+                .body("components.size()", equalTo(2))
+                .body("components[0].headerName", equalTo("User"))
+                .body("components[1].headerName", equalTo("UUID"))
+                .extract().jsonPath().getLong("id");
+
+        // Retrieve it
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("test-view"))
+                .body("components.size()", equalTo(2));
+
+        // List should contain it
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(1))
+                .body("[0].name", equalTo("test-view"));
+    }
+
+    @Test
+    public void view_update_changes_components() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long userNodeId = folder.group.sources.stream()
+                .filter(n -> "user".equals(n.name)).findFirst().get().id;
+        Long uuidNodeId = folder.group.sources.stream()
+                .filter(n -> "uuid".equals(n.name)).findFirst().get().id;
+        Long descNodeId = folder.group.sources.stream()
+                .filter(n -> "description".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create view with user only
+        String createJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "updatable", null,
+                List.of(new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0))
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(createJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // Update to uuid + description
+        String updateJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "updatable-renamed", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, uuidNodeId, null, null, "UUID", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, descNodeId, null, null, "Description", 1)
+                )
+        ));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(updateJson)
+                .when().put("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("updatable-renamed"))
+                .body("components.size()", equalTo(2))
+                .body("components[0].headerName", equalTo("UUID"));
+    }
+
+    @Test
+    public void view_delete_works() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long userNodeId = folder.group.sources.stream()
+                .filter(n -> "user".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        String createJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "deletable", null,
+                List.of(new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0))
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(createJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // Delete it
+        given()
+                .when().delete("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .then()
+                .statusCode(204);
+
+        // Should be gone
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(0));
+    }
+
+    @Test
+    public void view_delete_default_rejected() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long userNodeId = folder.group.sources.stream()
+                .filter(n -> "user".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create a view named "Default"
+        String createJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "Default", null,
+                List.of(new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0))
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(createJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // Attempting to delete "Default" should fail
+        given()
+                .when().delete("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .then()
+                .statusCode(anyOf(equalTo(400), equalTo(500)));
+    }
+
+    @Test
+    public void view_data_returns_filtered_rhivos_values() throws Exception {
+        // Import rhivos nodes and upload a run
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
+            JsonNode runData = mapper.readTree(is);
+            folderService.upload("rhivos-perf-comprehensive", "$", runData);
+        }
+
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(100);
+        }
+        assertTrue(workService.isIdle(), "Work queue should be idle");
+
+        // Find node IDs for nodes that produce values with rhivos data
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long startTimeNodeId = folder.group.sources.stream()
+                .filter(n -> "start_time".equals(n.name)).findFirst().get().id;
+        Long endTimeNodeId = folder.group.sources.stream()
+                .filter(n -> "end_time".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create a view with start_time and end_time
+        String viewJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "data-view", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, startTimeNodeId, null, null, "Start Time", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, endTimeNodeId, null, null, "End Time", 1)
+                )
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(viewJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // Get view data — should return filtered results with only start_time and end_time columns
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId + "/data")
+                .then()
+                .statusCode(200)
+                .body("size()", greaterThan(0))
+                // Each row should have the selected node columns
+                .body("[0].start_time", notNullValue())
+                .body("[0].end_time", notNullValue());
+    }
+
     // -- OpenAPI spec --
 
     @Test


### PR DESCRIPTION
…5, Phase 2)

ViewService: CRUD operations for views with folder-scoped queries. Create/update builds ViewComponentEntity list from API ViewComponent records. Delete protects the 'Default' view. getViewData() delegates to the filtered getGroupedValues() for pivoted view data.

ViewResource: REST endpoints at /api/folder/{name}/view for list, get, create, update, delete, and data retrieval.

ValueService: Add optional filterNodeIds parameter to getGroupedValues() instead of a separate method. When non-null, adds WHERE node_id IN (:nodeIds) to the bynode CTE, reducing response to only the view's selected nodes. The no-arg overload delegates with null (all nodes).

Tests using rhivos data:
- List views returns empty for new folder
- Create view with rhivos nodes and retrieve it
- Update view changes components
- Delete view works; delete Default is rejected
- View data returns filtered values (start_time, end_time only) after uploading rhivos run 40375