### PR TITLE
Added a new Rest end point for label Values in h5m

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ValueServiceInterface.java
@@ -48,4 +48,17 @@ public interface ValueServiceInterface {
      */
     List<Value> getNodeValues(Long nodeId);
 
+    /**
+         * Returns one row per upload for a folder, with each row containing the values of the requested nodes.
+         * groupByNodeId and sortByNodeId are always included in every row regardless of nodeIds.
+         * @param folderId Folder Id to query.
+         * @param nodeIds Node IDs to include as columns (null/empty list = all nodes).
+         * @param groupByNodeId Node whose value identifies the series (e.g. config fingerprint).
+         * @param sortByNodeId  Node whose value orders the rows (acts as X-axis).
+       */
+      List<JsonNode> getLabelValues(Long folderId,Long groupByNodeId, List<Long> nodeIds, Long sortByNodeId);
+
+      List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds, Long sortByNodeId);
+
+
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.h5m.api.FolderSummary;
 import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
+import io.hyperfoil.tools.h5m.api.svc.ValueServiceInterface;
 import io.hyperfoil.tools.yaup.json.Json;
 import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.PermitAll;
@@ -26,6 +27,9 @@ public class FolderResource {
 
     @Inject
     FolderServiceInterface folderService;
+
+    @Inject
+    ValueServiceInterface valueService;
 
     @GET
     @PermitAll
@@ -103,4 +107,17 @@ public class FolderResource {
     public Json structure(@PathParam("name") String name) {
         return folderService.structure(name);
     }
+
+    @GET
+    @Path("{id}/labelValues")
+    @PermitAll
+    @Operation(description = "Get metrics labels Values")
+    public List<JsonNode>getLabelValues(
+                    @PathParam("id") Long folderId,
+                    @QueryParam("groupById") Long groupById,
+                    @QueryParam("nodeIds") List<Long> nodeIds,
+                    @QueryParam("sortById") Long sortById)
+            {
+                return valueService.getLabelValues(folderId, groupById,nodeIds,sortById);
+            }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -3,6 +3,7 @@ package io.hyperfoil.tools.h5m.svc;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.hyperfoil.tools.h5m.api.Value;
 import io.hyperfoil.tools.h5m.api.svc.ValueServiceInterface;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
@@ -14,6 +15,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.hibernate.Session;
 import org.hibernate.query.NativeQuery;
@@ -422,6 +424,7 @@ public class ValueService implements ValueServiceInterface {
 
 
 
+
     /**
      * Returns grouped values for a node, optionally filtered to specific node IDs.
      * One row per upload, with keys being node names.
@@ -433,48 +436,7 @@ public class ValueService implements ValueServiceInterface {
     @Override
     @Transactional
     public List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds){
-        String nodeFilter = filterNodeIds != null ? "where node_id in (:nodeIds)" : "";
-        var query = em.unwrap(Session.class).createNativeQuery(
-            switch(dbKind) {
-                case "sqlite" ->
-                    """
-                    with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
-                            from value_edge ve left join value v on ve.child_id = v.id
-                            where ve.parent_id in (select id from value where node_id = :nodeId)
-                        union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data
-                            from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
-                    ), bynode as (
-                        select node_id,root_id,json_group_array(json(data)) as data
-                            from tree NODE_FILTER group by node_id,root_id order by idx
-                    )
-                    select json_group_object(n.name,json( ( case when json_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
-                        from bynode b join node n on b.node_id = n.id group by root_id;
-                    """.replace("NODE_FILTER", nodeFilter);
-                case "postgresql" ->
-                    """
-                    with recursive tree(id,node_id,root_id,idx,data) as (
-                        select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
-                            from value_edge ve left join value v on ve.child_id = v.id
-                            where ve.parent_id in (select id from value where node_id = :nodeId)
-                        union
-                        select v.id,v.node_id,t.root_id,v.idx,v.data
-                            from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
-                    ), bynode as (
-                        select node_id,root_id,jsonb_agg(to_jsonb(data)) as data
-                            from tree NODE_FILTER group by node_id,root_id,idx order by idx
-                    )
-                    select jsonb_object_agg(n.name,to_jsonb( ( case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
-                    from bynode b join node n on b.node_id = n.id group by root_id;
-                    """.replace("NODE_FILTER", nodeFilter);
-                default -> "";
-            }, JsonNode.class
-        ).setParameter("nodeId", nodeId);
-        if (filterNodeIds != null) {
-            query.setParameter("nodeIds", filterNodeIds);
-        }
-        return query.getResultList();
+        return getGroupedValues(nodeId,filterNodeIds,null);
     }
 
     @Override
@@ -482,6 +444,71 @@ public class ValueService implements ValueServiceInterface {
     public List<JsonNode> getGroupedValues(Long nodeId){
         return getGroupedValues(nodeId, null);
     }
+
+
+    @Override
+    @Transactional
+    public List<JsonNode> getGroupedValues(Long nodeId, List<Long> filterNodeIds, Long sortByNodeId) {
+        String nodeFilter = filterNodeIds != null && !filterNodeIds.isEmpty() ? "where node_id in (:nodeIds)" : "";
+        String sortCte = sortByNodeId != null ? switch (dbKind) {
+            case "sqlite"     -> "root_sort as (select root_id, min(case when typeof(json_extract(data,'$')) in ('integer','real') then cast(data as real) end) as sort_num,min(data) as sort_txt from tree where node_id = :sortNodeId group by root_id),";
+            case "postgresql" -> "root_sort as (select root_id, min(case when jsonb_typeof(data) = 'number' then (data::text)::numeric end) as sort_num, min(data::text) as sort_txt from tree where node_id = :sortNodeId group by root_id),";
+            default -> "";
+        } : "";
+        String sortJoin    = sortByNodeId != null ? "left join root_sort rs on b.root_id = rs.root_id" : "";
+        String sortGroupBy = sortByNodeId != null ? ", rs.sort_num, rs.sort_txt" : "";
+        String sortOrder   = sortByNodeId != null ? "order by rs.sort_num asc nulls last, rs.sort_txt asc" : "";
+
+        var query = em.unwrap(Session.class).createNativeQuery(
+                switch (dbKind) {
+                    case "sqlite" ->
+                            """
+                            with recursive tree(id,node_id,root_id,idx,data) as (
+                                select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
+                                    from value_edge ve left join value v on ve.child_id = v.id
+                                    where ve.parent_id in (select id from value where node_id = :nodeId)
+                                union
+                                select v.id,v.node_id,t.root_id,v.idx,v.data
+                                    from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
+                            ),
+                            SORT_CTE
+                            bynode as (
+                                select node_id,root_id,json_group_array(json(data)) as data
+                                    from tree NODE_FILTER group by node_id,root_id order by idx
+                            )
+                            select json_group_object(n.name,json((case when json_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
+                                from bynode b join node n on b.node_id = n.id SORT_JOIN group by b.root_id SORT_GROUPBY SORT_ORDER;
+                            """
+                                    .replace("NODE_FILTER", nodeFilter).replace("SORT_CTE", sortCte)
+                                    .replace("SORT_JOIN", sortJoin).replace("SORT_GROUPBY", sortGroupBy).replace("SORT_ORDER", sortOrder);
+                    case "postgresql" ->
+                            """
+                            with recursive tree(id,node_id,root_id,idx,data) as (
+                                select v.id,v.node_id,ve.parent_id as root_id,v.idx,v.data
+                                    from value_edge ve left join value v on ve.child_id = v.id
+                                    where ve.parent_id in (select id from value where node_id = :nodeId)
+                                union
+                                select v.id,v.node_id,t.root_id,v.idx,v.data
+                                    from value v join value_edge ve on v.id = ve.child_id join tree t on ve.parent_id = t.id
+                            ),
+                            SORT_CTE
+                            bynode as (
+                                select node_id,root_id,jsonb_agg(to_jsonb(data)) as data
+                                    from tree NODE_FILTER group by node_id,root_id,idx order by idx
+                            )
+                            select jsonb_object_agg(n.name,to_jsonb((case when jsonb_array_length(b.data) > 1 then b.data else b.data->0 end))) as data
+                                from bynode b join node n on b.node_id = n.id SORT_JOIN group by b.root_id SORT_GROUPBY SORT_ORDER;
+                            """
+                                    .replace("NODE_FILTER", nodeFilter).replace("SORT_CTE", sortCte)
+                                    .replace("SORT_JOIN", sortJoin).replace("SORT_GROUPBY", sortGroupBy).replace("SORT_ORDER", sortOrder);
+                    default -> "";
+                }, JsonNode.class
+        ).setParameter("nodeId", nodeId);
+        if (filterNodeIds != null && !filterNodeIds.isEmpty()) query.setParameter("nodeIds", filterNodeIds);
+        if (sortByNodeId != null)  query.setParameter("sortNodeId", sortByNodeId);
+        return query.getResultList();
+    }
+
     /**
      * get all value that have a value from node as an ancestor
      * @param nodeId
@@ -585,6 +612,26 @@ public class ValueService implements ValueServiceInterface {
         CycleAvoidingContext cycleContext = new CycleAvoidingContext();
         List<ValueEntity> entities = ValueEntity.find("node.id", nodeId).list();
         return entities.stream().map(entity -> apiMapper.toValue(entity, cycleContext)).toList();
+    }
+
+    @Override
+    @Transactional
+    public List<JsonNode> getLabelValues(Long folderId, Long groupByNodeId, List<Long> nodeIds, Long sortByNodeId) {
+        FolderEntity folder = FolderEntity.findById(folderId);
+        if (folder == null) {
+            throw new  NotFoundException("Folder not found: " + folderId);
+        }
+        Long rootNodeId=folder.group.root.id;
+        List<Long> filterNodeIds = new ArrayList<>();
+        if(nodeIds != null ){filterNodeIds.addAll(nodeIds);}
+        if(groupByNodeId != null){
+            filterNodeIds.add(groupByNodeId);
+        }
+        if(sortByNodeId != null){
+            filterNodeIds.add(sortByNodeId);
+        }
+        return getGroupedValues(rootNodeId, filterNodeIds.isEmpty() ? null : filterNodeIds, sortByNodeId);
+
     }
 
 

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -891,4 +891,56 @@ public class RestEndpointTest extends FreshDb {
                 .body(containsString("/api/value"));
     }
 
+    @Test
+    public void labelValues_returns_grouped_values() throws InterruptedException {
+        Long folderId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .when().post("/api/folder/lv-test")
+                .then()
+                .statusCode(200)
+                .extract().as(Long.class);
+
+        Long groupId = getGroupId("lv-test");
+        Long throughputId=createNode(groupId, "throughput", ".throughput");
+        Long buildId= createNode(groupId, "build_id", ".build_id");
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body("{\"throughput\": 115, \"build_id\": 201}")
+                .when().post("/api/folder/lv-test/upload")
+                .then().statusCode(204);
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body("{\"throughput\": 100, \"build_id\": 202}")
+                .when().post("/api/folder/lv-test/upload")
+                .then().statusCode(204);
+
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(workService.isIdle(), "Work queue should be idle");
+
+        given().when().get("/api/folder/"+folderId+"/labelValues")
+                .then().statusCode(200)
+                .body("size()", equalTo(2))
+                .body("throughput", hasItems(100,115))
+                .body("build_id", hasItems(201,202));
+
+        given().queryParam("sortById", throughputId)
+                .queryParam("nodeIds",throughputId)
+                .when().get("/api/folder/"+folderId+"/labelValues")
+                .then().statusCode(200)
+                .body("size()", equalTo(2))
+                .body("[0].throughput", equalTo(100))
+                .body("[1].throughput", equalTo(115));
+    }
+
+    @Test
+    public void labelValues_folder_not_found_returns_404() {
+        given()
+                .when().get("/api/folder/123/labelValues")
+                .then()
+                .statusCode(404);
+    }
+
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -7,14 +7,15 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.api.Value;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import io.hyperfoil.tools.h5m.entity.mapper.CycleAvoidingContext;
-import io.hyperfoil.tools.h5m.entity.node.FingerprintNode;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -23,9 +24,6 @@ import org.hibernate.LazyInitializationException;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
@@ -1284,4 +1282,195 @@ public class ValueServiceTest extends FreshDb {
         assertEquals(2,found.size(),"expect to see 2 entry: "+found);
         assertFalse(found.contains(bravobravoValue),"should not contain bravobravo["+bravobravoValue.id+"]'s value: "+found);
     }
+
+
+    @Test
+    public void getGroupedValues_filtered() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity throughputNode = new JqNode("throughput");
+        throughputNode.sources = List.of(rootNode);
+        throughputNode.persist();
+        NodeEntity buildIdNode = new JqNode("build_id");
+        buildIdNode.sources = List.of(rootNode);
+        buildIdNode.persist();
+
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("r1"));
+        root1.persist();
+        ValueEntity t1 = new ValueEntity(null, throughputNode, new TextNode("100"));
+        t1.sources = List.of(root1);
+        t1.persist();
+        ValueEntity b1 = new ValueEntity(null, buildIdNode, new TextNode("201"));
+        b1.sources = List.of(root1);
+        b1.persist();
+        tm.commit();
+
+        List<JsonNode> results = valueService.getGroupedValues(rootNode.id, List.of(throughputNode.id));
+
+        assertEquals(1, results.size(), "expect one row: " + results);
+        assertTrue(results.get(0).has("throughput"), "row should have throughput: " + results.get(0));
+        assertFalse(results.get(0).has("build_id"), "row should not have build_id when filtered out: " + results.get(0));
+    }
+
+    @Test
+    public void getGroupedValues_sorted() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException
+    {
+        ObjectMapper om = new ObjectMapper();
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity throughputNode = new JqNode("throughput");
+        throughputNode.sources = List.of(rootNode);
+        throughputNode.persist();
+        NodeEntity buildIdNode = new JqNode("build_id");
+        buildIdNode.sources = List.of(rootNode);
+        buildIdNode.persist();
+
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("r1"));
+        root1.persist();
+        ValueEntity throughputv1 = new ValueEntity(null, throughputNode, new TextNode("100"));
+        throughputv1.sources = List.of(root1);
+        throughputv1.persist();
+        ValueEntity buildv1 = new ValueEntity(null, buildIdNode, new TextNode("202"));
+        buildv1.sources = List.of(root1);
+        buildv1.persist();
+
+        ValueEntity root2 = new ValueEntity(null, rootNode, new TextNode("r2"));
+        root2.persist();
+        ValueEntity throughputv2 = new ValueEntity(null, throughputNode, new TextNode("101"));
+        throughputv2.sources = List.of(root2);
+        throughputv2.persist();
+        ValueEntity buildv2 = new ValueEntity(null, buildIdNode, new TextNode("201"));
+        buildv2.sources = List.of(root2);
+        buildv2.persist();
+
+        ValueEntity root3 = new ValueEntity(null, rootNode, new TextNode("r3"));
+        root3.persist();
+        ValueEntity throughputv3 = new ValueEntity(null, throughputNode, new TextNode("102"));
+        throughputv3.sources = List.of(root3);
+        throughputv3.persist();
+        ValueEntity buildv3 = new ValueEntity(null, buildIdNode, new TextNode("200"));
+        buildv3.sources = List.of(root3);
+        buildv3.persist();
+        tm.commit();
+
+        List<JsonNode> results = valueService.getGroupedValues(
+                rootNode.id,
+                List.of(throughputNode.id, buildIdNode.id),
+                buildIdNode.id
+        );
+
+        assertEquals(3, results.size(), "expect 3 rows: " + results);
+        assertEquals(200, results.get(0).get("build_id").asInt(), "first row should be build_id 200: " + results);
+        assertEquals(201, results.get(1).get("build_id").asInt(), "second row should be build_id 201: " + results);
+        assertEquals(202, results.get(2).get("build_id").asInt(), "third row should be build_id 202: " + results);
+    }
+
+    @Test
+    public void getGroupedValues_empty_filterNodeIds_returns_all_nodes() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException
+    {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity throughputNode = new JqNode("throughput");
+        throughputNode.sources = List.of(rootNode);
+        throughputNode.persist();
+        NodeEntity buildNode = new JqNode("build_id");
+        buildNode.sources = List.of(rootNode);
+        buildNode.persist();
+
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("r1"));
+        root1.persist();
+        ValueEntity throughputv1 = new ValueEntity(null, throughputNode, new TextNode("100"));
+        throughputv1.sources = List.of(root1);
+        throughputv1.persist();
+        ValueEntity buildv1 = new ValueEntity(null, buildNode, new TextNode("101"));
+        buildv1.sources = List.of(root1);
+        buildv1.persist();
+
+        ValueEntity root2 = new ValueEntity(null, rootNode, new TextNode("r2"));
+        root2.persist();
+        ValueEntity throughputv2 = new ValueEntity(null, throughputNode, new TextNode("200"));
+        throughputv2.sources = List.of(root2);
+        throughputv2.persist();
+        ValueEntity buildv2 = new ValueEntity(null, buildNode, new TextNode("201"));
+        buildv2.sources = List.of(root2);
+        buildv2.persist();
+
+        ValueEntity root3 = new ValueEntity(null, rootNode, new TextNode("r3"));
+        root3.persist();
+        ValueEntity throughputv3 = new ValueEntity(null, throughputNode, new TextNode("300"));
+        throughputv3.sources = List.of(root3);
+        throughputv3.persist();
+        ValueEntity buildv3 = new ValueEntity(null, buildNode, new TextNode("301"));
+        buildv3.sources = List.of(root3);
+        buildv3.persist();
+        tm.commit();
+
+        List<JsonNode> results = valueService.getGroupedValues(rootNode.id, List.of());
+
+        assertEquals(3, results.size(), "expect 3 rows: " + results);
+        assertTrue(results.get(0).has("throughput"), "row should have throughput: " + results.get(0));
+        assertTrue(results.get(0).has("build_id"), "row should have build_id: " + results.get(0));
+        assertTrue(results.get(1).has("throughput"), "row should have throughput: " + results.get(1));
+        assertTrue(results.get(1).has("build_id"), "row should have build_id: " + results.get(1));
+        assertTrue(results.get(2).has("throughput"), "row should have throughput: " + results.get(2));
+        assertTrue(results.get(2).has("build_id"), "row should have build_id: " + results.get(2));
+
+
+    }
+
+    @Test
+    public void getLabelValues_empty_filterNodeIds_returns_all_nodes() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException
+    {
+        tm.begin();
+        NodeGroupEntity group = new NodeGroupEntity();
+        group.persist();
+        FolderEntity folder = new FolderEntity();
+        folder.name = "lv-null-test";
+        folder.group = group;
+        folder.persist();
+
+        NodeEntity rootNode = group.root;
+
+        NodeEntity throughputNode = new JqNode("throughput");
+        throughputNode.sources = List.of(rootNode);
+        throughputNode.persist();
+        NodeEntity buildIdNode = new JqNode("build_id");
+        buildIdNode.sources = List.of(rootNode);
+        buildIdNode.persist();
+
+        ValueEntity root1 = new ValueEntity(null, rootNode, new TextNode("r1"));
+        root1.persist();
+        ValueEntity t1 = new ValueEntity(null, throughputNode, new TextNode("100"));
+        t1.sources = List.of(root1);
+        t1.persist();
+        ValueEntity b1 = new ValueEntity(null, buildIdNode, new TextNode("201"));
+        b1.sources = List.of(root1);
+        b1.persist();
+
+        ValueEntity root2 = new ValueEntity(null, rootNode, new TextNode("r2"));
+        root2.persist();
+        ValueEntity t2 = new ValueEntity(null, throughputNode, new TextNode("200"));
+        t2.sources = List.of(root2);
+        t2.persist();
+        ValueEntity b2 = new ValueEntity(null, buildIdNode, new TextNode("202"));
+        b2.sources = List.of(root2);
+        b2.persist();
+
+        tm.commit();
+
+        List<JsonNode> results = valueService.getLabelValues(folder.id, null, null, null);
+
+        assertEquals(2, results.size(), "expect two rows: " + results);
+        assertTrue(results.get(0).has("throughput"), "row should have throughput: " + results.get(0));
+        assertTrue(results.get(0).has("build_id"), "row should have build_id: " + results.get(0));
+        assertTrue(results.get(1).has("throughput"), "row should have throughput: " + results.get(1));
+        assertTrue(results.get(1).has("build_id"), "row should have build_id: " + results.get(1));
+
+    }
+
 }
+
+


### PR DESCRIPTION
 **Description of the PR**
  
- Added getLabelValues API endpoint (GET /api/folder/{name}/labelValues) that returns one JSON row per upload for a folder, with each row containing values keyed by node name
- Supports optional query params: nodes (filter which nodes appear as columns), groupbyId (include grouping node in every row), sortById (sort rows by a node's value ascending)
- Refactored getGroupedValues(Long, List<Long>) to delegate to the new 3-param overload getGroupedValues(Long, List<Long>, Long) eliminating duplicate SQL
- Added NotFoundException when folder is not found (returns 404)

  **Test plan**
  
ValueServiceTest:  
- getGroupedValues_filtered — verifies that passing filterNodeIds excludes nodes not in the list from the result
- getGroupedValues_sorted — verifies that passing sortByNodeId returns rows in ascending order by that node's value,   regardless of insertion order
- getGroupedValues_empty_filterNodeIds_returns_all_nodes — verifies that passing an empty list falls back to returning all nodes
- getLabelValues_empty_filterNodeIds_returns_all_nodes — verifies the service-level method returns all nodes and all uploads when no filter is applied

RestEndpointTest: 
- labelValues_returns_grouped_values -REST level integration test covering unfiltered fetch and  sorted fetch via HTTP
- labelValues_folder_not_found_returns_404 — verifies 404 is returned for a non-existent folder
