### PR TITLE
Fix isNullEmptyOrIdentityFunction false matches (issue #78)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
@@ -139,9 +139,13 @@ public class JsNode extends NodeEntity {
         return
             input==null ||
             input.isEmpty() ||
+            // arrow expression: value => value
             input.matches("\\s*\\(?\\s*(?<arg>[a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)?\\s*=>\\s*\\k<arg>\\s*") ||
-            input.matches("\\s*\\(?\\s*(?<arg>[a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)?\\s*=>.*?return\\s+\\k<arg>.*") ||
-            input.matches("\\s*function\\*?\\s*\\w*\\s*\\(\\s*(?<arg>[a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)\\s*\\{.*?return\\s+\\k<arg>.*")
+            // arrow block: value => { return value; } — require return <arg> followed by ; or }
+            // to avoid false matches like: value => { return value["results"].reduce(...) }
+            input.matches("\\s*\\(?\\s*(?<arg>[a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)?\\s*=>.*?return\\s+\\k<arg>\\s*[;}].*") ||
+            // traditional function: function(value) { return value; }
+            input.matches("\\s*function\\*?\\s*\\w*\\s*\\(\\s*(?<arg>[a-zA-Z_$][a-zA-Z0-9_$]*)\\s*\\)\\s*\\{.*?return\\s+\\k<arg>\\s*[;}].*")
             ;
     }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
@@ -27,6 +27,27 @@ public class JsNodeTest {
         assertTrue(JsNode.isNullEmptyOrIdentityFunction("( args ) => args"));
         assertTrue(JsNode.isNullEmptyOrIdentityFunction("( args ) => { console.log(args); return args; }"));
         assertTrue(JsNode.isNullEmptyOrIdentityFunction("function( args ){ console.log(args); return args; }"));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction(null));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction(""));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction("value => value"));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction("value => { return value; }"));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction("function(value) { return value; }"));
+        assertTrue(JsNode.isNullEmptyOrIdentityFunction("function fn(value) { return value; }"));
+    }
+
+    @Test
+    public void isNullEmptyOrIdentityFunction_false_for_transforms(){
+        // Property access after return <arg> — not identity (issue #78)
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => { return value[\"results\"].reduce((a,b) => a+b) }"));
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => { return value.foo }"));
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => { return value[\"key\"] }"));
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("function(value) { return value.foo; }"));
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("function(value) { return value[\"results\"]; }"));
+        // Conditional return — not identity
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => { if (value[\"workload\"] != \"x\") return null; return value[\"foo\"] }"));
+        // Actual transformation
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => value.split(',')"));
+        assertFalse(JsNode.isNullEmptyOrIdentityFunction("value => value + 1"));
     }
 
     @Test


### PR DESCRIPTION
The regex for detecting identity functions (e.g., value => value) falsely matched functions that transform the input when 'return <arg>' appeared followed by property access like ['results'] or .foo:

  value => { return value["results"].reduce((a,b) => a+b) }

was incorrectly classified as identity because 'return value' matched the backreference, and .* consumed the rest.

Fix: require 'return <arg>' to be followed by ; or } (statement terminator) rather than allowing arbitrary trailing content. This correctly rejects property access, method calls, and arithmetic on the returned parameter.

Added test cases for false-positive transforms from the issue.