### PR TITLE
Transient Work with CompletableFuture and crash recovery tracking

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Service interface for managing Folders.
@@ -55,12 +56,15 @@ public interface FolderServiceInterface {
 
     /**
      * Uploads data to a specific path within a folder.
+     * Returns a CompletableFuture that completes when all processing
+     * (including cascaded work) finishes for this upload.
      *
      * @param name The name of the folder.
      * @param path The path within the folder.
      * @param data The JSON data to upload.
+     * @return A future that completes when all work for this upload is done.
      */
-    void upload(String name, String path, JsonNode data);
+    CompletableFuture<Void> upload(String name, String path, JsonNode data);
 
     /**
      * Recalculates the contents or state of a folder by its name.

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
@@ -15,9 +15,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name="load-legacy-runs")
@@ -112,26 +116,35 @@ public class LoadLegacyRuns implements Callable<Integer> {
                     int count = 0;
                     int batchCount = 0;
                     Scanner scanner = new Scanner(System.in);
+                    List<CompletableFuture<Void>> batchFutures = new ArrayList<>();
                     try (ResultSet rs = ps.executeQuery()) {
                         while(rs.next()){
                             Long id = rs.getLong(1);
                             System.out.println(name+" "+id);
                             JsonNode data = mapper.readTree(rs.getCharacterStream("data"));
-                            folderService.upload(folder.name(),null,data);
+                            batchFutures.add(folderService.upload(folder.name(),null,data));
                             count++;
                             batchCount++;
-                            if(batch > 0 && batchCount > batch){
-                                System.out.println("waiting for batch to complete");
-                                while(!workService.isIdle()){
-                                    Thread.sleep(10_000);
-                                }
+                            if(batch > 0 && batchCount >= batch){
+                                System.out.println("waiting for batch of " + batchCount + " to complete");
+                                CompletableFuture.allOf(batchFutures.toArray(new CompletableFuture[0]))
+                                        .orTimeout(10, TimeUnit.MINUTES)
+                                        .join();
                                 System.out.println("batch complete");
+                                batchFutures.clear();
                                 if(pause){
                                     scanner.nextLine();
                                 }
                                 batchCount = 0;
                             }
                         }
+                    }
+                    // Wait for any remaining uploads
+                    if (!batchFutures.isEmpty()) {
+                        System.out.println("waiting for final " + batchFutures.size() + " uploads to complete");
+                        CompletableFuture.allOf(batchFutures.toArray(new CompletableFuture[0]))
+                                .orTimeout(10, TimeUnit.MINUTES)
+                                .join();
                     }
                     System.out.println("loaded " + count + " runs");
                 } finally {

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/UploadProcessingEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/UploadProcessingEntity.java
@@ -1,0 +1,35 @@
+package io.hyperfoil.tools.h5m.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Tracks whether all work for a given upload has been processed.
+ * Used for crash recovery: on startup, incomplete uploads are re-triggered.
+ */
+@Entity(name = "upload_processing")
+public class UploadProcessingEntity extends PanacheEntity {
+
+    @Column(name = "root_value_id", nullable = false, updatable = false)
+    public long rootValueId;
+
+    @Column(name = "folder_name", nullable = false, updatable = false)
+    public String folderName;
+
+    @Column(nullable = false)
+    public boolean completed = false;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    public LocalDateTime createdAt;
+
+    public UploadProcessingEntity() {}
+
+    public UploadProcessingEntity(long rootValueId, String folderName) {
+        this.rootValueId = rootValueId;
+        this.folderName = folderName;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -4,53 +4,25 @@ import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;
 import io.hyperfoil.tools.h5m.svc.WorkService;
-import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import jakarta.enterprise.inject.spi.CDI;
-import jakarta.persistence.*;
-import org.hibernate.annotations.BatchSize;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 
-@Entity(name = "work")
-@DiscriminatorColumn(name = "type")
-@DiscriminatorValue("node")
 //cross test comparison could use sourceNodes and not have an activeNode?
 //custom post nodegroup actions could have sourceNodes without activeNode
-public class Work  extends PanacheEntity implements Runnable, Comparable<Work>{
+public class Work implements Runnable, Comparable<Work>{
 
-    @BatchSize(size=10)
-    @ManyToMany(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY)
-    @JoinTable(
-            name="work_values",
-            joinColumns = @JoinColumn(name = "work_id"),
-            inverseJoinColumns = @JoinColumn(name = "value_id")
-    )
     public List<ValueEntity> sourceValues;//multiple values could happen for cross test comparisons and
 
-    @BatchSize(size=10)
-    @ManyToMany(cascade = {CascadeType.PERSIST}, fetch = FetchType.LAZY)
-    @JoinTable(
-            name="work_source_nodes",
-            joinColumns = @JoinColumn(name = "work_id"),
-            inverseJoinColumns = @JoinColumn(name = "node_id")
-    )
     public List<NodeEntity> sourceNodes; //what is going to use a list of sources that are not already listed for the activeNode?
 
     public int retryCount;
 
-    @BatchSize(size=10)
-    @ManyToMany(cascade = {CascadeType.PERSIST}, fetch = FetchType.EAGER)
-    @JoinTable(
-            name="work_active_nodes",
-            joinColumns = @JoinColumn(name = "work_id"),
-            inverseJoinColumns = @JoinColumn(name = "node_id")
-    )
     public Set<NodeEntity> activeNodes;
 
-    boolean cumulative = false;
-
+    public boolean cumulative = false;
 
     public Work(){
         retryCount = 0;
@@ -187,7 +159,7 @@ public class Work  extends PanacheEntity implements Runnable, Comparable<Work>{
 
     @Override
     public String toString() {
-        return "Work<id="+id+" activeNodes="+activeNodes+
+        return "Work<activeNodes="+activeNodes+
                 " sourceNodes="+sourceNodes.stream().map(n->""+n.getId()).collect(Collectors.joining(","))+
                 " sourceValues="+sourceValues.stream().map(v->""+v.getId()).collect(Collectors.joining(","))+
                 " retry="+retryCount+

--- a/src/main/java/io/hyperfoil/tools/h5m/queue/UploadTracker.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/queue/UploadTracker.java
@@ -1,0 +1,54 @@
+package io.hyperfoil.tools.h5m.queue;
+
+import io.quarkus.logging.Log;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracks completion of all work items triggered by a single upload.
+ * The counter is incremented when work items are created (including cascade)
+ * and decremented when each work item finishes. The future completes
+ * when all work reaches zero, or completes exceptionally on failure.
+ */
+public class UploadTracker {
+
+    private final long rootValueId;
+    private final AtomicInteger pendingCount = new AtomicInteger(0);
+    private final CompletableFuture<Void> future = new CompletableFuture<>();
+
+    public UploadTracker(long rootValueId) {
+        this.rootValueId = rootValueId;
+    }
+
+    public CompletableFuture<Void> getFuture() {
+        return future;
+    }
+
+    public void increment(int count) {
+        pendingCount.addAndGet(count);
+    }
+
+    public void decrement() {
+        int remaining = pendingCount.decrementAndGet();
+        Log.debugf("UploadTracker[%d]: decrement → %d remaining", rootValueId, remaining);
+        if (remaining == 0) {
+            future.complete(null);
+        } else if (remaining < 0) {
+            Log.warnf("UploadTracker[%d]: over-decremented to %d — possible accounting bug", rootValueId, remaining);
+        }
+    }
+
+    public void fail(Throwable t) {
+        Log.errorf(t, "UploadTracker[%d]: work failed", rootValueId);
+        // Set pending to a negative sentinel so subsequent decrements
+        // cannot trigger future.complete(null) — the failure wins
+        pendingCount.set(Integer.MIN_VALUE);
+        future.completeExceptionally(t);
+    }
+
+    @Override
+    public String toString() {
+        return "UploadTracker[rootValueId=" + rootValueId + ", pending=" + pendingCount.get() + "]";
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
@@ -188,8 +188,8 @@ public class WorkQueue implements BlockingQueue<Runnable> {
             List<Work> acceptedWork = works.stream().filter(w -> {
                 boolean has = hasWork(w);
                 if (has) {
-                    log.warn("addWorks: REJECTED duplicate work id={} hash={} pending={} active={}",
-                            w.id, w.hashCode(), isPending(w), isActive(w));
+                    log.warn("addWorks: REJECTED duplicate work hash={} pending={} active={}",
+                            w.hashCode(), isPending(w), isActive(w));
                 }
                 return !has;
             }).peek(w-> {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -83,6 +83,9 @@ public class FolderResource {
             @QueryParam("path") @Parameter(description = "Path within the folder") String path,
             JsonNode data) {
         folderService.upload(name, path, data);
+        // The upload() now returns a CompletableFuture, but the REST endpoint
+        // doesn't need to wait for it — the caller can poll for results.
+        // Future enhancement: return CompletionStage<Void> for async response.
     }
 
     @POST

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -10,11 +10,16 @@ import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
+import io.hyperfoil.tools.h5m.entity.UploadProcessingEntity;
 import io.hyperfoil.tools.h5m.entity.Team;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.ViewEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import io.hyperfoil.tools.h5m.entity.node.*;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.event.Observes;
+import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.hyperfoil.tools.h5m.entity.work.Work;
 import io.hyperfoil.tools.yaup.json.Json;
 import io.quarkus.logging.Log;
@@ -27,6 +32,7 @@ import org.hibernate.query.NativeQuery;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -57,6 +63,56 @@ public class FolderService implements FolderServiceInterface {
 
     @Inject
     ApiMapper apiMapper;
+
+    /**
+     * On startup, re-trigger processing for any uploads that were interrupted
+     * (e.g., by a crash). Uses all source nodes (not just top-level) so that
+     * mid-cascade crashes are recovered correctly — the deduplication logic in
+     * execute() skips already-computed values while ensuring missing children
+     * are still calculated.
+     */
+    @Transactional
+    public void recoverIncompleteUploads(@Observes @Priority(2) StartupEvent ev) {
+        List<UploadProcessingEntity> incomplete = UploadProcessingEntity.find("completed", false).list();
+        if (!incomplete.isEmpty()) {
+            Log.infof("Found %d incomplete uploads to recover", incomplete.size());
+            for (UploadProcessingEntity tracking : incomplete) {
+                ValueEntity rootValue = ValueEntity.findById(tracking.rootValueId);
+                if (rootValue == null) {
+                    Log.warnf("Root value %d not found for incomplete upload, removing tracking record", tracking.rootValueId);
+                    tracking.delete();
+                    continue;
+                }
+                FolderEntity folder = em.createQuery(
+                        "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
+                        FolderEntity.class
+                ).setParameter("name", tracking.folderName).getResultStream().findFirst().orElse(null);
+                if (folder == null) {
+                    Log.warnf("Folder '%s' not found for incomplete upload, removing tracking record", tracking.folderName);
+                    tracking.delete();
+                    continue;
+                }
+                Log.infof("Re-triggering processing for upload %d in folder '%s'", tracking.rootValueId, tracking.folderName);
+                // Use all source nodes (not just top-level) to handle mid-cascade crashes
+                List<Work> works = List.copyOf(folder.group.sources).stream()
+                        .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(rootValue)))
+                        .toList();
+                if (!works.isEmpty()) {
+                    CompletableFuture<Void> future = workService.createTracked(works, Set.of(rootValue.id));
+                    future.whenComplete((v, t) -> {
+                        QuarkusTransaction.requiringNew().run(() -> {
+                            UploadProcessingEntity entity = UploadProcessingEntity.find("rootValueId", rootValue.id).firstResult();
+                            if (entity != null) {
+                                entity.completed = true;
+                            }
+                        });
+                    });
+                } else {
+                    tracking.completed = true;
+                }
+            }
+        }
+    }
 
     @Override
     @Transactional
@@ -253,36 +309,50 @@ public class FolderService implements FolderServiceInterface {
         workService.create(newWorks);
     }
 
+    /**
+     * Uploads data and returns a future that completes when all processing finishes.
+     * Uses QuarkusTransaction to control the transaction boundary explicitly —
+     * the transaction commits when the lambda returns, before we return the future.
+     * This avoids the deadlock that occurs with @Transactional + CompletableFuture
+     * return types (Quarkus defers commit waiting for the future to complete).
+     */
     @Override
-    @Transactional
-    public void upload(String name, String path, JsonNode data){
-        FolderEntity folder = em.createQuery(
-                "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
-                FolderEntity.class
-        ).setParameter("name", name).getSingleResult();
-        ValueEntity newValue = new ValueEntity(folder,folder.group.root,data);
-        valueService.create(newValue);
+    public CompletableFuture<Void> upload(String name, String path, JsonNode data){
+        return QuarkusTransaction.requiringNew().call(() -> {
+            FolderEntity folder = em.createQuery(
+                    "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
+                    FolderEntity.class
+            ).setParameter("name", name).getSingleResult();
+            ValueEntity newValue = new ValueEntity(folder, folder.group.root, data);
+            valueService.create(newValue);
 
-        //do we only queue the top level and let new values queue the remaining?
-        //that would match the re-calculation workflow
-        //or do we rely on workQueue for de-duplication?
-/*
-        folder.group.getTopLevelNodes().forEach(source ->{
-            Work newWork = new Work(source,new ArrayList<>(source.sources),List.of(newValue));
-            workService.create(newWork);
-            workQueue.addWork(newWork);
+            // Track this upload for crash recovery — marked completed when all work finishes
+            UploadProcessingEntity tracking = new UploadProcessingEntity(newValue.id, name);
+            tracking.persist();
+
+            //only queue the top level and let new values queue the remaining
+            //that matches the re-calculation workflow
+            List<Work> works = folder.group.getTopLevelNodes().stream()
+                    .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(newValue)))
+                    .toList();
+
+            if (works.isEmpty()) {
+                tracking.completed = true;
+                return CompletableFuture.<Void>completedFuture(null);
+            }
+
+            CompletableFuture<Void> future = workService.createTracked(works, Set.of(newValue.id));
+            // Mark completed when all work finishes
+            future.whenComplete((v, t) -> {
+                QuarkusTransaction.requiringNew().run(() -> {
+                    UploadProcessingEntity entity = UploadProcessingEntity.find("rootValueId", newValue.id).firstResult();
+                    if (entity != null) {
+                        entity.completed = true;
+                    }
+                });
+            });
+            return future;
         });
-*/
-        //List.copyOf is a hack to get around ConcurrentModificationException that is likely due to using entity list and panache setSources
-//        List<Work> toQueue = List.copyOf(folder.group.sources).stream().map(source -> {
-//            Work newWork = new Work(source,new ArrayList<>(source.sources),List.of(newValue));
-//            workService.create(newWork);
-//            return newWork;
-//        }).toList();
-//        workQueue.addWorks(toQueue);
-
-        workService.create(folder.group.getTopLevelNodes().stream().map(node-> new Work(node,new ArrayList<>(node.sources),List.of(newValue))).toList());
-        //workService.create(List.copyOf(folder.group.sources).stream().map(source -> new Work(source, new ArrayList<>(source.sources), List.of(newValue))).toList());
     }
 
     /**

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.h5m.api.svc.WorkServiceInterface;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.work.Work;
+import io.hyperfoil.tools.h5m.queue.UploadTracker;
 import io.hyperfoil.tools.h5m.queue.WorkQueue;
 import io.hyperfoil.tools.h5m.queue.WorkQueueExecutor;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -11,6 +12,7 @@ import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.quarkus.runtime.StartupEvent;
 import io.hyperfoil.tools.h5m.event.ChangeDetectedEvent;
 import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
@@ -26,6 +28,8 @@ import org.hibernate.Hibernate;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -63,15 +67,53 @@ public class WorkService implements WorkServiceInterface {
 
     private WorkQueueExecutor workExecutor;
 
+    private final ConcurrentHashMap<Long, UploadTracker> trackers = new ConcurrentHashMap<>();
+
+    /**
+     * Finds trackers associated with the work's source values.
+     * A tracker exists for each root value ID that was registered via createTracked().
+     * This derives the association from sourceValues rather than duplicating state on Work.
+     */
+    private List<UploadTracker> findTrackers(Work work) {
+        if (work.sourceValues == null || trackers.isEmpty()) {
+            return List.of();
+        }
+        List<UploadTracker> found = new ArrayList<>();
+        for (ValueEntity sv : work.sourceValues) {
+            if (sv.id != null) {
+                UploadTracker tracker = trackers.get(sv.id);
+                if (tracker != null) {
+                    found.add(tracker);
+                }
+            }
+        }
+        return found;
+    }
+
+    private void incrementTrackers(Work work, int count) {
+        for (UploadTracker tracker : findTrackers(work)) {
+            tracker.increment(count);
+        }
+    }
+
+    private void decrementTrackers(Work work) {
+        for (UploadTracker tracker : findTrackers(work)) {
+            tracker.decrement();
+        }
+    }
+
+    private void failTrackers(Work work, Throwable t) {
+        for (UploadTracker tracker : findTrackers(work)) {
+            tracker.fail(t);
+        }
+    }
+
     @Transactional
-    void onStart(@Observes StartupEvent ev) {
+    void onStart(@Observes @Priority(1) StartupEvent ev) {
         workExecutor = new WorkQueueExecutor(corePoolSize, maxPoolSize, keepAlive.toSeconds(), TimeUnit.SECONDS, new WorkQueue());
         workExecutor.allowCoreThreadTimeOut(false);
         workExecutor.prestartAllCoreThreads();
         new ExecutorServiceMetrics(workExecutor, "h5mWorkExecutor", null).bindTo(registry);
-
-        //resumes unfinished work from previous execution
-        workExecutor.getWorkQueue().addWorks(Work.listAll());
     }
 
     @PreDestroy
@@ -80,6 +122,13 @@ public class WorkService implements WorkServiceInterface {
             workExecutor.shutdown();
         }
     }
+
+    /**
+     * Creates work items and queues them for execution.
+     * Work items are NOT persisted to the DB — they exist only in memory.
+     * Queue insertion is deferred until the current transaction commits
+     * to ensure source values are visible to worker threads.
+     */
     @Transactional
     public void create(List<Work> works) {
         WorkQueue workQueue = workExecutor.getWorkQueue();
@@ -88,34 +137,20 @@ public class WorkService implements WorkServiceInterface {
             if (workQueue.hasWork(work)) {
                 continue;
             }
-            if (!work.isPersistent()) {
-                work.id = null;
-                Work merged = em.merge(work);
-                em.flush();
-                work.id = merged.id;
-            }
             newWorks.add(work);
         }
         if (!newWorks.isEmpty()) {
-            // Defer queue insertion until this transaction commits.
-            // Worker threads will only see Work items after the DB row is visible,
-            // preventing StaleObjectStateException from the visibility race.
             List<Work> toQueue = List.copyOf(newWorks);
-            // Eagerly initialize lazy proxies that WorkQueue.sort() → dependsOn()
-            // traverses, since addWorks runs in afterCompletion outside the session.
             for (Work work : toQueue) {
-                for (ValueEntity sv : work.sourceValues) {
-                    Hibernate.initialize(sv.node);
-                    Hibernate.initialize(sv.sources);
-                    if (sv.node != null) {
-                        // Trigger ancestor cache computation while session is open
-                        sv.node.dependsOn(sv.node);
-                    }
-                }
+                // Pre-compute ancestor caches while session is open — needed by
+                // WorkQueue.sort() → dependsOn() which runs in afterCompletion
+                // outside the session. Without this, dependsOn() would try to
+                // lazily traverse NodeEntity.sources and fail.
                 if (work.activeNodes != null) {
-                    // Trigger ancestor cache computation while session is open
                     work.dependsOn(work);
                 }
+                // Increment trackers for each work item (before afterCompletion decrement)
+                incrementTrackers(work, 1);
             }
             workQueue.incrementDeferred(toQueue.size());
             try {
@@ -127,27 +162,55 @@ public class WorkService implements WorkServiceInterface {
                     public void afterCompletion(int status) {
                         if (status == Status.STATUS_COMMITTED) {
                             Log.debugf("afterCompletion: queueing %d Work items", toQueue.size());
-                            workQueue.addWorks(toQueue);
+                            Collection<Work> accepted = workQueue.addWorks(toQueue);
+                            // Decrement trackers for rejected duplicates — they were
+                            // counted in the increment but will never be executed
+                            for (Work work : toQueue) {
+                                if (!accepted.contains(work)) {
+                                    decrementTrackers(work);
+                                }
+                            }
                         } else {
                             Log.warnf("Transaction rolled back (status=%d), %d Work items not queued",
                                     status, toQueue.size());
+                            // Decrement trackers for rolled-back work
+                            for (Work work : toQueue) {
+                                decrementTrackers(work);
+                            }
                         }
                         workQueue.decrementDeferred(toQueue.size());
                     }
                 });
             } catch (Exception e) {
                 workQueue.decrementDeferred(toQueue.size());
+                // Undo tracker increments
+                for (Work work : toQueue) {
+                    decrementTrackers(work);
+                }
                 throw new IllegalStateException(
                         "Failed to register transaction synchronization; refusing to queue before commit", e);
             }
         }
     }
 
-    @Transactional
-    public void delete(Work work){
-        if(work.id!=null){
-            Work.deleteById(work.id);
+    /**
+     * Creates work items with upload completion tracking.
+     * Trackers are keyed by root value IDs. The association between Work
+     * and trackers is derived from Work.sourceValues — no duplicated state.
+     * For cross-upload Work, a single Work can have source values from
+     * multiple uploads, and all relevant trackers are updated automatically.
+     * Returns a CompletableFuture that completes when all trackers complete.
+     */
+    public CompletableFuture<Void> createTracked(List<Work> works, Set<Long> rootValueIds) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (long rootValueId : rootValueIds) {
+            UploadTracker tracker = trackers.computeIfAbsent(rootValueId, UploadTracker::new);
+            // Clean up tracker when its future completes
+            tracker.getFuture().whenComplete((v, t) -> trackers.remove(rootValueId));
+            futures.add(tracker.getFuture());
         }
+        create(works);
+        return CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new));
     }
 
     @Override
@@ -166,44 +229,61 @@ public class WorkService implements WorkServiceInterface {
         WorkQueue workQueue = workExecutor.getWorkQueue();
         boolean decrementDeferred = false;
         try {
-            Work work = em.find(Work.class, w.id);
-            if (work == null) {
-                Log.warnf("execute: Work id=%d not found in DB (already processed?), skipping", w.id);
+            // Use source values from the Work. If data is already initialized (normal
+            // pipeline path via work queue), use it directly to avoid DB round-trip +
+            // JSON deserialization. If data is not initialized (e.g., test calling
+            // execute() directly with committed entities), reload from DB.
+            List<ValueEntity> sourceValues = new ArrayList<>();
+            for (ValueEntity sv : w.sourceValues) {
+                if (Hibernate.isPropertyInitialized(sv, "data")) {
+                    sourceValues.add(sv);
+                } else {
+                    ValueEntity managed = em.find(ValueEntity.class, sv.id);
+                    if (managed != null) {
+                        Hibernate.initialize(managed.data);
+                        sourceValues.add(managed);
+                    }
+                }
+            }
+
+            // Reload active nodes in this transaction's persistence context —
+            // calculateValues() accesses node.sources which is lazy
+            Set<NodeEntity> activeNodes = new HashSet<>();
+            for (NodeEntity an : w.activeNodes) {
+                NodeEntity managed = em.find(NodeEntity.class, an.id);
+                if (managed != null) {
+                    activeNodes.add(managed);
+                }
+            }
+            if(activeNodes.isEmpty() || sourceValues.isEmpty()){
+                // Nothing to process — still need to decrement trackers
+                decrementTrackers(w);
                 return;
             }
-            if(work.activeNodes==null || work.activeNodes.isEmpty() || work.sourceValues == null || work.sourceValues.isEmpty()){
-                //error conditions?
-                //work.activeNode == null is not yet a validation condition but it could be for post processing tasks?
-            }
-            // Eagerly initialize lazy-loaded data fields to avoid LazyInitializationException
-            // when accessed later in calculateValues (ValueEntity.data is @Basic(fetch = LAZY))
-            for (ValueEntity sv : work.sourceValues) {
-                Hibernate.initialize(sv.data);
-            }
+
             //looping over values works for Jq / Js nodes but what about cross test comparison
             //calculateValue should probably accept all sourceValues and leave it to the node function to decide
-            List<ValueEntity> calculated = new  ArrayList<>();
-            for(NodeEntity node : work.activeNodes){
-                List<ValueEntity> thisIteration = nodeService.calculateValues(node,work.sourceValues);
+            List<ValueEntity> calculated = new ArrayList<>();
+            for(NodeEntity node : activeNodes){
+                List<ValueEntity> thisIteration = nodeService.calculateValues(node, sourceValues);
                 calculated.addAll(thisIteration);
             }
             List<ValueEntity> newOrUpdated = new ArrayList<>();
-            for(ValueEntity v : work.sourceValues) {
-                for(NodeEntity activeNode : work.activeNodes){
+            for(ValueEntity v : sourceValues) {
+                for(NodeEntity activeNode : activeNodes){
                     Map<String, ValueEntity> descendants = valueService.getDescendantValueByPath(v, activeNode);
                     for(Iterator<ValueEntity> iter = calculated.iterator(); iter.hasNext();){
                         ValueEntity newValue = iter.next();
                         String path = newValue.getPath();
                         if(descendants.containsKey(path)){
                             ValueEntity existingValue = descendants.get(path);
-                            //existingValue.getId() should not be null because it was fetched from persistence
                             if(existingValue.getId().equals(newValue.getId())) {
                                 //if it's the same value we don't have to work with it
                             }else if( newValue.data.equals(existingValue.data)){
                                 if(newValue.id != null){
                                     valueService.delete(newValue);
                                 }
-                                iter.remove();//we don't need this new ValueEntity
+                                iter.remove();
                             }else{
                                 //update the new value
                                 existingValue.data = newValue.data;
@@ -227,49 +307,53 @@ public class WorkService implements WorkServiceInterface {
                 for(NodeEntity node : createdValues){
                     if(node.isDetection()){
                         List<Long> valueIds = newOrUpdated.stream().map(ValueEntity::getId).toList();
-                        long folderId = work.sourceValues.stream()
+                        long folderId = sourceValues.stream()
                                 .filter(v -> v.folder != null)
                                 .map(v -> v.folder.id)
                                 .findFirst()
                                 .orElse(-1L);
                         changeDetectedEvent.fire(new ChangeDetectedEvent(folderId, node.getId(), node.name, valueIds, true));
-
                     }
                     //we need to trigger more calculations? perhaps for a recalculation we do?
-                    create(nodeService.getDependentNodes(node).stream().map(n -> new Work(n, n.sources, work.sourceValues)).toList());
+                    // Cascade work inherits sourceValues, so tracker association
+                    // is derived automatically via findTrackers()
+                    List<Work> cascadeWork = nodeService.getDependentNodes(node).stream()
+                            .map(n -> new Work(n, n.sources, sourceValues))
+                            .toList();
+                    create(cascadeWork);
                 }
             }
 
-            //not in the finally so that it only happens if the work succeeds
-            delete(work);
-
             // Defer decrement until after this transaction commits so that
             // isIdle() cannot return true while the DB commit is still in flight.
-            if(w.activeNodes!=null && !w.activeNodes.isEmpty()){
+            if(w.activeNodes != null && !w.activeNodes.isEmpty()){
                 decrementDeferred = true;
                 tm.getTransaction().registerSynchronization(new Synchronization() {
                     @Override public void beforeCompletion() {}
                     @Override public void afterCompletion(int status) {
                         workQueue.decrement(w);
+                        decrementTrackers(w);
                     }
                 });
             }
         }catch( Exception e){
-            //TODO how to handle the exception, adding it back to the todo list
-            System.err.println("WorkRunner caught: "+e.getMessage()+"\n work="+w);
-            e.printStackTrace();
+            Log.errorf(e, "WorkRunner caught: %s\n work=%s", e.getMessage(), w);
             w.retryCount++;
             if(w.retryCount > RETRY_LIMIT){
-                System.err.println("Work exceeded retry limit");
+                Log.error("Work exceeded retry limit");
+                // Fail trackers so CompletableFutures complete exceptionally
+                failTrackers(w, e);
             } else {
-                System.err.println("Adding work to retry in queue");
+                Log.info("Adding work to retry in queue");
                 workQueue.add(w);
+                // Skip decrement in finally — work is re-queued and will be
+                // decremented when the retry completes
+                decrementDeferred = true;
             }
         } finally {
-            // Only decrement immediately if we couldn't register the afterCompletion
-            // (early return for "not found", or exception before registration)
-            if(!decrementDeferred && w.activeNodes!=null && !w.activeNodes.isEmpty()){
+            if(!decrementDeferred && w.activeNodes != null && !w.activeNodes.isEmpty()){
                 workQueue.decrement(w);
+                decrementTrackers(w);
             }
         }
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
@@ -28,16 +28,13 @@ public class FreshDb {
             try(Statement stmt = conn.createStatement()){
 
                 if(dbKind.equals("postgresql")){
+                    stmt.executeUpdate("TRUNCATE TABLE upload_processing CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE folder_view_component CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE folder_view CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE notification_log CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE notification_config CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE api_key CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE team_members CASCADE");
-                    stmt.executeUpdate("TRUNCATE TABLE work_values CASCADE");
-                    stmt.executeUpdate("TRUNCATE TABLE work_active_nodes CASCADE");
-                    stmt.executeUpdate("TRUNCATE TABLE work_source_nodes CASCADE");
-                    stmt.executeUpdate("TRUNCATE TABLE work CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE value_edge CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE value CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE folder CASCADE");
@@ -47,16 +44,13 @@ public class FreshDb {
                     stmt.executeUpdate("TRUNCATE TABLE h5m_user CASCADE");
                     stmt.executeUpdate("TRUNCATE TABLE team CASCADE");
                 }else if (dbKind.equals("sqlite")){
+                    stmt.executeUpdate("DELETE from upload_processing");
                     stmt.executeUpdate("DELETE from folder_view_component");
                     stmt.executeUpdate("DELETE from folder_view");
                     stmt.executeUpdate("DELETE from notification_log");
                     stmt.executeUpdate("DELETE from notification_config");
                     stmt.executeUpdate("DELETE from api_key");
                     stmt.executeUpdate("DELETE from team_members");
-                    stmt.executeUpdate("DELETE from work_values");
-                    stmt.executeUpdate("DELETE from work_active_nodes");
-                    stmt.executeUpdate("DELETE from work_source_nodes");
-                    stmt.executeUpdate("DELETE from work");
                     stmt.executeUpdate("DELETE from value_edge");
                     stmt.executeUpdate("DELETE from value");
                     stmt.executeUpdate("DELETE from folder");

--- a/src/test/java/io/hyperfoil/tools/h5m/benchmark/UploadPipelineBenchmarkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/benchmark/UploadPipelineBenchmarkTest.java
@@ -279,11 +279,10 @@ public class UploadPipelineBenchmarkTest extends FreshDb {
         long values = countRows("value");
         long nodeEdges = countRows("node_edge");
         long valueEdges = countRows("value_edge");
-        long workItems = countRows("work");
         String report = String.format(
                 "[PIPELINE] %s: configured_nodes=%d, uploads=%d, total_nodes=%d, total_values=%d, " +
-                        "node_edges=%d, value_edges=%d, pending_work=%d",
-                label, nodeCount, uploadCount, nodes, values, nodeEdges, valueEdges, workItems);
+                        "node_edges=%d, value_edges=%d",
+                label, nodeCount, uploadCount, nodes, values, nodeEdges, valueEdges);
         reports.add(report);
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
@@ -40,9 +40,7 @@ public class WorkQueueTest extends FreshDb {
         ValueEntity rootValue2 = new ValueEntity(null,rootNode,new TextNode("text2"));
 
         Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1));
-        work1.persist();
         Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2));
-        work2.persist();
 
         assertEquals(work1.hashCode(),work2.hashCode(),"both worth should have the same hashcode despite different values");
 
@@ -69,9 +67,7 @@ public class WorkQueueTest extends FreshDb {
 
 
         Work first = new Work(aNode,aNode.sources,List.of(rootValue));
-        first.persist();
         Work second = new Work(aNode,aNode.sources,List.of(rootValue));
-        second.persist();
 
         assertEquals(first.hashCode(),second.hashCode(),"work with different id but same scope should have the same hash");
         q.addWorks(List.of(first, second));
@@ -92,9 +88,7 @@ public class WorkQueueTest extends FreshDb {
         bNode.persist();
 
         Work aWork = new Work(aNode,null,null);
-        aWork.persist();
         Work bWork = new Work(bNode,null,null);
-        bWork.persist();
         tm.commit();
 
         q.addWorks(List.of(bWork));
@@ -130,11 +124,8 @@ public class WorkQueueTest extends FreshDb {
         cNode.persist();
 
         Work aWork = new Work(aNode,null,null);
-        aWork.persist();
         Work bWork = new Work(bNode,null,null);
-        bWork.persist();
         Work cWork = new Work(cNode,null,null);
-        cWork.persist();
         tm.commit();
 
         q.addWorks(List.of(aWork, bWork, cWork));

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -441,12 +442,8 @@ public class RestEndpointTest extends FreshDb {
 
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             JsonNode runData = mapper.readTree(is);
-            folderService.upload("rhivos-perf-comprehensive", "$", runData);
-        }
-
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(100);
+            folderService.upload("rhivos-perf-comprehensive", "$", runData)
+                    .orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         given()
@@ -468,12 +465,8 @@ public class RestEndpointTest extends FreshDb {
         for (String runFile : List.of("/rhivos/40375.json", "/rhivos/40376.json")) {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 JsonNode runData = mapper.readTree(is);
-                folderService.upload("rhivos-perf-comprehensive", "$", runData);
-            }
-
-            long deadline = System.currentTimeMillis() + 30_000;
-            while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
-                Thread.sleep(100);
+                folderService.upload("rhivos-perf-comprehensive", "$", runData)
+                        .orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
 
@@ -493,12 +486,8 @@ public class RestEndpointTest extends FreshDb {
 
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             JsonNode runData = mapper.readTree(is);
-            folderService.upload("rhivos-perf-comprehensive", "$", runData);
-        }
-
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(100);
+            folderService.upload("rhivos-perf-comprehensive", "$", runData)
+                    .orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Find the root value ID — the upload itself
@@ -717,14 +706,9 @@ public class RestEndpointTest extends FreshDb {
 
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             JsonNode runData = mapper.readTree(is);
-            folderService.upload("rhivos-perf-comprehensive", "$", runData);
+            folderService.upload("rhivos-perf-comprehensive", "$", runData)
+                    .orTimeout(30, TimeUnit.SECONDS).join();
         }
-
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
-            Thread.sleep(100);
-        }
-        assertTrue(workService.isIdle(), "Work queue should be idle");
 
         // Find node IDs for nodes that produce values with rhivos data
         tm.begin();
@@ -771,11 +755,8 @@ public class RestEndpointTest extends FreshDb {
         for (String runFile : List.of("/rhivos/40375.json", "/rhivos/40376.json")) {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 JsonNode runData = mapper.readTree(is);
-                folderService.upload("rhivos-perf-comprehensive", "$", runData);
-            }
-            long deadline = System.currentTimeMillis() + 30_000;
-            while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
-                Thread.sleep(100);
+                folderService.upload("rhivos-perf-comprehensive", "$", runData)
+                        .orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ChangeDetectionTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ChangeDetectionTest.java
@@ -82,27 +82,16 @@ public class ChangeDetectionTest extends FreshDb {
         ft.setNodes(fingerprintNode, rootNode, rangeNode);
         ft.persist();
 
-        Work work = new Work(ft, new ArrayList<>(ft.sources), List.of(rootVal));
-        work.persist();
         tm.commit();
 
         return new ThresholdFixture(ft, rootVal);
-    }
-
-    private Work loadWork(NodeEntity activeNode) throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
-        tm.begin();
-        Work work = Work.find("?1 member of activeNodes", activeNode).firstResult();
-        work.sourceValues.size();
-        work.sourceNodes.size();
-        tm.commit();
-        return work;
     }
 
     @Test
     public void event_fires_when_threshold_violated() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // value 5.0 is below min=10 → violation
         ThresholdFixture fixture = setupThreshold(5.0);
-        Work work = loadWork(fixture.ft());
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
 
         workService.execute(work);
 
@@ -117,7 +106,7 @@ public class ChangeDetectionTest extends FreshDb {
     public void event_does_not_fire_when_no_violation() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // value 50.0 is within [10, 100] → no violation
         ThresholdFixture fixture = setupThreshold(50.0);
-        Work work = loadWork(fixture.ft());
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
 
         workService.execute(work);
 
@@ -128,22 +117,15 @@ public class ChangeDetectionTest extends FreshDb {
     public void recalculation_does_not_fire_when_value_unchanged() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // first calculation: value 5.0 is below min=10 → violation, event fires
         ThresholdFixture fixture = setupThreshold(5.0);
-        Work work = loadWork(fixture.ft());
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
         workService.execute(work);
 
         assertEquals(1, eventObserver.getEvents().size(), "first calculation should fire event");
         eventObserver.clear();
 
         // recalculation: same data, should produce identical value → deduplicated, no event
-        tm.begin();
-        FixedThreshold managedFt = FixedThreshold.findById(fixture.ft().getId());
-        ValueEntity managedRoot = ValueEntity.findById(fixture.rootValue().id);
-        Work recalc = new Work(managedFt, new ArrayList<>(managedFt.sources), List.of(managedRoot));
-        recalc.persist();
-        tm.commit();
-
-        Work loadedRecalc = loadWork(managedFt);
-        workService.execute(loadedRecalc);
+        Work recalc = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
+        workService.execute(recalc);
 
         assertEquals(0, eventObserver.getEvents().size(), "recalculation with identical value should not fire event");
     }
@@ -158,13 +140,10 @@ public class ChangeDetectionTest extends FreshDb {
 
         ValueEntity rootValue = new ValueEntity(null, rootNode, new TextNode("{\"y\": 42}"));
         rootValue.persist();
-
-        Work work = new Work(jqNode, new ArrayList<>(jqNode.sources), List.of(rootValue));
-        work.persist();
         tm.commit();
 
-        Work loaded = loadWork(jqNode);
-        workService.execute(loaded);
+        Work work = new Work(jqNode, new ArrayList<>(jqNode.sources), List.of(rootValue));
+        workService.execute(work);
 
         assertEquals(0, eventObserver.getEvents().size(), "should not fire ChangeDetectedEvent for non-detection nodes");
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -1,0 +1,272 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.UploadProcessingEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.TransactionManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class FolderServiceTest extends FreshDb {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    FolderService folderService;
+
+    @Inject
+    WorkService workService;
+
+    @Inject
+    EntityManager em;
+
+    @Inject
+    ValueService valueService;
+
+    private void awaitIdle(long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int stableChecks = 0;
+        while (stableChecks < 5) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Work queue drain timed out after " + timeoutMs + "ms");
+            }
+            if (workService.isIdle()) {
+                stableChecks++;
+            } else {
+                stableChecks = 0;
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    // -- Crash recovery --
+
+    @Test
+    public void recovery_reprocesses_incomplete_upload() throws Exception {
+        // Set up folder with a JQ node
+        tm.begin();
+        long folderId = folderService.create("recovery-test");
+        FolderEntity folder = folderService.read(folderId);
+        JqNode jqNode = new JqNode("extract", ".key", folder.group.root);
+        jqNode.group = folder.group;
+        jqNode.persist();
+        tm.commit();
+
+        // Create a root value manually (simulating a crash mid-upload
+        // where the value was persisted but work was never completed)
+        tm.begin();
+        FolderEntity folder2 = FolderEntity.find("name", "recovery-test").firstResult();
+        ValueEntity rootValue = new ValueEntity(folder2, folder2.group.root,
+                mapper.readTree("{\"key\": \"recovered\"}"));
+        valueService.create(rootValue);
+
+        // Create an incomplete tracking record (simulating crash before completion)
+        UploadProcessingEntity tracking = new UploadProcessingEntity(rootValue.id, "recovery-test");
+        tracking.persist();
+        tm.commit();
+
+        // Verify no computed values yet (the work was never executed)
+        tm.begin();
+        List<ValueEntity> beforeRecovery = ValueEntity.find("node.id", jqNode.id).list();
+        assertEquals(0, beforeRecovery.size(), "No values should exist before recovery");
+        tm.commit();
+
+        // Trigger recovery
+        folderService.recoverIncompleteUploads(null);
+        awaitIdle(10_000);
+
+        // Verify the value was computed by the recovery
+        tm.begin();
+        List<ValueEntity> afterRecovery = ValueEntity.find("node.id", jqNode.id).list();
+        assertFalse(afterRecovery.isEmpty(), "JQ node should have computed values after recovery");
+        assertEquals("recovered", afterRecovery.get(0).data.asText(),
+                "Recovered value should match the uploaded data");
+
+        // Verify the tracking record is now completed
+        UploadProcessingEntity updatedTracking = UploadProcessingEntity.find("rootValueId", rootValue.id).firstResult();
+        assertTrue(updatedTracking.completed, "Tracking record should be marked completed after recovery");
+        tm.commit();
+    }
+
+    @Test
+    public void recovery_skips_missing_root_value() throws Exception {
+        // Create an incomplete tracking record pointing to a non-existent root value
+        tm.begin();
+        UploadProcessingEntity tracking = new UploadProcessingEntity(999999L, "no-such-folder");
+        tracking.persist();
+        long trackingId = tracking.id;
+        tm.commit();
+
+        // Trigger recovery — should log warning and delete the tracking record
+        folderService.recoverIncompleteUploads(null);
+
+        // Verify the tracking record was deleted
+        tm.begin();
+        UploadProcessingEntity deleted = UploadProcessingEntity.findById(trackingId);
+        assertNull(deleted, "Tracking record should be deleted when root value is missing");
+        tm.commit();
+    }
+
+    @Test
+    public void recovery_skips_missing_folder() throws Exception {
+        // Create a root value in a folder, then delete the folder but leave tracking
+        tm.begin();
+        long folderId = folderService.create("temp-folder");
+        FolderEntity folder = folderService.read(folderId);
+        ValueEntity rootValue = new ValueEntity(folder, folder.group.root,
+                mapper.readTree("{\"key\": \"orphaned\"}"));
+        valueService.create(rootValue);
+        long rootValueId = rootValue.id;
+
+        UploadProcessingEntity tracking = new UploadProcessingEntity(rootValueId, "deleted-folder");
+        tracking.persist();
+        long trackingId = tracking.id;
+        tm.commit();
+
+        // Trigger recovery — "deleted-folder" doesn't exist
+        folderService.recoverIncompleteUploads(null);
+
+        // Verify the tracking record was deleted
+        tm.begin();
+        UploadProcessingEntity deleted = UploadProcessingEntity.findById(trackingId);
+        assertNull(deleted, "Tracking record should be deleted when folder is missing");
+        tm.commit();
+    }
+
+    @Test
+    public void recovery_completes_when_all_values_already_computed() throws Exception {
+        // Simulates a crash that happened after all top-level nodes computed
+        // their values but before the tracking record was marked completed.
+        // Recovery should dedup everything (no new values) and still complete.
+        tm.begin();
+        long folderId = folderService.create("already-computed");
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode extractKey = new JqNode("extractKey", ".key", folder.group.root);
+        extractKey.group = folder.group;
+        extractKey.persist();
+        folder.group.sources.add(extractKey);
+
+        JqNode extractValue = new JqNode("extractValue", ".value", folder.group.root);
+        extractValue.group = folder.group;
+        extractValue.persist();
+        folder.group.sources.add(extractValue);
+
+        long extractKeyId = extractKey.id;
+        long extractValueId = extractValue.id;
+        tm.commit();
+
+        // Create root value AND computed values (simulating all work completed)
+        tm.begin();
+        FolderEntity f = FolderEntity.find("name", "already-computed").firstResult();
+        ValueEntity rootValue = new ValueEntity(f, f.group.root,
+                mapper.readTree("{\"key\": \"k1\", \"value\": \"v1\"}"));
+        valueService.create(rootValue);
+
+        // Both nodes already have their computed values
+        ValueEntity keyValue = new ValueEntity(f, extractKey, mapper.readTree("\"k1\""));
+        keyValue.sources = List.of(rootValue);
+        valueService.create(keyValue);
+
+        ValueEntity valValue = new ValueEntity(f, extractValue, mapper.readTree("\"v1\""));
+        valValue.sources = List.of(rootValue);
+        valueService.create(valValue);
+
+        // But tracking was never marked completed (crash happened here)
+        UploadProcessingEntity tracking = new UploadProcessingEntity(rootValue.id, "already-computed");
+        tracking.persist();
+        long rootValueId = rootValue.id;
+        tm.commit();
+
+        // Count values before recovery
+        tm.begin();
+        long valuesBefore = ValueEntity.count();
+        tm.commit();
+
+        // Trigger recovery — should dedup everything and complete
+        folderService.recoverIncompleteUploads(null);
+        awaitIdle(10_000);
+
+        // Verify no new values were created (everything was deduped)
+        tm.begin();
+        long valuesAfter = ValueEntity.count();
+        assertEquals(valuesBefore, valuesAfter,
+                "No new values should be created when all work was already computed");
+
+        // Verify tracking is now completed
+        UploadProcessingEntity updatedTracking = UploadProcessingEntity.find("rootValueId", rootValueId).firstResult();
+        assertTrue(updatedTracking.completed,
+                "Tracking record should be marked completed even when all values were already computed");
+        tm.commit();
+    }
+
+    @Test
+    public void recovery_processes_multiple_independent_nodes() throws Exception {
+        // Set up folder with two independent top-level nodes extracting different fields.
+        // Verifies that recovery processes all nodes, not just the first one.
+        tm.begin();
+        long folderId = folderService.create("multi-node-test");
+        FolderEntity folder = folderService.read(folderId);
+        NodeEntity root = folder.group.root;
+
+        JqNode extractKey = new JqNode("extractKey", ".key", root);
+        extractKey.group = folder.group;
+        extractKey.persist();
+        folder.group.sources.add(extractKey);
+
+        JqNode extractValue = new JqNode("extractValue", ".value", root);
+        extractValue.group = folder.group;
+        extractValue.persist();
+        folder.group.sources.add(extractValue);
+
+        long extractKeyId = extractKey.id;
+        long extractValueId = extractValue.id;
+        tm.commit();
+
+        // Create root value and incomplete tracking (simulating crash)
+        tm.begin();
+        FolderEntity f = FolderEntity.find("name", "multi-node-test").firstResult();
+        ValueEntity rootValue = new ValueEntity(f, f.group.root,
+                mapper.readTree("{\"key\": \"k1\", \"value\": \"v1\"}"));
+        valueService.create(rootValue);
+
+        UploadProcessingEntity tracking = new UploadProcessingEntity(rootValue.id, "multi-node-test");
+        tracking.persist();
+        long rootValueId = rootValue.id;
+        tm.commit();
+
+        // Trigger recovery
+        folderService.recoverIncompleteUploads(null);
+        awaitIdle(10_000);
+
+        // Verify both nodes computed values
+        tm.begin();
+        List<ValueEntity> keyValues = ValueEntity.find("node.id", extractKeyId).list();
+        assertFalse(keyValues.isEmpty(), "extractKey should have computed values after recovery");
+        assertEquals("k1", keyValues.get(0).data.asText());
+
+        List<ValueEntity> valValues = ValueEntity.find("node.id", extractValueId).list();
+        assertFalse(valValues.isEmpty(), "extractValue should have computed values after recovery");
+        assertEquals("v1", valValues.get(0).data.asText());
+
+        // Verify tracking completed
+        UploadProcessingEntity updatedTracking = UploadProcessingEntity.find("rootValueId", rootValueId).firstResult();
+        assertTrue(updatedTracking.completed, "Tracking record should be marked completed after recovery");
+        tm.commit();
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/WorkQueueRaceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/WorkQueueRaceTest.java
@@ -8,7 +8,6 @@ import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
-import io.hyperfoil.tools.h5m.entity.work.Work;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.TransactionManager;
@@ -100,9 +99,8 @@ public class WorkQueueRaceTest extends FreshDb {
     }
 
     private void assertNoRaceConditionSymptoms() {
-        long remainingWork = Work.count();
-        assertEquals(0, remainingWork,
-                remainingWork + " Work items stuck in DB — this indicates work was " +
+        assertTrue(workService.isIdle(),
+                "Work queue is not idle -- this indicates work was " +
                 "queued but never successfully processed. See #50");
 
         long valueCount = ValueEntity.count();
@@ -148,16 +146,16 @@ public class WorkQueueRaceTest extends FreshDb {
 
     private void awaitWorkQueue(long timeoutMs) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeoutMs;
-        // Require both queue-idle AND no persisted Work rows for several consecutive
-        // checks. The Work.count() gate catches the afterCompletion gap where the
-        // queue is briefly idle between a parent work completing and its cascade
-        // children being enqueued after the transaction commits.
+        // Require queue-idle for several consecutive checks. The multiple-check
+        // gate catches the afterCompletion gap where the queue is briefly idle
+        // between a parent work completing and its cascade children being enqueued
+        // after the transaction commits.
         int stableChecks = 0;
         while (stableChecks < 5) {
             if (System.currentTimeMillis() > deadline) {
                 fail("Work queue drain timed out after " + timeoutMs + "ms");
             }
-            if (workService.isIdle() && Work.count() == 0) {
+            if (workService.isIdle()) {
                 stableChecks++;
             } else {
                 stableChecks = 0;


### PR DESCRIPTION
## Summary

Remove Work persistence from the hot path — Work items exist only in memory, eliminating orphaned DB rows from concurrent worker duplicate rejection. Upload returns a `CompletableFuture<Void>` for per-upload completion tracking.

## Key Changes

- **WorkService.create()**: No `em.merge/em.flush` — Work is never persisted to the DB. Only pre-computes ancestor caches for work queue sort.
- **WorkService.execute()**: Uses source values directly from the Work object (data already in memory) instead of reloading from DB. Uses `Hibernate.isPropertyInitialized()` to detect if data needs loading (fallback for tests calling execute() directly). Active nodes are still reloaded for lazy `sources` access.
- **UploadTracker**: `AtomicInteger` counter + `CompletableFuture` per upload, handles success, failure, early return, and rejected duplicates
- **FolderService.upload()**: Returns `CompletableFuture<Void>`, uses `QuarkusTransaction.requiringNew()` to avoid `@Transactional` + `CompletionStage` deadlock
- **UploadProcessingEntity**: Lightweight crash recovery — tracks whether each upload completed. On startup, incomplete uploads are re-triggered.
- **LoadLegacyRuns**: Batched uploads with `CompletableFuture.allOf()`

## Benchmark: 20 rhivos runs, core=4

| Metric | Main | This branch |
|--------|------|-------------|
| **Import time** | **330s** | **308s (-7%)** |
| Work items left in DB | 27 orphans | 0 |
| Values | 8,700 | 8,700 |
| Value edges | 9,740 | 9,740 |
| Tracking records | N/A | 20/20 completed |

The 7% speedup comes from keeping source value JSON data in memory through the work queue instead of round-tripping through PostgreSQL JSONB (serialize → store → load → deserialize). CPU profiling showed JSON deserialization (`DatabaseJsonFormatMapper.fromString`) was the #1 hotspot at ~2000 samples.

## Optimization Progression

| Step | Time | vs Main |
|------|------|---------|
| Initial (sequential .join()) | 381s | +15% |
| Batched `allOf()` | 358s | +8% |
| Remove unnecessary `Hibernate.initialize()` | 345s | +5% |
| Skip source value DB reload | **308s** | **-7%** |

## Trade-offs

**Positives:**
- 7% faster than main for rhivos import
- Zero orphaned Work rows (vs 27 on main with core=4)
- Per-upload `CompletableFuture` — no more polling `isIdle()` with Thread.sleep
- Fewer DB operations per work item (no persist/find/delete cycle, no source value reload)
- Crash recovery via `UploadProcessingEntity`

**Negatives:**
- No per-work-item crash recovery (entire upload is re-processed)
- `QuarkusTransaction.requiringNew()` instead of `@Transactional` on `upload()` is less obvious
- Source values held in memory longer (through the work queue lifetime)