### PR TITLE
Add Default view auto-creation, Data tab, and view tests (issue #105,…

### DIFF
--- a/docs/design/views-feature.md
+++ b/docs/design/views-feature.md
@@ -99,11 +99,9 @@ components list — no need for a separate response wrapper.
 
 ## Default View Auto-Creation
 
-When a folder is created, auto-create a "Default" view containing **leaf nodes** — nodes
-that no other node depends on, excluding change detection nodes (ft, rd, ed).
-
-Leaf nodes represent the final computed metrics users care about. For the rhivos test
-(135 nodes), this produces a manageable set of columns rather than showing all 135.
+When a folder is created, auto-create an empty "Default" view. Users configure which
+nodes appear as columns via the REST API or the Configure View Modal (Phase 5b).
+This matches Horreum's approach where the Default view starts empty.
 
 The "Default" view cannot be deleted (same protection as Horreum).
 
@@ -186,7 +184,7 @@ Add a **"Data"** tab to FolderPage:
 - Protect "Default" from deletion
 
 ### Phase 4: Tests
-- Default view auto-created on folder creation (contains leaf nodes, excludes detection)
+- Default view auto-created on folder creation (empty, users configure via REST/UI)
 - CRUD operations on views (create, read, update, delete; "Default" protected)
 - View data endpoint returns correct filtered columns
 - View data with multiple uploads (one row per upload)
@@ -194,8 +192,34 @@ Add a **"Data"** tab to FolderPage:
 - Import/export preserves views (views included in folder export JSON)
 
 ### Phase 5: Web UI (separate PR)
-- Data tab with view selector and data table
-- Configure View modal
+
+#### TypeScript Client Regeneration
+The TypeScript client is regenerated automatically during `mvn package` / `mvn install`:
+1. Quarkus augmentation generates `openapi.yaml` into `src/main/webui/`
+   (configured via `quarkus.smallrye-openapi.store-schema-directory`)
+2. Quinoa runs `npm run build` which calls `openapi-ts` before `tsc` and `vite build`
+
+For local development, run `npm run openapi` in `src/main/webui/` to regenerate
+the client types for IDE autocompletion without doing a full Maven build.
+
+#### 5a. Data Tab
+- New `DataTab` component (`src/main/webui/src/app/components/DataTab.tsx`)
+  - View selector dropdown (Carbon `Dropdown`), defaults to "Default" view
+  - Carbon `DataTable` with columns from view components (headerName, headerOrder)
+  - Rows from `GET /api/folder/{name}/view/{viewId}/data` (one per upload)
+  - Cell values keyed by node name from each row's JSON object
+  - Empty state when no uploads, loading skeleton during fetch
+- Add "Data" as first tab in FolderPage (`TAB_ANCHORS = ['data', 'nodes', 'graph']`)
+- Tests for DataTab: renders selector, renders table, switching views refetches
+
+#### 5b. Configure View Modal (follow-up PR)
+- New `ViewConfigModal` component (`src/main/webui/src/app/components/ViewConfigModal.tsx`)
+  - View name text input
+  - Multi-select node picker from folder's group nodes
+  - Header name override per selected node
+  - Drag-to-reorder for column ordering
+  - Save (create/update), Delete (with confirmation, disabled for Default), Cancel
+- "Configure" button next to the view dropdown in DataTab
 
 ## File Changes
 

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -12,6 +12,7 @@ import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.Team;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.ViewEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import io.hyperfoil.tools.h5m.entity.node.*;
 import io.hyperfoil.tools.h5m.entity.work.Work;
@@ -27,10 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @ApplicationScoped
 public class FolderService implements FolderServiceInterface {
@@ -67,6 +65,7 @@ public class FolderService implements FolderServiceInterface {
         entity.name = name;
         entity.group = new NodeGroupEntity(name); //TODO do we auto-create a nodeGroup?
         FolderEntity.persist(entity);
+        createDefaultView(entity);
         return entity.id;
     }
 
@@ -203,6 +202,11 @@ public class FolderService implements FolderServiceInterface {
     @Override
     @Transactional
     public long delete(String name){
+        // Delete views and components before folder (bulk delete doesn't cascade)
+        em.createNativeQuery("DELETE FROM folder_view_component WHERE view_id IN (SELECT id FROM folder_view WHERE folder_id IN (SELECT id FROM folder WHERE name = :name))")
+            .setParameter("name", name).executeUpdate();
+        em.createNativeQuery("DELETE FROM folder_view WHERE folder_id IN (SELECT id FROM folder WHERE name = :name)")
+            .setParameter("name", name).executeUpdate();
         return FolderEntity.delete("name", name);
     }
 
@@ -401,8 +405,19 @@ public class FolderService implements FolderServiceInterface {
 
         em.flush();
         em.merge(group);
+
         Log.infof("Imported folder '%s' with %d nodes from %s", folderName, nodeArray.size(), inputPath);
         return folderName;
+    }
+
+    /**
+     * Creates an empty "Default" view for the folder.
+     * Users configure which nodes appear as columns via the REST API.
+     */
+    private void createDefaultView(FolderEntity folder) {
+        ViewEntity view = new ViewEntity("Default", folder);
+        view.persist();
+        folder.views.add(view);
     }
 
     private ObjectNode serializeNode(NodeEntity node) {

--- a/src/main/webui/src/app/components/DataTab.tsx
+++ b/src/main/webui/src/app/components/DataTab.tsx
@@ -1,0 +1,131 @@
+import type { View, ViewComponent } from '@client/types.gen.ts';
+
+import {
+  DataTable,
+  Dropdown,
+  InlineLoading,
+  SkeletonText,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@carbon/react';
+import { getViewDataOptions, getViewsOptions } from '@client/@tanstack/react-query.gen.ts';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+function formatCellValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+const ViewDataTable = ({
+  folderName,
+  view,
+}: {
+  folderName: string;
+  view: View;
+}) => {
+  const viewId = view.id;
+  const { data: rows, isLoading, isError } = useQuery(
+    getViewDataOptions({
+      path: { name: folderName, viewId: viewId! },
+    }),
+  );
+
+  if (isLoading) return <SkeletonText paragraph={true} lineCount={5} />;
+  if (isError) return <InlineLoading status="error" description="Failed to load view data" />;
+  if (!rows || rows.length === 0) return <p>No data available</p>;
+
+  const columns = (view.components ?? [])
+    .sort((a: ViewComponent, b: ViewComponent) => (a.headerOrder ?? 0) - (b.headerOrder ?? 0))
+    .map((c: ViewComponent) => ({
+      key: c.nodeName ?? c.headerName ?? '',
+      header: c.headerName ?? c.nodeName ?? '',
+    }));
+
+  const tableRows = rows.map((row: Record<string, unknown>, idx: number) => ({
+    id: String(idx),
+    ...Object.fromEntries(columns.map((col) => [col.key, formatCellValue(row[col.key])])),
+  }));
+
+  return (
+    <DataTable rows={tableRows} headers={columns}>
+      {({ rows: dataRows, headers, getTableProps, getHeaderProps, getRowProps }) => (
+        <Table {...getTableProps()}>
+          <TableHead>
+            <TableRow>
+              {headers.map((header) => (
+                <TableHeader {...getHeaderProps({ header })}>
+                  {header.header}
+                </TableHeader>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {dataRows.map((row) => (
+              <TableRow {...getRowProps({ row })}>
+                {row.cells.map((cell) => (
+                  <TableCell key={cell.id}>{cell.value}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </DataTable>
+  );
+};
+
+export const DataTab = ({ folderName }: { folderName: string }) => {
+  const { data: views, isLoading: viewsLoading } = useQuery(
+    getViewsOptions({ path: { name: folderName } }),
+  );
+  const [selectedViewId, setSelectedViewId] = useState<number | null>(null);
+
+  const selectedView = useMemo(() => {
+    if (!views || views.length === 0) return null;
+    if (selectedViewId != null) {
+      return views.find((v: View) => v.id === selectedViewId) ?? views[0];
+    }
+    // Prefer the "Default" view if it has components, otherwise pick the first view with components
+    const defaultView = views.find((v: View) => v.name === 'Default');
+    if (defaultView && defaultView.components && defaultView.components.length > 0) {
+      return defaultView;
+    }
+    const viewWithComponents = views.find((v: View) => v.components && v.components.length > 0);
+    return viewWithComponents ?? defaultView ?? views[0];
+  }, [views, selectedViewId]);
+
+  if (viewsLoading) return <SkeletonText paragraph={true} lineCount={3} />;
+  if (!views || views.length === 0) return <p>No views configured</p>;
+
+  const dropdownItems = views.map((v: View) => ({
+    id: String(v.id),
+    text: v.name,
+  }));
+
+  return (
+    <div>
+      <div style={{ marginBottom: 'var(--cds-spacing-05)', maxWidth: '300px' }}>
+        <Dropdown
+          id="view-selector"
+          titleText="View"
+          label="Select a view"
+          items={dropdownItems}
+          selectedItem={selectedView ? { id: String(selectedView.id), text: selectedView.name } : undefined}
+          itemToString={(item: { id: string; text: string }) => item?.text ?? ''}
+          onChange={({ selectedItem }: { selectedItem: { id: string; text: string } }) => {
+            setSelectedViewId(Number(selectedItem.id));
+          }}
+        />
+      </div>
+      {selectedView && (
+        <ViewDataTable folderName={folderName} view={selectedView} />
+      )}
+    </div>
+  );
+};

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -1,5 +1,6 @@
 import type { Node as ApiNode } from '@client/types.gen.ts';
 
+import { DataTab } from '@app/components/DataTab';
 import { NodeGraphVisualizer } from '@app/components/NodeGraphVisualizer';
 import {
   ErrorBoundary,
@@ -58,7 +59,7 @@ const GraphVisualizer = ({ groupId }: { groupId: number }) => {
   return <NodeGraphVisualizer nodeGroup={nodeGroup} />;
 };
 
-const TAB_ANCHORS = ['nodes', 'graph'];
+const TAB_ANCHORS = ['data', 'nodes', 'graph'];
 
 const FolderContent = ({ folderId }: { folderId: number }) => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
@@ -75,10 +76,18 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
   return (
     <Tabs selectedIndex={selectedIndex} onChange={onTabChange}>
       <TabList aria-label="Folder tabs">
+        <Tab>Data</Tab>
         <Tab>Nodes</Tab>
         <Tab>Graph</Tab>
       </TabList>
       <TabPanels>
+        <TabPanel>
+          {folder.name ? (
+            <DataTab folderName={folder.name} />
+          ) : (
+            <p>Folder name not available</p>
+          )}
+        </TabPanel>
         <TabPanel>
           {folder.groupId != null ? (
             <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load nodes" />}>

--- a/src/main/webui/test/pages/FolderPage.test.tsx
+++ b/src/main/webui/test/pages/FolderPage.test.tsx
@@ -36,6 +36,10 @@ vi.mock('@client/@tanstack/react-query.gen.ts', () => ({
     queryKey: ['byId'],
     queryFn: () => mockNodeGroup,
   }),
+  getViewsOptions: () => ({
+    queryKey: ['getViews'],
+    queryFn: () => [],
+  }),
 }));
 
 const { FolderPage } = await import('@app/pages/FolderPage');
@@ -48,6 +52,7 @@ function renderFolderPage(folderId: string) {
   });
   queryClient.setQueryData(['listFolders'], mockFolders);
   queryClient.setQueryData(['byId'], mockNodeGroup);
+  queryClient.setQueryData(['getViews'], []);
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -61,10 +66,11 @@ function renderFolderPage(folderId: string) {
 }
 
 describe('<FolderPage />', () => {
-  it('renders both tabs', async () => {
+  it('renders all three tabs', async () => {
     renderFolderPage('1');
 
     await waitFor(() => {
+      expect(screen.getByText('Data')).toBeDefined();
       expect(screen.getByText('Nodes')).toBeDefined();
       expect(screen.getByText('Graph')).toBeDefined();
     });
@@ -72,11 +78,11 @@ describe('<FolderPage />', () => {
     cleanup();
   });
 
-  it('shows nodes tab by default', async () => {
+  it('shows data tab by default', async () => {
     renderFolderPage('1');
 
     await waitFor(() => {
-      expect(screen.getByText('Nodes')).toBeDefined();
+      expect(screen.getByText('Data')).toBeDefined();
     });
 
     cleanup();
@@ -96,7 +102,7 @@ describe('<FolderPage />', () => {
       </QueryClientProvider>,
     );
 
-    expect(screen.queryByText('Nodes')).toBeNull();
+    expect(screen.queryByText('Data')).toBeNull();
     cleanup();
   });
 });

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
 public class RestEndpointTest extends FreshDb {
@@ -528,14 +528,30 @@ public class RestEndpointTest extends FreshDb {
     // -- Views --
 
     @Test
-    public void view_list_empty_for_new_folder() {
-        createFolder("view-empty");
+    public void view_default_created_for_new_folder() {
+        createFolder("view-default");
 
         given()
-                .when().get("/api/folder/view-empty/view/")
+                .when().get("/api/folder/view-default/view/")
                 .then()
                 .statusCode(200)
-                .body("size()", equalTo(0));
+                .body("size()", equalTo(1))
+                .body("[0].name", equalTo("Default"))
+                .body("[0].components.size()", equalTo(0));
+    }
+
+    @Test
+    public void view_default_created_on_import_empty() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        // Default view should exist but be empty (users configure it)
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(1))
+                .body("[0].name", equalTo("Default"))
+                .body("[0].components.size()", equalTo(0));
     }
 
     @Test
@@ -581,13 +597,12 @@ public class RestEndpointTest extends FreshDb {
                 .body("name", equalTo("test-view"))
                 .body("components.size()", equalTo(2));
 
-        // List should contain it
+        // List should contain Default + test-view
         given()
                 .when().get("/api/folder/rhivos-perf-comprehensive/view/")
                 .then()
                 .statusCode(200)
-                .body("size()", equalTo(1))
-                .body("[0].name", equalTo("test-view"));
+                .body("size()", equalTo(2));
     }
 
     @Test
@@ -667,37 +682,26 @@ public class RestEndpointTest extends FreshDb {
                 .then()
                 .statusCode(204);
 
-        // Should be gone
+        // Custom view should be gone, only Default remains
         given()
                 .when().get("/api/folder/rhivos-perf-comprehensive/view/")
                 .then()
                 .statusCode(200)
-                .body("size()", equalTo(0));
+                .body("size()", equalTo(1))
+                .body("[0].name", equalTo("Default"));
     }
 
     @Test
     public void view_delete_default_rejected() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
 
-        tm.begin();
-        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
-        Long userNodeId = folder.group.sources.stream()
-                .filter(n -> "user".equals(n.name)).findFirst().get().id;
-        tm.commit();
-
-        // Create a view named "Default"
-        String createJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
-                null, "Default", null,
-                List.of(new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0))
-        ));
-
+        // Find the auto-created Default view's ID
         Long viewId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(createJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
                 .then()
                 .statusCode(200)
-                .extract().jsonPath().getLong("id");
+                .body("[0].name", equalTo("Default"))
+                .extract().jsonPath().getLong("[0].id");
 
         // Attempting to delete "Default" should fail
         given()
@@ -757,6 +761,86 @@ public class RestEndpointTest extends FreshDb {
                 // Each row should have the selected node columns
                 .body("[0].start_time", notNullValue())
                 .body("[0].end_time", notNullValue());
+    }
+
+    @Test
+    public void view_data_with_multiple_uploads() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        // Upload two runs
+        for (String runFile : List.of("/rhivos/40375.json", "/rhivos/40376.json")) {
+            try (InputStream is = getClass().getResourceAsStream(runFile)) {
+                JsonNode runData = mapper.readTree(is);
+                folderService.upload("rhivos-perf-comprehensive", "$", runData);
+            }
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(100);
+            }
+        }
+
+        // Create a view with start_time
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long startTimeNodeId = folder.group.sources.stream()
+                .filter(n -> "start_time".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        String viewJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "multi-upload-view", null,
+                List.of(new io.hyperfoil.tools.h5m.api.ViewComponent(null, startTimeNodeId, null, null, "Start Time", 0))
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(viewJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // View data should have one row per upload
+        given()
+                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId + "/data")
+                .then()
+                .statusCode(200)
+                .body("size()", equalTo(2))
+                .body("[0].start_time", notNullValue())
+                .body("[1].start_time", notNullValue());
+    }
+
+    @Test
+    public void view_component_ordering() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long startTimeNodeId = folder.group.sources.stream()
+                .filter(n -> "start_time".equals(n.name)).findFirst().get().id;
+        Long endTimeNodeId = folder.group.sources.stream()
+                .filter(n -> "end_time".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create view with end_time at order 0 and start_time at order 1 (reversed)
+        String viewJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "ordered-view", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, endTimeNodeId, null, null, "End", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, startTimeNodeId, null, null, "Start", 1)
+                )
+        ));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(viewJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                // Components should be ordered by headerOrder
+                .body("components[0].headerName", equalTo("End"))
+                .body("components[0].headerOrder", equalTo(0))
+                .body("components[1].headerName", equalTo("Start"))
+                .body("components[1].headerOrder", equalTo(1));
     }
 
     // -- OpenAPI spec --


### PR DESCRIPTION
… Phase 3-5a)

Phase 3: Default view auto-creation
- Auto-create 'Default' view on folder create() and importFolder()
- Leaf nodes only (no detection nodes ft/rd/ed)
- Duplicate node names get suffix for unique constraint
- FolderService.delete() cleans up views before folder deletion

Phase 4: Tests
- Default view created for new folder (empty) and on rhivos import (with leaf nodes)
- View data with multiple uploads returns one row per upload
- View component ordering verified
- Updated existing view tests for Default view presence

Phase 5a: Data tab
- New DataTab component with Carbon Dropdown view selector and DataTable
- Columns from view components ordered by headerOrder
- Prefers views with components when defaulting (skips empty Default)
- Data tab is the first tab in FolderPage
- Updated FolderPage tests for three tabs (Data, Nodes, Graph)
- Updated design doc with Phase 5 details