### PR TITLE
Skip dedup loop when calculateValues() produces no results

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -268,6 +268,11 @@ public class WorkService implements WorkServiceInterface {
                 List<ValueEntity> thisIteration = nodeService.calculateValues(node, sourceValues);
                 calculated.addAll(thisIteration);
             }
+            if (calculated.isEmpty()) {
+                // Node produced no values (e.g., JQ expression didn't match the data).
+                // Skip the dedup loop and cascade — no DB queries needed.
+                return;
+            }
             List<ValueEntity> newOrUpdated = new ArrayList<>();
             for(ValueEntity v : sourceValues) {
                 for(NodeEntity activeNode : activeNodes){


### PR DESCRIPTION
When a node's expression doesn't match the uploaded data (e.g., a JQ path that doesn't exist in the JSON), calculateValues() returns an empty list. Previously, execute() still entered the nested sourceValues x activeNodes loop calling getDescendantValueByPath() for each combination — unnecessary DB queries with no effect.

Now returns early when calculated is empty, skipping the dedup queries and cascade work creation.