### PR TITLE
Issue 105 views phase5b

### DIFF
--- a/src/main/webui/src/app/components/DataTab.tsx
+++ b/src/main/webui/src/app/components/DataTab.tsx
@@ -1,8 +1,11 @@
 import type { View, ViewComponent } from '@client/types.gen.ts';
 
+import { ViewConfigModal } from '@app/components/ViewConfigModal';
 import {
+  Button,
   DataTable,
   Dropdown,
+  ErrorBoundary,
   InlineLoading,
   SkeletonText,
   Table,
@@ -14,7 +17,7 @@ import {
 } from '@carbon/react';
 import { getViewDataOptions, getViewsOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 
 function formatCellValue(value: unknown): string {
   if (value == null) return '';
@@ -80,24 +83,26 @@ const ViewDataTable = ({
   );
 };
 
-export const DataTab = ({ folderName }: { folderName: string }) => {
+export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: number }) => {
   const { data: views, isLoading: viewsLoading } = useQuery(
     getViewsOptions({ path: { name: folderName } }),
   );
   const [selectedViewId, setSelectedViewId] = useState<number | null>(null);
+  const [configModalOpen, setConfigModalOpen] = useState(false);
+  const [editingView, setEditingView] = useState<View | null>(null);
 
-  const selectedView = useMemo(() => {
+  const selectedView = useMemo((): View | null => {
     if (!views || views.length === 0) return null;
     if (selectedViewId != null) {
-      return views.find((v: View) => v.id === selectedViewId) ?? views[0];
+      return views.find((v: View) => v.id === selectedViewId) ?? views[0] ?? null;
     }
     // Prefer the "Default" view if it has components, otherwise pick the first view with components
-    const defaultView = views.find((v: View) => v.name === 'Default');
+    const defaultView = views.find((v: View) => v.name === 'Default') ?? null;
     if (defaultView && defaultView.components && defaultView.components.length > 0) {
       return defaultView;
     }
-    const viewWithComponents = views.find((v: View) => v.components && v.components.length > 0);
-    return viewWithComponents ?? defaultView ?? views[0];
+    const viewWithComponents = views.find((v: View) => v.components && v.components.length > 0) ?? null;
+    return viewWithComponents ?? defaultView ?? views[0] ?? null;
   }, [views, selectedViewId]);
 
   if (viewsLoading) return <SkeletonText paragraph={true} lineCount={3} />;
@@ -110,22 +115,49 @@ export const DataTab = ({ folderName }: { folderName: string }) => {
 
   return (
     <div>
-      <div style={{ marginBottom: 'var(--cds-spacing-05)', maxWidth: '300px' }}>
-        <Dropdown
-          id="view-selector"
-          titleText="View"
-          label="Select a view"
-          items={dropdownItems}
-          selectedItem={selectedView ? { id: String(selectedView.id), text: selectedView.name } : undefined}
-          itemToString={(item: { id: string; text: string }) => item?.text ?? ''}
-          onChange={({ selectedItem }: { selectedItem: { id: string; text: string } }) => {
-            setSelectedViewId(Number(selectedItem.id));
-          }}
-        />
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 'var(--cds-spacing-03)', marginBottom: 'var(--cds-spacing-05)' }}>
+        <div style={{ maxWidth: '300px', flex: 1 }}>
+          <Dropdown
+            id="view-selector"
+            titleText="View"
+            label="Select a view"
+            items={dropdownItems}
+            selectedItem={selectedView ? { id: String(selectedView.id), text: selectedView.name } : undefined}
+            itemToString={(item: { id: string; text: string }) => item?.text ?? ''}
+            onChange={({ selectedItem }: { selectedItem: { id: string; text: string } | null }) => {
+              setSelectedViewId(selectedItem ? Number(selectedItem.id) : null);
+            }}
+          />
+        </div>
+        <Button
+          kind="ghost"
+          size="md"
+          onClick={() => { setEditingView(selectedView); setConfigModalOpen(true); }}
+        >
+          Configure
+        </Button>
+        <Button
+          kind="ghost"
+          size="md"
+          onClick={() => { setEditingView(null); setConfigModalOpen(true); }}
+        >
+          New View
+        </Button>
       </div>
       {selectedView && (
         <ViewDataTable folderName={folderName} view={selectedView} />
       )}
+      <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load modal" />}>
+        <Suspense fallback={<SkeletonText paragraph={true} lineCount={3} />}>
+          <ViewConfigModal
+            open={configModalOpen}
+            onClose={() => setConfigModalOpen(false)}
+            folderName={folderName}
+            groupId={groupId}
+            view={editingView}
+          />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   );
 };

--- a/src/main/webui/src/app/components/ViewConfigModal.tsx
+++ b/src/main/webui/src/app/components/ViewConfigModal.tsx
@@ -1,0 +1,166 @@
+import type { Node as ApiNode, View, ViewComponent } from '@client/types.gen.ts';
+
+import {
+  Button,
+  ComposedModal,
+  FilterableMultiSelect,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from '@carbon/react';
+import { byIdOptions } from '@client/@tanstack/react-query.gen.ts';
+import { ViewService } from '@client/sdk.gen.ts';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useState } from 'react';
+
+interface ViewConfigModalProps {
+  open: boolean;
+  onClose: () => void;
+  folderName: string;
+  groupId: number;
+  view?: View | null;
+}
+
+interface NodeItem {
+  id: string;
+  text: string;
+  nodeId: number;
+}
+
+export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: ViewConfigModalProps) => {
+  const queryClient = useQueryClient();
+  const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
+  const isEditing = view != null && view.id != null;
+  const isDefault = view?.name === 'Default';
+
+  const [viewName, setViewName] = useState(view?.name ?? '');
+  const [selectedNodes, setSelectedNodes] = useState<NodeItem[]>([]);
+
+  // Initialize from existing view when editing
+  useEffect(() => {
+    if (view) {
+      setViewName(view.name);
+      const items = (view.components ?? []).map((c: ViewComponent) => ({
+        id: String(c.nodeId),
+        text: c.headerName ?? c.nodeName ?? '',
+        nodeId: c.nodeId!,
+      }));
+      setSelectedNodes(items);
+    } else {
+      setViewName('');
+      setSelectedNodes([]);
+    }
+  }, [view]);
+
+  // Available nodes for the multi-select (exclude detection nodes)
+  const availableNodes: NodeItem[] = (nodeGroup.sources ?? [])
+    .filter((n: ApiNode) => !['FIXED_THRESHOLD', 'RELATIVE_DIFFERENCE', 'EDIVISIVE'].includes(n.type ?? ''))
+    .map((n: ApiNode) => ({
+      id: String(n.id),
+      text: n.name ?? '',
+      nodeId: n.id!,
+    }));
+
+  const createMutation = useMutation({
+    mutationFn: (data: View) =>
+      ViewService.createView({
+        path: { name: folderName },
+        body: data,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      onClose();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: View) =>
+      ViewService.updateView({
+        path: { name: folderName, viewId: view!.id! },
+        body: data,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      onClose();
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () =>
+      ViewService.deleteView({
+        path: { name: folderName, viewId: view!.id! },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      onClose();
+    },
+  });
+
+  const handleSave = useCallback(() => {
+    const components: ViewComponent[] = selectedNodes.map((node, idx) => ({
+      nodeId: node.nodeId,
+      headerName: node.text,
+      headerOrder: idx,
+    }));
+
+    const viewData: View = {
+      name: viewName,
+      components,
+    };
+
+    if (isEditing) {
+      updateMutation.mutate(viewData);
+    } else {
+      createMutation.mutate(viewData);
+    }
+  }, [viewName, selectedNodes, isEditing, createMutation, updateMutation]);
+
+  const handleDelete = useCallback(() => {
+    if (isEditing && !isDefault && window.confirm('Delete this view?')) {
+      deleteMutation.mutate();
+    }
+  }, [isEditing, isDefault, deleteMutation]);
+
+  const isSaving = createMutation.isPending || updateMutation.isPending;
+  const canSave = viewName.trim().length > 0 && selectedNodes.length > 0;
+
+  return (
+    <ComposedModal open={open} onClose={onClose} size="lg">
+      <ModalHeader title={isEditing ? `Edit View: ${view?.name}` : 'Create View'} />
+      <ModalBody style={{ minHeight: '24rem', overflow: 'visible' }}>
+        <TextInput
+          id="view-name"
+          labelText="View name"
+          value={viewName}
+          onChange={(e) => setViewName(e.target.value)}
+          disabled={isDefault}
+          style={{ marginBottom: 'var(--cds-spacing-05)' }}
+        />
+        <FilterableMultiSelect
+          id="node-selector"
+          titleText="Select nodes to display as columns"
+          items={availableNodes}
+          itemToString={(item: NodeItem) => item?.text ?? ''}
+          initialSelectedItems={selectedNodes}
+          onChange={({ selectedItems }: { selectedItems: NodeItem[] }) => {
+            setSelectedNodes(selectedItems);
+          }}
+        />
+      </ModalBody>
+      <ModalFooter>
+        {isEditing && !isDefault && (
+          <Button kind="danger" onClick={handleDelete} disabled={deleteMutation.isPending}>
+            Delete
+          </Button>
+        )}
+        <Button kind="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button kind="primary" onClick={handleSave} disabled={!canSave || isSaving}>
+          {isSaving ? 'Saving...' : 'Save'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -82,8 +82,8 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
       </TabList>
       <TabPanels>
         <TabPanel>
-          {folder.name ? (
-            <DataTab folderName={folder.name} />
+          {folder.name && folder.groupId != null ? (
+            <DataTab folderName={folder.name} groupId={folder.groupId} />
           ) : (
             <p>Folder name not available</p>
           )}

--- a/src/main/webui/test/components/DataTab.test.tsx
+++ b/src/main/webui/test/components/DataTab.test.tsx
@@ -1,0 +1,243 @@
+import type { View } from '@client/types.gen.ts';
+
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// jsdom doesn't have matchMedia or ResizeObserver — Carbon components need them
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const mockViews: View[] = [
+  {
+    id: 1,
+    name: 'Default',
+    folderId: 1,
+    components: [
+      { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+      { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Summary',
+    folderId: 1,
+    components: [
+      { id: 3, nodeId: 2, nodeName: 'cpu', headerName: 'CPU Usage', headerOrder: 0 },
+    ],
+  },
+];
+
+const emptyDefaultView: View = {
+  id: 1,
+  name: 'Default',
+  folderId: 1,
+  components: [],
+};
+
+const mockViewData = [
+  { cpu: 42, mem: 1024 },
+  { cpu: 55, mem: 2048 },
+];
+
+const mockNodeGroup = {
+  id: 1,
+  name: 'test-group',
+  root: { id: 1, name: 'root', type: 'ROOT', sources: [] },
+  sources: [
+    { id: 2, name: 'cpu', type: 'JQ', operation: '.cpu', sources: [] },
+    { id: 3, name: 'mem', type: 'JQ', operation: '.mem', sources: [] },
+  ],
+};
+
+vi.mock('@client/@tanstack/react-query.gen.ts', () => ({
+  getViewsOptions: () => ({
+    queryKey: ['getViews'],
+    queryFn: () => mockViews,
+  }),
+  getViewDataOptions: () => ({
+    queryKey: ['getViewData'],
+    queryFn: () => mockViewData,
+  }),
+  byIdOptions: () => ({
+    queryKey: ['byId'],
+    queryFn: () => mockNodeGroup,
+  }),
+}));
+
+vi.mock('@client/sdk.gen.ts', () => ({
+  ViewService: {
+    createView: vi.fn().mockResolvedValue({ data: {} }),
+    updateView: vi.fn().mockResolvedValue({ data: {} }),
+    deleteView: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+const { DataTab } = await import('@app/components/DataTab');
+const { createTestQueryClient, renderWithProviders } = await import('../test-utils');
+
+function renderDataTab(views: View[] = mockViews, viewData: unknown[] = mockViewData) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(['getViews'], views);
+  queryClient.setQueryData(['getViewData'], viewData);
+  queryClient.setQueryData(['byId'], mockNodeGroup);
+
+  return renderWithProviders(
+    <DataTab folderName="test-folder" groupId={1} />,
+    { queryClient },
+  );
+}
+
+describe('<DataTab />', () => {
+  it('renders view selector dropdown with view names', async () => {
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Default')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders Configure and New View buttons', async () => {
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Configure')).toBeDefined();
+      expect(screen.getByText('New View')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders data table with column headers from view components', async () => {
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('CPU')).toBeDefined();
+      expect(screen.getByText('Memory')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders data table with cell values', async () => {
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('42')).toBeDefined();
+      expect(screen.getByText('1024')).toBeDefined();
+      expect(screen.getByText('55')).toBeDefined();
+      expect(screen.getByText('2048')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('shows "No views configured" when views list is empty', async () => {
+    renderDataTab([]);
+
+    await waitFor(() => {
+      expect(screen.getByText('No views configured')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('shows "No data available" when view data is empty', async () => {
+    renderDataTab(mockViews, []);
+
+    await waitFor(() => {
+      expect(screen.getByText('No data available')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('prefers Default view with components on initial render', async () => {
+    renderDataTab();
+
+    // Default view should be selected, showing its columns
+    await waitFor(() => {
+      expect(screen.getByText('CPU')).toBeDefined();
+      expect(screen.getByText('Memory')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('falls back to first view with components when Default has none', async () => {
+    const views: View[] = [
+      emptyDefaultView,
+      {
+        id: 2,
+        name: 'Summary',
+        folderId: 1,
+        components: [
+          { id: 3, nodeId: 2, nodeName: 'cpu', headerName: 'CPU Usage', headerOrder: 0 },
+        ],
+      },
+    ];
+
+    renderDataTab(views);
+
+    await waitFor(() => {
+      expect(screen.getByText('CPU Usage')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('opens config modal when Configure button is clicked', async () => {
+    const user = userEvent.setup();
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Configure')).toBeDefined();
+    });
+
+    await user.click(screen.getByText('Configure'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit View: Default')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('opens config modal in create mode when New View is clicked', async () => {
+    const user = userEvent.setup();
+    renderDataTab();
+
+    await waitFor(() => {
+      expect(screen.getByText('New View')).toBeDefined();
+    });
+
+    await user.click(screen.getByText('New View'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Create View')).toBeDefined();
+    });
+
+    cleanup();
+  });
+});

--- a/src/main/webui/test/components/ViewConfigModal.test.tsx
+++ b/src/main/webui/test/components/ViewConfigModal.test.tsx
@@ -1,0 +1,283 @@
+import type { View } from '@client/types.gen.ts';
+
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// jsdom doesn't have matchMedia or ResizeObserver — Carbon components need them
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const mockNodeGroup = {
+  id: 1,
+  name: 'test-group',
+  root: { id: 1, name: 'root', type: 'ROOT', sources: [] },
+  sources: [
+    { id: 2, name: 'cpu', type: 'JQ', operation: '.cpu', sources: [] },
+    { id: 3, name: 'mem', type: 'JQ', operation: '.mem', sources: [] },
+    { id: 4, name: 'cpu_ft', type: 'FIXED_THRESHOLD', sources: [] },
+    { id: 5, name: 'cpu_rd', type: 'RELATIVE_DIFFERENCE', sources: [] },
+  ],
+};
+
+const mockCreateView = vi.fn().mockResolvedValue({ data: {} });
+const mockUpdateView = vi.fn().mockResolvedValue({ data: {} });
+const mockDeleteView = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock('@client/@tanstack/react-query.gen.ts', () => ({
+  byIdOptions: () => ({
+    queryKey: ['byId'],
+    queryFn: () => mockNodeGroup,
+  }),
+}));
+
+vi.mock('@client/sdk.gen.ts', () => ({
+  ViewService: {
+    createView: (...args: unknown[]) => mockCreateView(...args),
+    updateView: (...args: unknown[]) => mockUpdateView(...args),
+    deleteView: (...args: unknown[]) => mockDeleteView(...args),
+  },
+}));
+
+const { ViewConfigModal } = await import('@app/components/ViewConfigModal');
+const { createTestQueryClient, renderWithProviders } = await import('../test-utils');
+
+function renderModal(props: {
+  open?: boolean;
+  onClose?: () => void;
+  view?: View | null;
+}) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryData(['byId'], mockNodeGroup);
+
+  return renderWithProviders(
+    <ViewConfigModal
+      open={props.open ?? true}
+      onClose={props.onClose ?? vi.fn()}
+      folderName="test-folder"
+      groupId={1}
+      view={props.view ?? null}
+    />,
+    { queryClient },
+  );
+}
+
+describe('<ViewConfigModal />', () => {
+  beforeEach(() => {
+    mockCreateView.mockClear();
+    mockUpdateView.mockClear();
+    mockDeleteView.mockClear();
+  });
+
+  it('renders Create View title when no view is provided', async () => {
+    renderModal({});
+
+    await waitFor(() => {
+      expect(screen.getByText('Create View')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders Edit View title when editing an existing view', async () => {
+    const view: View = {
+      id: 1,
+      name: 'My View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit View: My View')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders view name input', async () => {
+    renderModal({});
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('View name')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('renders node selector with non-detection nodes only', async () => {
+    renderModal({});
+
+    await waitFor(() => {
+      expect(screen.getByText('Select nodes to display as columns')).toBeDefined();
+    });
+
+    // Detection nodes (FIXED_THRESHOLD, RELATIVE_DIFFERENCE) should be excluded
+    // The multi-select dropdown shows available items when opened
+    // We verify the component renders — detailed item filtering is an integration concern
+
+    cleanup();
+  });
+
+  it('renders Save and Cancel buttons', async () => {
+    renderModal({});
+
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeDefined();
+      expect(screen.getByText('Cancel')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('Save button is disabled when view name is empty', async () => {
+    renderModal({});
+
+    await waitFor(() => {
+      const saveButton = screen.getByText('Save');
+      expect(saveButton.closest('button')?.disabled).toBe(true);
+    });
+
+    cleanup();
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderModal({ onClose });
+
+    await waitFor(() => {
+      expect(screen.getByText('Cancel')).toBeDefined();
+    });
+
+    await user.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('disables view name input for Default view', async () => {
+    const defaultView: View = {
+      id: 1,
+      name: 'Default',
+      components: [],
+    };
+
+    renderModal({ view: defaultView });
+
+    await waitFor(() => {
+      const input = screen.getByLabelText('View name') as HTMLInputElement;
+      expect(input.disabled).toBe(true);
+    });
+
+    cleanup();
+  });
+
+  it('does not show Delete button for Default view', async () => {
+    const defaultView: View = {
+      id: 1,
+      name: 'Default',
+      components: [],
+    };
+
+    renderModal({ view: defaultView });
+
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeDefined();
+    });
+
+    expect(screen.queryByText('Delete')).toBeNull();
+
+    cleanup();
+  });
+
+  it('shows Delete button for non-Default views when editing', async () => {
+    const view: View = {
+      id: 2,
+      name: 'Custom View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      expect(screen.getByText('Delete')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('does not show Delete button when creating a new view', async () => {
+    renderModal({ view: null });
+
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeDefined();
+    });
+
+    expect(screen.queryByText('Delete')).toBeNull();
+
+    cleanup();
+  });
+
+  it('populates view name from existing view when editing', async () => {
+    const view: View = {
+      id: 2,
+      name: 'Custom View',
+      components: [],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      const input = screen.getByLabelText('View name') as HTMLInputElement;
+      expect(input.value).toBe('Custom View');
+    });
+
+    cleanup();
+  });
+
+  it('starts with empty view name when creating', async () => {
+    renderModal({ view: null });
+
+    await waitFor(() => {
+      const input = screen.getByLabelText('View name') as HTMLInputElement;
+      expect(input.value).toBe('');
+    });
+
+    cleanup();
+  });
+
+  it('hides modal content when open is false', () => {
+    renderModal({ open: false });
+
+    // Carbon ComposedModal renders to DOM but hides via CSS when open=false
+    // The modal container should not have the 'is-visible' class
+    const modal = screen.getByText('Create View').closest('.cds--modal');
+    expect(modal?.classList.contains('is-visible')).toBe(false);
+
+    cleanup();
+  });
+});


### PR DESCRIPTION
ViewConfigModal component:
- Create new views or edit existing ones
- View name text input (disabled for Default view)
- FilterableMultiSelect node picker from folder's group nodes (excludes detection nodes: ft, rd, ed)
- Large modal with room for node selection dropdown
- Save creates/updates via REST, Delete with confirmation (disabled for Default view)
- Invalidates view queries on success

DataTab changes:
- Configure button opens modal for current view
- New View button opens modal for creating a new view
- Accepts groupId prop for node group query

FolderPage: passes groupId to DataTab

Frontend tests (24 new tests):
- DataTab.test.tsx (10): view selector, data table, buttons, empty states, default view selection, modal open modes
- ViewConfigModal.test.tsx (14): create/edit titles, name input, Save/Cancel/Delete buttons, Default view restrictions

Also fixes TS errors: explicit View | null return type on useMemo, nullable selectedItem in onChange, removed unused imports