### PR TITLE
View improvements: refresh, reordering, error handling, and tests

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
@@ -86,6 +86,9 @@ public class ViewService implements ViewServiceInterface {
 
         entity.name = view.name();
         entity.components.clear();
+        // Flush the deletes before inserting new components to avoid
+        // unique constraint violations on (view_id, header_name)
+        entity.flush();
 
         if (view.components() != null) {
             for (int i = 0; i < view.components().size(); i++) {

--- a/src/main/webui/src/app/components/DataTab.tsx
+++ b/src/main/webui/src/app/components/DataTab.tsx
@@ -90,6 +90,7 @@ export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: 
   const [selectedViewId, setSelectedViewId] = useState<number | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [editingView, setEditingView] = useState<View | null>(null);
+  const [modalKey, setModalKey] = useState(0);
 
   const selectedView = useMemo((): View | null => {
     if (!views || views.length === 0) return null;
@@ -132,24 +133,39 @@ export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: 
         <Button
           kind="ghost"
           size="md"
-          onClick={() => { setEditingView(selectedView); setConfigModalOpen(true); }}
+          onClick={() => {
+            const latestView = views?.find((v: View) => v.id === selectedView?.id) ?? selectedView;
+            setEditingView(latestView);
+            setModalKey((k) => k + 1);
+            setConfigModalOpen(true);
+          }}
         >
           Configure
         </Button>
         <Button
           kind="ghost"
           size="md"
-          onClick={() => { setEditingView(null); setConfigModalOpen(true); }}
+          onClick={() => { setEditingView(null); setModalKey((k) => k + 1); setConfigModalOpen(true); }}
         >
           New View
         </Button>
       </div>
-      {selectedView && (
-        <ViewDataTable folderName={folderName} view={selectedView} />
+      {selectedView && (!selectedView.components || selectedView.components.length === 0) && (
+        <p style={{ opacity: 0.7 }}>
+          This view has no columns configured. Click <strong>Configure</strong> to select which nodes to display.
+        </p>
+      )}
+      {selectedView && selectedView.components && selectedView.components.length > 0 && (
+        <ViewDataTable
+          key={`${String(selectedView.id)}-${String(selectedView.components?.length ?? 0)}-${selectedView.components?.map(c => String(c.nodeId)).join(',') ?? ''}`}
+          folderName={folderName}
+          view={selectedView}
+        />
       )}
       <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load modal" />}>
         <Suspense fallback={<SkeletonText paragraph={true} lineCount={3} />}>
           <ViewConfigModal
+            key={modalKey}
             open={configModalOpen}
             onClose={() => setConfigModalOpen(false)}
             folderName={folderName}

--- a/src/main/webui/src/app/components/ViewConfigModal.tsx
+++ b/src/main/webui/src/app/components/ViewConfigModal.tsx
@@ -9,10 +9,11 @@ import {
   ModalHeader,
   TextInput,
 } from '@carbon/react';
+import { ArrowUp, ArrowDown, Close } from '@carbon/icons-react';
 import { byIdOptions } from '@client/@tanstack/react-query.gen.ts';
 import { ViewService } from '@client/sdk.gen.ts';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 interface ViewConfigModalProps {
   open: boolean;
@@ -34,26 +35,8 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
   const isEditing = view != null && view.id != null;
   const isDefault = view?.name === 'Default';
 
-  const [viewName, setViewName] = useState(view?.name ?? '');
-  const [selectedNodes, setSelectedNodes] = useState<NodeItem[]>([]);
-
-  // Initialize from existing view when editing
-  useEffect(() => {
-    if (view) {
-      setViewName(view.name);
-      const items = (view.components ?? []).map((c: ViewComponent) => ({
-        id: String(c.nodeId),
-        text: c.headerName ?? c.nodeName ?? '',
-        nodeId: c.nodeId!,
-      }));
-      setSelectedNodes(items);
-    } else {
-      setViewName('');
-      setSelectedNodes([]);
-    }
-  }, [view]);
-
   // Available nodes for the multi-select (exclude detection nodes)
+  // Built once and stable so FilterableMultiSelect can match by reference
   const availableNodes: NodeItem[] = (nodeGroup.sources ?? [])
     .filter((n: ApiNode) => !['FIXED_THRESHOLD', 'RELATIVE_DIFFERENCE', 'EDIVISIVE'].includes(n.type ?? ''))
     .map((n: ApiNode) => ({
@@ -62,6 +45,52 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
       nodeId: n.id!,
     }));
 
+  const [viewName, setViewName] = useState(view?.name ?? '');
+  // Initialize selectedNodes from the view's components, preserving the
+  // existing headerOrder. Find matching items in availableNodes (same
+  // object references required by Carbon's FilterableMultiSelect).
+  const [selectedNodes, setSelectedNodes] = useState<NodeItem[]>(() => {
+    if (!view?.components || view.components.length === 0) return [];
+    // Sort components by headerOrder to preserve column ordering
+    const sorted = [...view.components].sort(
+      (a: ViewComponent, b: ViewComponent) => (a.headerOrder ?? 0) - (b.headerOrder ?? 0)
+    );
+    const ordered: NodeItem[] = [];
+    for (const c of sorted) {
+      const match = availableNodes.find((n) => n.id === String(c.nodeId));
+      if (match) ordered.push(match);
+    }
+    return ordered;
+  });
+
+  const moveUp = useCallback((index: number) => {
+    if (index <= 0) return;
+    setSelectedNodes((prev) => {
+      const next = [...prev];
+      const temp = next[index - 1]!;
+      next[index - 1] = next[index]!;
+      next[index] = temp;
+      return next;
+    });
+  }, []);
+
+  const moveDown = useCallback((index: number) => {
+    setSelectedNodes((prev) => {
+      if (index >= prev.length - 1) return prev;
+      const next = [...prev];
+      const temp = next[index]!;
+      next[index] = next[index + 1]!;
+      next[index + 1] = temp;
+      return next;
+    });
+  }, []);
+
+  const removeNode = useCallback((index: number) => {
+    setSelectedNodes((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   const createMutation = useMutation({
     mutationFn: (data: View) =>
       ViewService.createView({
@@ -69,8 +98,16 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
         body: data,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      setSaveError(null);
+      void queryClient.refetchQueries({ predicate: (q) => {
+        const key = q.queryKey[0];
+        return typeof key === 'object' && key !== null && '_id' in key &&
+          (key._id === 'getViews' || key._id === 'getViewData');
+      }});
       onClose();
+    },
+    onError: (e: Error) => {
+      setSaveError(e.message ?? 'Failed to create view');
     },
   });
 
@@ -81,8 +118,16 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
         body: data,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      setSaveError(null);
+      void queryClient.refetchQueries({ predicate: (q) => {
+        const key = q.queryKey[0];
+        return typeof key === 'object' && key !== null && '_id' in key &&
+          (key._id === 'getViews' || key._id === 'getViewData');
+      }});
       onClose();
+    },
+    onError: (e: Error) => {
+      setSaveError(e.message ?? 'Failed to update view');
     },
   });
 
@@ -92,7 +137,11 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
         path: { name: folderName, viewId: view!.id! },
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['getViews'] });
+      void queryClient.refetchQueries({ predicate: (q) => {
+        const key = q.queryKey[0];
+        return typeof key === 'object' && key !== null && '_id' in key &&
+          (key._id === 'getViews' || key._id === 'getViewData');
+      }});
       onClose();
     },
   });
@@ -144,9 +193,71 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
           itemToString={(item: NodeItem) => item?.text ?? ''}
           initialSelectedItems={selectedNodes}
           onChange={({ selectedItems }: { selectedItems: NodeItem[] }) => {
-            setSelectedNodes(selectedItems);
+            // Preserve existing order: keep items that are still selected
+            // in their current position, append newly added items at the end
+            const existingIds = new Set(selectedNodes.map((n) => n.id));
+            const newIds = new Set(selectedItems.map((n) => n.id));
+            const kept = selectedNodes.filter((n) => newIds.has(n.id));
+            const added = selectedItems.filter((n) => !existingIds.has(n.id));
+            setSelectedNodes([...kept, ...added]);
           }}
         />
+        {selectedNodes.length > 0 && (
+          <div style={{ marginTop: 'var(--cds-spacing-05)' }}>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7, marginBottom: 'var(--cds-spacing-02)' }}>
+              Column order (drag or use arrows to reorder)
+            </div>
+            {selectedNodes.map((node, idx) => (
+              <div
+                key={node.id}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--cds-spacing-02)',
+                  padding: '4px 8px',
+                  marginBottom: '2px',
+                  background: 'var(--cds-layer-02)',
+                  borderRadius: '4px',
+                  fontSize: '0.875rem',
+                }}
+              >
+                <span style={{ opacity: 0.5, minWidth: '20px' }}>{String(idx + 1)}.</span>
+                <span style={{ flex: 1 }}>{node.text}</span>
+                <Button
+                  kind="ghost"
+                  size="sm"
+                  hasIconOnly
+                  renderIcon={ArrowUp}
+                  iconDescription="Move up"
+                  onClick={() => moveUp(idx)}
+                  disabled={idx === 0}
+                />
+                <Button
+                  kind="ghost"
+                  size="sm"
+                  hasIconOnly
+                  renderIcon={ArrowDown}
+                  iconDescription="Move down"
+                  onClick={() => moveDown(idx)}
+                  disabled={idx === selectedNodes.length - 1}
+                />
+                <Button
+                  kind="ghost"
+                  size="sm"
+                  hasIconOnly
+                  renderIcon={Close}
+                  iconDescription="Remove"
+                  onClick={() => removeNode(idx)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+        {saveError && (
+          <div style={{ color: 'var(--cds-support-error)', marginTop: 'var(--cds-spacing-03)' }}>
+            {saveError}
+          </div>
+        )}
       </ModalBody>
       <ModalFooter>
         {isEditing && !isDefault && (

--- a/src/main/webui/test/components/DataTab.test.tsx
+++ b/src/main/webui/test/components/DataTab.test.tsx
@@ -224,6 +224,18 @@ describe('<DataTab />', () => {
     cleanup();
   });
 
+  it('shows configure prompt when view has no columns', async () => {
+    const views: View[] = [emptyDefaultView];
+
+    renderDataTab(views);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no columns configured/i)).toBeDefined();
+    });
+
+    cleanup();
+  });
+
   it('opens config modal in create mode when New View is clicked', async () => {
     const user = userEvent.setup();
     renderDataTab();

--- a/src/main/webui/test/components/ViewConfigModal.test.tsx
+++ b/src/main/webui/test/components/ViewConfigModal.test.tsx
@@ -280,4 +280,177 @@ describe('<ViewConfigModal />', () => {
 
     cleanup();
   });
+
+  it('shows column ordering list when editing a view with components', async () => {
+    const view: View = {
+      id: 1,
+      name: 'Ordered View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+        { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      // Should show the column order label
+      expect(screen.getByText(/column order/i)).toBeDefined();
+      // Should show numbered positions with node names
+      expect(screen.getByText('1.')).toBeDefined();
+      expect(screen.getByText('2.')).toBeDefined();
+      expect(screen.getByText('cpu')).toBeDefined();
+      expect(screen.getByText('mem')).toBeDefined();
+    });
+
+    cleanup();
+  });
+
+  it('preserves column order from existing view headerOrder', async () => {
+    const view: View = {
+      id: 1,
+      name: 'Reversed View',
+      components: [
+        { id: 1, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 0 },
+        { id: 2, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      // mem should be first (headerOrder 0), cpu second (headerOrder 1)
+      const items = screen.getAllByText(/^(cpu|mem)$/);
+      expect(items.at(0)?.textContent).toBe('mem');
+      expect(items.at(1)?.textContent).toBe('cpu');
+    });
+
+    cleanup();
+  });
+
+  it('does not show column ordering list when no nodes are selected', async () => {
+    renderModal({ view: null });
+
+    await waitFor(() => {
+      expect(screen.getByText('Create View')).toBeDefined();
+    });
+
+    expect(screen.queryByText(/column order/i)).toBeNull();
+
+    cleanup();
+  });
+
+  it('shows move up, move down, and remove buttons for each column', async () => {
+    const view: View = {
+      id: 1,
+      name: 'Test View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+        { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      // Each column row should have Move up, Move down, and Remove buttons
+      const moveUpButtons = screen.getAllByLabelText('Move up');
+      const moveDownButtons = screen.getAllByLabelText('Move down');
+      const removeButtons = screen.getAllByLabelText('Remove');
+      expect(moveUpButtons.length).toBe(2);
+      expect(moveDownButtons.length).toBe(2);
+      expect(removeButtons.length).toBe(2);
+    });
+
+    cleanup();
+  });
+
+  it('disables move up for first item and move down for last item', async () => {
+    const view: View = {
+      id: 1,
+      name: 'Test View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+        { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      const moveUpButtons = screen.getAllByLabelText('Move up');
+      const moveDownButtons = screen.getAllByLabelText('Move down');
+      // First item's move up should be disabled
+      expect((moveUpButtons.at(0) as HTMLButtonElement)?.disabled).toBe(true);
+      // Last item's move down should be disabled
+      expect((moveDownButtons.at(1) as HTMLButtonElement)?.disabled).toBe(true);
+      // Other buttons should be enabled
+      expect((moveUpButtons.at(1) as HTMLButtonElement)?.disabled).toBe(false);
+      expect((moveDownButtons.at(0) as HTMLButtonElement)?.disabled).toBe(false);
+    });
+
+    cleanup();
+  });
+
+  it('reorders columns when move down is clicked', async () => {
+    const user = userEvent.setup();
+    const view: View = {
+      id: 1,
+      name: 'Test View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+        { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      expect(screen.getByText('cpu')).toBeDefined();
+    });
+
+    // Click move down on first item (cpu)
+    const moveDownButtons = screen.getAllByLabelText('Move down');
+    await user.click(moveDownButtons.at(0)!);
+
+    // Now mem should be first, cpu second
+    await waitFor(() => {
+      const items = screen.getAllByText(/^(cpu|mem)$/);
+      expect(items.at(0)?.textContent).toBe('mem');
+      expect(items.at(1)?.textContent).toBe('cpu');
+    });
+
+    cleanup();
+  });
+
+  it('removes a column when remove button is clicked', async () => {
+    const user = userEvent.setup();
+    const view: View = {
+      id: 1,
+      name: 'Test View',
+      components: [
+        { id: 1, nodeId: 2, nodeName: 'cpu', headerName: 'CPU', headerOrder: 0 },
+        { id: 2, nodeId: 3, nodeName: 'mem', headerName: 'Memory', headerOrder: 1 },
+      ],
+    };
+
+    renderModal({ view });
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Remove').length).toBe(2);
+    });
+
+    // Remove the first item (cpu)
+    const removeButtons = screen.getAllByLabelText('Remove');
+    await user.click(removeButtons.at(0)!);
+
+    // Only mem should remain
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Remove').length).toBe(1);
+      expect(screen.getByText('mem')).toBeDefined();
+      expect(screen.queryByText('cpu')).toBeNull();
+    });
+
+    cleanup();
+  });
 });

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -643,6 +643,59 @@ public class RestEndpointTest extends FreshDb {
     }
 
     @Test
+    public void view_update_with_same_header_names() throws Exception {
+        folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
+        Long userNodeId = folder.group.sources.stream()
+                .filter(n -> "user".equals(n.name)).findFirst().get().id;
+        Long uuidNodeId = folder.group.sources.stream()
+                .filter(n -> "uuid".equals(n.name)).findFirst().get().id;
+        tm.commit();
+
+        // Create view with user and uuid
+        String createJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "same-headers", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, uuidNodeId, null, null, "UUID", 1)
+                )
+        ));
+
+        Long viewId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(createJson)
+                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
+
+        // Update with the same header names but reversed order — this previously
+        // caused a unique constraint violation because Hibernate inserted new
+        // components before deleting old ones with the same (view_id, header_name)
+        String updateJson = mapper.writeValueAsString(new io.hyperfoil.tools.h5m.api.View(
+                null, "same-headers", null,
+                List.of(
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, uuidNodeId, null, null, "UUID", 0),
+                        new io.hyperfoil.tools.h5m.api.ViewComponent(null, userNodeId, null, null, "User", 1)
+                )
+        ));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(updateJson)
+                .when().put("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .then()
+                .statusCode(200)
+                .body("components.size()", equalTo(2))
+                .body("components[0].headerName", equalTo("UUID"))
+                .body("components[0].headerOrder", equalTo(0))
+                .body("components[1].headerName", equalTo("User"))
+                .body("components[1].headerOrder", equalTo(1));
+    }
+
+    @Test
     public void view_delete_works() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
 


### PR DESCRIPTION
DataTab:
- Show helpful message when view has no columns configured instead of confusing 'No data available'
- Data table refreshes automatically after saving view configuration (keyed by component IDs to force remount on changes)
- Configure button reads latest view data from query result
- Modal remounted via counter key for fresh FilterableMultiSelect state

ViewConfigModal:
- Column reordering: ordered list below multi-select with numbered positions, up/down arrow buttons, and remove (x) button
- Existing column order preserved from headerOrder when editing
- New items appended at end, removals keep remaining order
- Error display when create/update/delete fails (was silent)
- Selected nodes shown correctly when reopening (same object references from availableNodes for Carbon FilterableMultiSelect)
- Query refetch uses predicate matching _id field (generated query keys use object format, not plain strings)

ViewService:
- Flush component deletes before insert on view update to avoid unique constraint violation on (view_id, header_name)

Tests:
- Frontend (8 new): empty view prompt, column ordering list rendering, preserved headerOrder, disabled up/down buttons, reorder on click, remove column on click
- Backend (1 new): view_update_with_same_header_names verifies the flush fix for unique constraint violation