### PR TITLE
Implement StdDev anomaly detection node (issue #115)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/NodeType.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/NodeType.java
@@ -12,6 +12,7 @@ public enum NodeType {
     JSONATA("nata"),
     RELATIVE_DIFFERENCE("rd"),
     ROOT("root"),
+    STDDEV_ANOMALY("sd"),
     SPLIT("split"),
     SQL_JSONPATH_ALL_NODE("sql-all"),
     SQL_JSONPATH_NODE("sql"),

--- a/src/main/java/io/hyperfoil/tools/h5m/api/StdDevAnomalyConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/StdDevAnomalyConfig.java
@@ -1,0 +1,15 @@
+package io.hyperfoil.tools.h5m.api;
+
+public record StdDevAnomalyConfig(
+        int windowSize,
+        double deviations,
+        Direction direction,
+        int minDataPoints,
+        String fingerprintFilter
+) {
+    public enum Direction {
+        UPPER,
+        LOWER,
+        BOTH
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
@@ -18,6 +18,7 @@ import java.util.concurrent.Callable;
         AddSplit.class,
         AddRelativeDifference.class,
         AddFixedThreshold.class,
+        AddStdDevAnomaly.class,
         AddNotification.class,
     }
 )

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
@@ -1,0 +1,152 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.Node;
+import io.hyperfoil.tools.h5m.api.NodeGroup;
+import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.svc.NodeGroupServiceInterface;
+import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
+import io.hyperfoil.tools.h5m.entity.node.StdDevAnomaly;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+@CommandLine.Command(name = "stddev", separator = " ", description = "add a standard deviation anomaly detection node", mixinStandardHelpOptions = true)
+public class AddStdDevAnomaly implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"to"}, description = "target group / test") String groupName;
+
+    @CommandLine.Option(names = {"range"}, arity = "1", description = "node that produces the value to inspect")
+    String rangeName;
+
+    @CommandLine.Option(names = {"domain"}, arity = "0..1", description = "node used to sort the range values")
+    String domainName;
+
+    @CommandLine.Option(names = {"by"}, description = "grouping node", arity = "0..1")
+    public String groupBy;
+
+    @CommandLine.Option(names = {"fingerprint"}, description = "node names to use as fingerprint")
+    List<String> fingerprints;
+
+    @CommandLine.Option(names = {"--fingerprint-filter", "-ff"}, arity = "0..1", description = "jq filter expression for fingerprints")
+    String fingerprintFilter;
+
+    @CommandLine.Option(names = {"windowSize"}, arity = "0..1", description = "number of preceding data points for baseline",
+            defaultValue = "" + StdDevAnomaly.DEFAULT_WINDOW_SIZE)
+    int windowSize;
+
+    @CommandLine.Option(names = {"deviations"}, arity = "0..1", description = "number of standard deviations for alert threshold",
+            defaultValue = "" + StdDevAnomaly.DEFAULT_DEVIATIONS)
+    double deviations;
+
+    @CommandLine.Option(names = {"direction"}, arity = "0..1", description = "UPPER, LOWER, or BOTH",
+            defaultValue = "BOTH")
+    StdDevAnomalyConfig.Direction direction;
+
+    @CommandLine.Option(names = {"minDataPoints"}, arity = "0..1", description = "minimum data points before alerting",
+            defaultValue = "" + StdDevAnomaly.DEFAULT_MIN_DATA_POINTS)
+    int minDataPoints;
+
+    @CommandLine.Parameters(index = "0", arity = "1", description = "node name") String name;
+
+    @Inject
+    NodeGroupServiceInterface nodeGroupService;
+
+    @Inject
+    NodeServiceInterface nodeService;
+
+    @Override
+    public Integer call() throws Exception {
+        if (name == null || name.isEmpty()) {
+            System.err.println("missing node name");
+            return 1;
+        }
+        if (groupName == null || groupName.isEmpty()) {
+            System.err.println("missing group name");
+            return 1;
+        }
+        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        if (foundGroup == null) {
+            System.err.println("node group with name " + groupName + " does not exist");
+            return 1;
+        }
+
+        List<Node> foundNodes = nodeService.findNodeByFqdn(name, foundGroup.id());
+        if (!foundNodes.isEmpty()) {
+            System.err.println(groupName + " already has " + name + " node(s)\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+        }
+
+        if (rangeName == null || rangeName.isEmpty()) {
+            System.err.println("Missing range");
+            return 1;
+        }
+        foundNodes = nodeService.findNodeByFqdn(rangeName, foundGroup.id());
+        if (foundNodes.isEmpty()) {
+            System.err.println("could not find matching range node by name " + rangeName);
+            return 1;
+        } else if (foundNodes.size() > 1) {
+            System.err.println("found more than one matching range node by name " + rangeName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+            return 1;
+        }
+        Node rangeNode = foundNodes.getFirst();
+
+        Node domainNode = null;
+        if (domainName != null && !domainName.isEmpty()) {
+            foundNodes = nodeService.findNodeByFqdn(domainName, foundGroup.id());
+            if (foundNodes.isEmpty()) {
+                System.err.println("could not find matching domain node by name " + domainName);
+                return 1;
+            } else if (foundNodes.size() > 1) {
+                System.err.println("found more than one matching domain node by name " + domainName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+                return 1;
+            }
+            domainNode = foundNodes.getFirst();
+        }
+
+        Node groupByNode = null;
+        if (groupBy != null && !groupBy.isEmpty()) {
+            foundNodes = nodeService.findNodeByFqdn(groupBy, foundGroup.id());
+            if (foundNodes.isEmpty()) {
+                System.err.println("could not find matching group by node with name " + groupBy);
+                return 1;
+            } else if (foundNodes.size() > 1) {
+                System.err.println("found more than one matching group by node for name " + groupBy + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+                return 1;
+            }
+            groupByNode = foundNodes.getFirst();
+        }
+        if (groupByNode == null) {
+            groupByNode = foundGroup.root();
+        }
+
+        List<Long> fingerprintNodes = new ArrayList<>();
+        if (fingerprints != null && !fingerprints.isEmpty()) {
+            List<String> fingerprintNames = fingerprints.stream().flatMap(fp -> Arrays.stream(fp.split(","))).map(String::trim).filter(v -> !v.isBlank()).toList();
+            for (String fingerprintName : fingerprintNames) {
+                foundNodes = nodeService.findNodeByFqdn(fingerprintName, foundGroup.id());
+                if (foundNodes.isEmpty()) {
+                    System.err.println("could not find matching fingerprint node by name " + fingerprintName);
+                    return 1;
+                } else if (foundNodes.size() > 1) {
+                    System.err.println("found more than one matching fingerprint node by name " + fingerprintName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+                    return 1;
+                }
+                fingerprintNodes.add(foundNodes.getFirst().id());
+            }
+        }
+
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        List<Long> sources = domainNode == null
+                ? List.of(fingerprintId, groupByNode.id(), rangeNode.id())
+                : List.of(fingerprintId, groupByNode.id(), rangeNode.id(), domainNode.id());
+        nodeService.createConfigured(name, foundGroup.id(), NodeType.STDDEV_ANOMALY, sources,
+                new StdDevAnomalyConfig(windowSize, deviations, direction, minDataPoints, fingerprintFilter));
+
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/StdDevAnomaly.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/StdDevAnomaly.java
@@ -1,0 +1,175 @@
+package io.hyperfoil.tools.h5m.entity.node;
+
+import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.yaup.json.Json;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.Transient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Standard-deviation-based anomaly detection node.
+ * Detects values that exceed mean ± (deviations × stddev) of the
+ * preceding windowSize data points. Designed as a CI gate for
+ * catching large regressions relative to natural noise.
+ *
+ * Sources: [fingerprint=0, groupBy=1, range=2, domain=3]
+ */
+@Entity
+@DiscriminatorValue("sd")
+public class StdDevAnomaly extends NodeEntity implements DetectionNode {
+
+    private static final String WINDOW_SIZE = "windowSize";
+    public static final int DEFAULT_WINDOW_SIZE = 40;
+
+    private static final String DEVIATIONS = "deviations";
+    public static final double DEFAULT_DEVIATIONS = 4.0;
+
+    private static final String DIRECTION = "direction";
+    public static final StdDevAnomalyConfig.Direction DEFAULT_DIRECTION = StdDevAnomalyConfig.Direction.BOTH;
+
+    private static final String MIN_DATA_POINTS = "minDataPoints";
+    public static final int DEFAULT_MIN_DATA_POINTS = 10;
+
+    private static final String FINGERPRINT_FILTER = "fingerprintFilter";
+
+    @Transient
+    private Json config;
+
+    public StdDevAnomaly() {
+        config = new Json();
+    }
+
+    public StdDevAnomaly(String name, String operation) {
+        super(name, operation);
+        config = new Json();
+    }
+
+    @Override
+    public NodeType type() {
+        return NodeType.STDDEV_ANOMALY;
+    }
+
+    @PostLoad
+    public void loadConfig() {
+        if (this.config == null || this.config.isEmpty()) {
+            if (this.operation != null && !this.operation.isBlank()) {
+                config = Json.fromString(this.operation);
+            } else {
+                config = new Json();
+            }
+        }
+    }
+
+    /**
+     * Sets the source nodes in the required order.
+     * @param fingerprint node producing fingerprint values for grouping
+     * @param groupBy node for grouping (typically the split/dataset node)
+     * @param range node producing the numeric values to monitor
+     * @param domain node producing the ordering values (e.g., timestamp, build number)
+     */
+    public void setNodes(NodeEntity fingerprint, NodeEntity groupBy, NodeEntity range, NodeEntity domain) {
+        List<NodeEntity> sources = new ArrayList<>();
+        sources.add(fingerprint);
+        sources.add(groupBy);
+        sources.add(range);
+        if (domain != null) {
+            sources.add(domain);
+        }
+        this.sources = sources;
+    }
+
+    @Override
+    @Transient
+    public NodeEntity getFingerprintNode() {
+        return sources.get(0);
+    }
+
+    @Override
+    @Transient
+    public NodeEntity getGroupByNode() {
+        return sources.get(1);
+    }
+
+    @Override
+    @Transient
+    public NodeEntity getRangeNode() {
+        return sources.get(2);
+    }
+
+    @Transient
+    public NodeEntity getDomainNode() {
+        return sources.size() > 3 ? sources.get(3) : null;
+    }
+
+    @Transient
+    public int getWindowSize() {
+        return (int) config.getLong(WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
+    }
+
+    public void setWindowSize(int windowSize) {
+        config.set(WINDOW_SIZE, windowSize);
+        operation = config.toString();
+    }
+
+    @Transient
+    public double getDeviations() {
+        // Use Number cast instead of Json.getDouble() to handle BigDecimal values
+        // parsed by Json.fromString() (see yaup#41)
+        Object val = config.get(DEVIATIONS);
+        if (val instanceof Number n) return n.doubleValue();
+        return DEFAULT_DEVIATIONS;
+    }
+
+    public void setDeviations(double deviations) {
+        config.set(DEVIATIONS, deviations);
+        operation = config.toString();
+    }
+
+    @Transient
+    public StdDevAnomalyConfig.Direction getDirection() {
+        String dir = config.getString(DIRECTION);
+        if (dir == null || dir.isBlank()) return DEFAULT_DIRECTION;
+        try {
+            return StdDevAnomalyConfig.Direction.valueOf(dir);
+        } catch (IllegalArgumentException e) {
+            return DEFAULT_DIRECTION;
+        }
+    }
+
+    public void setDirection(StdDevAnomalyConfig.Direction direction) {
+        config.set(DIRECTION, direction.name());
+        operation = config.toString();
+    }
+
+    @Transient
+    public int getMinDataPoints() {
+        return (int) config.getLong(MIN_DATA_POINTS, DEFAULT_MIN_DATA_POINTS);
+    }
+
+    public void setMinDataPoints(int minDataPoints) {
+        config.set(MIN_DATA_POINTS, minDataPoints);
+        operation = config.toString();
+    }
+
+    @Override
+    @Transient
+    public String getFingerprintFilter() {
+        return config.getString(FINGERPRINT_FILTER);
+    }
+
+    public void setFingerprintFilter(String fingerprintFilter) {
+        config.set(FINGERPRINT_FILTER, fingerprintFilter);
+        operation = config.toString();
+    }
+
+    @Override
+    protected NodeEntity shallowCopy() {
+        return new StdDevAnomaly(name, operation);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -3,6 +3,7 @@ package io.hyperfoil.tools.h5m.entity.work;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;
+import io.hyperfoil.tools.h5m.entity.node.StdDevAnomaly;
 import io.hyperfoil.tools.h5m.svc.WorkService;
 import jakarta.enterprise.inject.spi.CDI;
 
@@ -33,7 +34,8 @@ public class Work implements Runnable, Comparable<Work>{
     public Work(Set<NodeEntity> activeNodes,List<NodeEntity> sourceNodes,List<ValueEntity> sourceValues){
         this();
         this.activeNodes = new HashSet<>(activeNodes); //so that it will be mutable
-        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference)){
+        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
+                || node instanceof StdDevAnomaly)){
             this.cumulative = true;
         }
         this.sourceValues = sourceValues == null ? Collections.emptyList() : new ArrayList(sourceValues);
@@ -46,7 +48,8 @@ public class Work implements Runnable, Comparable<Work>{
 
     public void setActiveNodes(Set<NodeEntity> activeNodes) {
         this.activeNodes = activeNodes;
-        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference)){
+        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
+                || node instanceof StdDevAnomaly)){
             this.cumulative = true;
         }else{
             this.cumulative = false;

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -206,7 +206,7 @@ public class FolderService implements FolderServiceInterface {
             JOIN node r ON r.id = g.root_id
             LEFT JOIN value rv ON rv.node_id = r.id
             LEFT JOIN node n ON n.group_id = g.id AND n.id != r.id
-            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN ('ft', 'rd')
+            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN ('ft', 'rd', 'sd')
             LEFT JOIN value dv ON dv.node_id = dn.id
             GROUP BY f.id, f.name
             ORDER BY f.name

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -12,6 +12,7 @@ import io.hyperfoil.tools.h5m.api.FixedThresholdConfig;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.RelativeDifferenceConfig;
+import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
@@ -119,6 +120,8 @@ public class NodeService implements NodeServiceInterface {
                     OBJECT_MAPPER.convertValue(configuration, FixedThresholdConfig.class)));
             case RELATIVE_DIFFERENCE -> new RelativeDifference(name, OBJECT_MAPPER.writeValueAsString(
                     OBJECT_MAPPER.convertValue(configuration, RelativeDifferenceConfig.class)));
+            case STDDEV_ANOMALY -> new StdDevAnomaly(name, OBJECT_MAPPER.writeValueAsString(
+                    OBJECT_MAPPER.convertValue(configuration, StdDevAnomalyConfig.class)));
             default -> throw new IllegalArgumentException("Invalid node type " + type.display());
         };
         node.group = NodeGroupEntity.findById(groupId);
@@ -367,6 +370,13 @@ public class NodeService implements NodeServiceInterface {
                 for(int rIdx=0; rIdx<roots.size(); rIdx++){
                     ValueEntity root =  roots.get(rIdx);
                     rtrn.addAll(calculateFixedThresholdValues(ft,root,rtrn.size()));
+                }
+                break;
+            case STDDEV_ANOMALY:
+                StdDevAnomaly sd = (StdDevAnomaly) node;
+                for(int rIdx=0; rIdx<roots.size(); rIdx++){
+                    ValueEntity root =  roots.get(rIdx);
+                    rtrn.addAll(calculateStdDevAnomalyValues(sd, root, rtrn.size()));
                 }
                 break;
             default:
@@ -674,6 +684,145 @@ public class NodeService implements NodeServiceInterface {
             e.printStackTrace();
         }
         return rtrn;
+    }
+
+    @Transactional
+    public List<ValueEntity> calculateStdDevAnomalyValues(StdDevAnomaly sd, ValueEntity root, int startingOrdinal) throws IOException {
+        List<ValueEntity> rtrn = new ArrayList<>();
+        try {
+            NodeEntity groupBy = NodeEntity.findById(sd.getGroupByNode().getId());
+            List<ValueEntity> fingerprintValues = valueService.getDescendantValues(root, sd.getFingerprintNode());
+            String fpFilter = sd.getFingerprintFilter();
+
+            for (int fIdx = 0; fIdx < fingerprintValues.size(); fIdx++) {
+                ValueEntity fingerprintValue = fingerprintValues.get(fIdx);
+                if (fpFilter != null && !evaluateFingerprintFilter(fpFilter, fingerprintValue.data)) {
+                    continue;
+                }
+
+                // Get the groupBy ancestor for this fingerprint — this scopes to the
+                // specific dataset/split branch. For non-split uploads, this is the root.
+                List<ValueEntity> groupByValues = valueService.getAncestor(fingerprintValue, groupBy);
+                if (groupByValues.isEmpty()) {
+                    continue;
+                }
+                ValueEntity groupByValue = groupByValues.getFirst();
+
+                // Get the range value from the CURRENT upload that belongs to the same
+                // dataset as this fingerprint (shared groupBy ancestor).
+                List<ValueEntity> currentRangeValues = valueService.getDescendantValues(groupByValue, sd.getRangeNode());
+                if (currentRangeValues.isEmpty()) {
+                    continue;
+                }
+
+                // Get the domain value from the current upload for the output data
+                JsonNode currentDomainData = null;
+                ValueEntity domainPivot = null;
+                if (sd.getDomainNode() != null) {
+                    List<ValueEntity> currentDomainValues = valueService.getDescendantValues(groupByValue, sd.getDomainNode());
+                    if (!currentDomainValues.isEmpty()) {
+                        domainPivot = currentDomainValues.getFirst();
+                        currentDomainData = domainPivot.data;
+                    }
+                }
+
+                // For each range value in the current dataset:
+                for (ValueEntity currentRangeValue : currentRangeValues) {
+                    Double currentNumeric = toDouble(currentRangeValue.data);
+                    if (currentNumeric == null) {
+                        continue;
+                    }
+
+                    // Fetch historical range values for the baseline window.
+                    // Use the current upload's domain value as pivot to get preceding values.
+                    // Request windowSize + 1 because the current value will be in the result set
+                    // (its domain matches the pivot with <=). We skip it by ID below,
+                    // leaving windowSize baseline values.
+                    List<ValueEntity> historicalValues = valueService.findMatchingFingerprint(
+                            sd.getRangeNode(), groupBy, fingerprintValue,
+                            sd.getDomainNode(), domainPivot, null,
+                            sd.getWindowSize() + 1, 0, true);
+
+                    // Build the numeric series: historical values in chronological order,
+                    // with the current value as the last element
+                    List<Double> values = new ArrayList<>();
+                    for (ValueEntity rv : historicalValues) {
+                        // Skip the current value if it appears in the historical set
+                        if (rv.getId().equals(currentRangeValue.getId())) {
+                            continue;
+                        }
+                        Double d = toDouble(rv.data);
+                        if (d != null) {
+                            values.add(d);
+                        }
+                    }
+                    // Append the current value as the last element — this is what gets checked
+                    values.add(currentNumeric);
+
+                    // Delegate the math to the pure calculator
+                    StdDevAnomalyCalculator.Result result = StdDevAnomalyCalculator.evaluate(
+                            values, sd.getWindowSize(), sd.getDeviations(),
+                            sd.getDirection(), sd.getMinDataPoints());
+
+                    if (result != null && result.anomaly()) {
+                        ObjectNode data = OBJECT_MAPPER.createObjectNode();
+                        data.set("value", new DoubleNode(result.currentValue()));
+                        data.set("mean", new DoubleNode(result.mean()));
+                        data.set("stddev", new DoubleNode(result.stddev()));
+                        data.set("deviations", new DoubleNode(result.deviations()));
+                        data.put("direction", result.direction());
+                        data.set("threshold", new DoubleNode(result.threshold()));
+                        data.set("fingerprint", fingerprintValue.data);
+                        if (currentDomainData != null) {
+                            data.set("domainvalue", currentDomainData);
+                        }
+                        ValueEntity changeValue = new ValueEntity(root.folder, sd, data);
+                        changeValue.idx = startingOrdinal;
+                        List<ValueEntity> foundParents = valueService.getAncestor(fingerprintValue, groupBy);
+                        if (foundParents.size() == 1) {
+                            changeValue.sources = foundParents;
+                        }
+                        rtrn.add(changeValue);
+                    }
+                }
+
+                // Stale change cleanup: delete previously persisted StdDev anomalies
+                // for this fingerprint at the current upload's domain value.
+                // The new results (in rtrn) will replace them when persisted by the caller.
+                // This handles: reprocessing, recalculation, and baseline shifts.
+                if (currentDomainData != null) {
+                    List<ValueEntity> persistedChanges = valueService.findMatchingFingerprint(
+                            sd, groupBy, fingerprintValue,
+                            sd.getDomainNode(), null, null,
+                            -1, -1, true);
+                    for (ValueEntity existing : persistedChanges) {
+                        JsonNode existingDomain = existing.data != null ? existing.data.get("domainvalue") : null;
+                        if (existingDomain != null && existingDomain.equals(currentDomainData)) {
+                            valueService.delete(existing);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return rtrn;
+    }
+
+    private static Double toDouble(JsonNode data) {
+        if (data instanceof NumericNode numericNode) {
+            return numericNode.asDouble();
+        } else if (data != null) {
+            String text = data.asText();
+            if (text != null && text.length() < 20 && text.matches("-?[0-9]+\\.?[0-9]*")) {
+                try {
+                    return Double.parseDouble(text);
+                } catch (NumberFormatException e) {
+                    return null;
+                }
+            }
+        }
+        return null;
     }
 
     @Transactional

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyCalculator.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyCalculator.java
@@ -1,0 +1,101 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+
+/**
+ * Standard-deviation-based anomaly detection algorithm.
+ * Pure computation — no DB access, no CDI, no JPA dependencies.
+ *
+ * Checks if the last value in a series exceeds mean ± (deviations × stddev)
+ * of the preceding baseline window.
+ */
+public class StdDevAnomalyCalculator {
+
+    private StdDevAnomalyCalculator() {} // not instantiable
+
+    /**
+     * Result of a stddev anomaly check.
+     * @param anomaly true if an anomaly was detected
+     * @param currentValue the value being checked
+     * @param mean mean of the baseline window
+     * @param stddev standard deviation of the baseline window
+     * @param deviations how many stddevs the current value is from the mean
+     * @param threshold the threshold that was exceeded (upper or lower)
+     * @param direction "above" or "below", null if no anomaly
+     */
+    public record Result(
+            boolean anomaly,
+            double currentValue,
+            double mean,
+            double stddev,
+            double deviations,
+            double threshold,
+            String direction
+    ) {
+        public static Result noAnomaly(double currentValue, double mean, double stddev) {
+            return new Result(false, currentValue, mean, stddev, (currentValue - mean) / stddev, 0, null);
+        }
+    }
+
+    /**
+     * Evaluates whether the last value in the series is an anomaly
+     * relative to the preceding baseline window.
+     *
+     * @param values the numeric values in chronological order (oldest first).
+     *               The last value is the current data point, everything before is the baseline.
+     * @param windowSize number of preceding values to use as baseline
+     * @param numDeviations number of standard deviations for the threshold
+     * @param direction which direction to check (UPPER, LOWER, BOTH)
+     * @param minDataPoints minimum total values required before checking
+     * @return detection result, or null if insufficient data
+     */
+    public static Result evaluate(
+            java.util.List<Double> values,
+            int windowSize,
+            double numDeviations,
+            StdDevAnomalyConfig.Direction direction,
+            int minDataPoints) {
+
+        if (values == null || values.size() < minDataPoints) {
+            return null; // insufficient data
+        }
+
+        double currentValue = values.getLast();
+        int baselineEnd = values.size() - 1;
+        int baselineStart = Math.max(0, baselineEnd - windowSize);
+
+        SummaryStatistics stats = new SummaryStatistics();
+        for (int i = baselineStart; i < baselineEnd; i++) {
+            stats.addValue(values.get(i));
+        }
+
+        if (stats.getN() < 2) {
+            return null; // need at least 2 data points for meaningful stddev
+        }
+
+        double mean = stats.getMean();
+        double stddev = stats.getStandardDeviation();
+
+        // Guard against zero stddev (all identical values)
+        if (stddev == 0.0) {
+            stddev = Math.max(Math.abs(mean) * 0.001, 1e-10);
+        }
+
+        double upperThreshold = mean + numDeviations * stddev;
+        double lowerThreshold = mean - numDeviations * stddev;
+        double actualDeviations = (currentValue - mean) / stddev;
+
+        if ((direction == StdDevAnomalyConfig.Direction.UPPER || direction == StdDevAnomalyConfig.Direction.BOTH)
+                && currentValue > upperThreshold) {
+            return new Result(true, currentValue, mean, stddev, actualDeviations, upperThreshold, "above");
+        }
+
+        if ((direction == StdDevAnomalyConfig.Direction.LOWER || direction == StdDevAnomalyConfig.Direction.BOTH)
+                && currentValue < lowerThreshold) {
+            return new Result(true, currentValue, mean, stddev, actualDeviations, lowerThreshold, "below");
+        }
+
+        return Result.noAnomaly(currentValue, mean, stddev);
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
@@ -1349,4 +1349,72 @@ public class H5mTest {
                 "Should contain calculated ratio -48.78048780487805\n" + output4);
     }
 
+    @Test
+    public void calculate_stddev_anomaly_node(QuarkusMainLauncher launcher) throws IOException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        Path folder = Files.createTempDirectory("h5m");
+
+        // 5 stable uploads at y=100, then 1 anomaly at y=200
+        // Upload files individually in order to guarantee deterministic processing.
+        // File.listFiles() does not guarantee order, so directory upload is unreliable.
+        List<Path> uploadFiles = new java.util.ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            uploadFiles.add(Files.writeString(folder.resolve(String.format("upload_%02d.json", i)),
+                    String.format("""
+                    {
+                        "x": %d, "y": 100.0, "fp1": "alpha"
+                    }
+                    """, i)));
+        }
+        uploadFiles.add(Files.writeString(folder.resolve("upload_06.json"),
+                """
+                {
+                    "x": 6, "y": 200.0, "fp1": "alpha"
+                }
+                """));
+
+        // Build commands: setup nodes, then upload each file individually in order
+        List<String[]> commands = new java.util.ArrayList<>();
+        commands.add(new String[]{"add", "folder", testName});
+        commands.add(new String[]{"add", "jq", "to", testName, "domainNode", ".x"});
+        commands.add(new String[]{"add", "jq", "to", testName, "rangeNode", ".y"});
+        commands.add(new String[]{"add", "jq", "to", testName, "fp1", ".fp1"});
+        commands.add(new String[]{"list", testName, "nodes"});
+        commands.add(new String[]{"add", "stddev", "sdNode", "to", testName,
+                "range", "rangeNode", "domain", "domainNode",
+                "fingerprint", "fp1",
+                "windowSize", "5", "deviations", "3", "minDataPoints", "3",
+                "direction", "BOTH"});
+        commands.add(new String[]{"list", testName, "nodes"});
+        for (Path f : uploadFiles) {
+            commands.add(new String[]{"upload", f.toString(), "to", testName});
+        }
+        commands.add(new String[]{"list", "value", "from", testName});
+
+        List<LaunchResult> results = run(launcher, commands.toArray(new String[0][]));
+
+
+        results.forEach(result -> {
+            assertEquals(0, result.exitCode(), result.getOutput());
+        });
+
+        LaunchResult last = results.getLast();
+        String output = last.getOutput();
+
+        // The node list is the second "list nodes" command (index 6, after add stddev)
+        LaunchResult nodeList = results.get(6);
+        assertTrue(nodeList.getOutput().contains("sdNode"), "Node list should contain sdNode\n" + nodeList.getOutput());
+
+        // After uploading 5 stable + 1 anomaly, the anomaly should be detected
+        // Output should contain stddev detection fields
+        assertTrue(output.contains("\"mean\""), "Detection should contain mean\n" + output);
+        assertTrue(output.contains("\"stddev\""), "Detection should contain stddev\n" + output);
+        assertTrue(output.contains("\"deviations\""), "Detection should contain deviations\n" + output);
+        assertTrue(output.contains("\"direction\""), "Detection should contain direction\n" + output);
+        assertTrue(output.contains("above"), "200 should be detected as above the threshold\n" + output);
+    }
+
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -348,6 +348,22 @@ public class RestEndpointTest extends FreshDb {
     }
 
     @Test
+    public void node_create_configured_stddev_anomaly() {
+        createFolder("sd-test");
+        Long groupId = getGroupId("sd-test");
+        Long rangeNodeId = createNode(groupId, "range", ".y");
+        Long fpNodeId = createNode(groupId, "fingerprint", ".fp");
+
+        Long nodeId = createConfiguredNode(groupId, "stddev", NodeType.STDDEV_ANOMALY.name(),
+                List.of(fpNodeId, rangeNodeId),
+                """
+                {"windowSize": 40, "deviations": 4.0, "direction": "BOTH", "minDataPoints": 10, "fingerprintFilter": null}
+                """);
+
+        assertTrue(nodeId > 0, "should return a valid node ID");
+    }
+
+    @Test
     public void node_create_configured_fingerprint() {
         createFolder("fp-test");
         Long groupId = getGroupId("fp-test");

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyTest.java
@@ -1,0 +1,820 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.node.*;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class StdDevAnomalyTest extends FreshDb {
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    NodeService nodeService;
+
+    @Inject
+    ValueService valueService;
+
+    /**
+     * Helper: creates the standard node topology for StdDev tests.
+     * root → split → [range (.y), domain (.domain), fingerprint (.fingerprint)]
+     * Returns the StdDevAnomaly node (already persisted).
+     */
+    private record TestTopology(
+            NodeEntity root, SplitNode split, NodeEntity range,
+            NodeEntity domain, NodeEntity fingerprint, StdDevAnomaly sd
+    ) {}
+
+    private TestTopology createTopology(int windowSize, double deviations,
+                                         StdDevAnomalyConfig.Direction direction, int minDataPoints) throws Exception {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        SplitNode splitNode = new SplitNode("split", "split", List.of(rootNode));
+        splitNode.persist();
+        NodeEntity rangeNode = new JqNode("range", ".y", splitNode);
+        rangeNode.persist();
+        NodeEntity domainNode = new JqNode("domain", ".domain", splitNode);
+        domainNode.persist();
+        NodeEntity fingerprintNode = new JqNode("fingerprint", ".fingerprint", splitNode);
+        fingerprintNode.persist();
+
+        StdDevAnomaly sd = new StdDevAnomaly("stddev-test", "{}");
+        sd.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
+        sd.setWindowSize(windowSize);
+        sd.setDeviations(deviations);
+        sd.setDirection(direction);
+        sd.setMinDataPoints(minDataPoints);
+        sd.persist();
+        tm.commit();
+
+        return new TestTopology(rootNode, splitNode, rangeNode, domainNode, fingerprintNode, sd);
+    }
+
+    /**
+     * Helper: uploads a data point and returns the root ValueEntity.
+     */
+    private ValueEntity uploadDataPoint(TestTopology t, String fingerprint, double domain, double range) throws Exception {
+        tm.begin();
+        String json = String.format(
+                """
+                { "split": [ { "fingerprint": "%s", "domain": %s, "y": %s } ] }
+                """, fingerprint, domain, range);
+        ValueEntity root = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(json));
+        root.persist();
+        ValueEntity split = new ValueEntity(null, t.split, root.data.get("split").get(0), List.of(root));
+        split.persist();
+        new ValueEntity(null, t.domain, split.data.get("domain"), List.of(split)).persist();
+        new ValueEntity(null, t.range, split.data.get("y"), List.of(split)).persist();
+        new ValueEntity(null, t.fingerprint, split.data.get("fingerprint"), List.of(split)).persist();
+        tm.commit();
+        return root;
+    }
+
+    @Test
+    public void step_function_detects_anomaly() throws Exception {
+        // 10 stable values at 100, then jump to 200 → should detect
+        TestTopology t = createTopology(10, 4.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+
+        // Upload 10 stable data points
+        ValueEntity lastRoot = null;
+        for (int i = 1; i <= 10; i++) {
+            lastRoot = uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Verify no anomaly in stable data
+        List<ValueEntity> stableChanges = nodeService.calculateStdDevAnomalyValues(t.sd, lastRoot, 0);
+        assertEquals(0, stableChanges.size(), "Stable data should produce no anomalies");
+
+        // Upload the anomaly: jump to 200
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 11, 200.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+
+        assertEquals(1, changes.size(), "Step function should detect 1 anomaly");
+        JsonNode changeData = changes.get(0).data;
+        assertEquals(200.0, changeData.get("value").asDouble(), 0.01);
+        assertEquals(100.0, changeData.get("mean").asDouble(), 0.01);
+        assertEquals("above", changeData.get("direction").asText());
+        assertNotNull(changeData.get("stddev"));
+        assertNotNull(changeData.get("deviations"));
+        assertNotNull(changeData.get("threshold"));
+    }
+
+    @Test
+    public void stable_data_no_false_positives() throws Exception {
+        // Values within normal noise — should NOT alert at 4 sigma
+        TestTopology t = createTopology(10, 4.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+
+        // Upload 10 values with small variance: 100 ± ~2
+        double[] values = {100, 101, 99, 102, 98, 100, 101, 99, 100, 101};
+        ValueEntity lastRoot = null;
+        for (int i = 0; i < values.length; i++) {
+            lastRoot = uploadDataPoint(t, "alpha", i + 1, values[i]);
+        }
+
+        // Upload a value within 4 sigma of the baseline (mean ~100, stddev ~1.1, 4σ ≈ 4.4)
+        ValueEntity normalRoot = uploadDataPoint(t, "alpha", 11, 103.0); // within 4σ
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, normalRoot, 0);
+
+        assertEquals(0, changes.size(), "Value within 4 sigma should not trigger anomaly");
+    }
+
+    @Test
+    public void direction_upper_only_detects_increases() throws Exception {
+        TestTopology t = createTopology(10, 3.0, StdDevAnomalyConfig.Direction.UPPER, 5);
+
+        for (int i = 1; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Drop to 50 — should NOT detect (UPPER only)
+        ValueEntity dropRoot = uploadDataPoint(t, "alpha", 11, 50.0);
+        List<ValueEntity> dropChanges = nodeService.calculateStdDevAnomalyValues(t.sd, dropRoot, 0);
+        assertEquals(0, dropChanges.size(), "UPPER direction should not detect decreases");
+
+        // Jump to 200 — should detect
+        ValueEntity jumpRoot = uploadDataPoint(t, "alpha", 12, 200.0);
+        List<ValueEntity> jumpChanges = nodeService.calculateStdDevAnomalyValues(t.sd, jumpRoot, 0);
+        assertEquals(1, jumpChanges.size(), "UPPER direction should detect increases");
+        JsonNode jumpData = jumpChanges.get(0).data;
+        assertEquals("above", jumpData.get("direction").asText());
+        assertEquals(200.0, jumpData.get("value").asDouble(), 0.01, "Detected value should be 200");
+        assertNotNull(jumpData.get("mean"), "Output should contain mean");
+        assertNotNull(jumpData.get("stddev"), "Output should contain stddev");
+        assertNotNull(jumpData.get("threshold"), "Output should contain threshold");
+        assertTrue(jumpData.get("threshold").asDouble() < 200.0,
+                "Upper threshold should be below 200 (baseline is ~100)");
+    }
+
+    @Test
+    public void direction_lower_only_detects_decreases() throws Exception {
+        TestTopology t = createTopology(10, 3.0, StdDevAnomalyConfig.Direction.LOWER, 5);
+
+        for (int i = 1; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Jump to 200 — should NOT detect (LOWER only)
+        ValueEntity jumpRoot = uploadDataPoint(t, "alpha", 11, 200.0);
+        List<ValueEntity> jumpChanges = nodeService.calculateStdDevAnomalyValues(t.sd, jumpRoot, 0);
+        assertEquals(0, jumpChanges.size(), "LOWER direction should not detect increases");
+
+        // Drop to 10 — extreme drop from baseline of ~100, should detect even with
+        // the 200 outlier in the window since most values are ~100
+        ValueEntity dropRoot = uploadDataPoint(t, "alpha", 12, 10.0);
+        List<ValueEntity> dropChanges = nodeService.calculateStdDevAnomalyValues(t.sd, dropRoot, 0);
+        assertEquals(1, dropChanges.size(), "LOWER direction should detect extreme decreases");
+        JsonNode dropData = dropChanges.get(0).data;
+        assertEquals("below", dropData.get("direction").asText());
+        assertEquals(10.0, dropData.get("value").asDouble(), 0.01, "Detected value should be 10");
+        assertNotNull(dropData.get("mean"), "Output should contain mean");
+        assertNotNull(dropData.get("stddev"), "Output should contain stddev");
+        assertNotNull(dropData.get("threshold"), "Output should contain threshold");
+        assertTrue(dropData.get("threshold").asDouble() > 10.0,
+                "Lower threshold should be above 10 (baseline is ~100)");
+    }
+
+    @Test
+    public void insufficient_data_no_detection() throws Exception {
+        // minDataPoints=10 but only upload 5 values → should not alert even with anomaly
+        TestTopology t = createTopology(10, 4.0, StdDevAnomalyConfig.Direction.BOTH, 10);
+
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Upload extreme value — should still not trigger because insufficient data
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 6, 500.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+
+        assertEquals(0, changes.size(),
+                "Should not trigger anomaly with fewer than minDataPoints samples");
+    }
+
+    @Test
+    public void zero_stddev_detects_any_change() throws Exception {
+        // All identical values → stddev is 0 → any change should be detected
+        TestTopology t = createTopology(10, 4.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+
+        for (int i = 1; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0); // all identical
+        }
+
+        // Any different value should be detected (stddev floor kicks in)
+        ValueEntity changeRoot = uploadDataPoint(t, "alpha", 11, 101.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, changeRoot, 0);
+
+        assertEquals(1, changes.size(),
+                "With zero stddev (identical baseline), any change should be detected");
+    }
+
+    @Test
+    public void known_distribution_3sigma_vs_4sigma() throws Exception {
+        // For N(100, 10): stddev=10
+        // 3 sigma threshold: [70, 130]
+        // 4 sigma threshold: [60, 140]
+        // A value of 135 should trigger at 3σ but NOT at 4σ
+        TestTopology t3 = createTopology(20, 3.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+        TestTopology t4 = createTopology(20, 4.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+
+        // Upload 20 values from N(100, 10) — hand-picked to have mean≈100, stddev≈10
+        double[] baseline = {
+                95, 105, 90, 110, 100, 98, 102, 93, 107, 99,
+                101, 96, 104, 91, 109, 100, 97, 103, 94, 106
+        };
+        ValueEntity lastRoot3 = null, lastRoot4 = null;
+        for (int i = 0; i < baseline.length; i++) {
+            lastRoot3 = uploadDataPoint(t3, "alpha", i + 1, baseline[i]);
+            lastRoot4 = uploadDataPoint(t4, "alpha", i + 1, baseline[i]);
+        }
+
+        // Baseline: mean=100.00, stddev=5.81
+        // 3σ threshold: 117.44, 4σ threshold: 123.25
+        // Upload 120 — between 3σ and 4σ (3.44σ from mean)
+        ValueEntity root120_3 = uploadDataPoint(t3, "alpha", 21, 120.0);
+        ValueEntity root120_4 = uploadDataPoint(t4, "alpha", 21, 120.0);
+
+        List<ValueEntity> changes3 = nodeService.calculateStdDevAnomalyValues(t3.sd, root120_3, 0);
+        List<ValueEntity> changes4 = nodeService.calculateStdDevAnomalyValues(t4.sd, root120_4, 0);
+
+        assertEquals(1, changes3.size(),
+                "Value 120 (3.44σ) should trigger at 3 sigma (threshold ≈ 117.44)");
+        JsonNode changeData3 = changes3.get(0).data;
+        assertEquals(120.0, changeData3.get("value").asDouble(), 0.01, "Detected value should be 120");
+        assertEquals(100.0, changeData3.get("mean").asDouble(), 1.0, "Mean should be ~100");
+        assertTrue(changeData3.get("stddev").asDouble() > 4.0 && changeData3.get("stddev").asDouble() < 7.0,
+                "Stddev should be ~5.81, got: " + changeData3.get("stddev").asDouble());
+        assertEquals("above", changeData3.get("direction").asText());
+        assertTrue(changeData3.get("threshold").asDouble() < 120.0,
+                "3σ threshold should be below 120");
+
+        assertEquals(0, changes4.size(),
+                "Value 120 (3.44σ) should NOT trigger at 4 sigma (threshold ≈ 123.25)");
+    }
+
+    @Test
+    public void gradual_drift_no_false_alarm() throws Exception {
+        // Gradual upward drift: each value slightly higher than the last
+        // StdDev should adapt and NOT alert because the stddev naturally
+        // grows to accommodate the trend
+        TestTopology t = createTopology(10, 4.0, StdDevAnomalyConfig.Direction.BOTH, 5);
+
+        // Linear drift: 100, 102, 104, ..., 120
+        for (int i = 0; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i + 1, 100.0 + i * 2.0);
+        }
+
+        // Next value continues the trend at 122
+        ValueEntity nextRoot = uploadDataPoint(t, "alpha", 12, 122.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, nextRoot, 0);
+
+        assertEquals(0, changes.size(),
+                "Gradual drift should not trigger anomaly — stddev adapts to the trend");
+    }
+
+    @Test
+    public void only_uses_window_size_most_recent_values() throws Exception {
+        // Upload 50 values: first 40 at y=100 (old baseline), then 10 at y=200 (new baseline)
+        // With windowSize=5, the baseline should only see the last 5 values (all at 200)
+        // so y=200 should NOT be anomalous — the window has adapted
+        // But if the algorithm used all 50 values, mean≈120 and 200 would be anomalous
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Old baseline: 40 uploads at y=100
+        for (int i = 1; i <= 40; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+        // New baseline: 10 uploads at y=200 (legitimate shift)
+        for (int i = 41; i <= 50; i++) {
+            uploadDataPoint(t, "alpha", i, 200.0);
+        }
+
+        // Upload another value at y=200 — should NOT trigger because
+        // the window (last 5 values) is all 200s
+        ValueEntity currentRoot = uploadDataPoint(t, "alpha", 51, 200.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, currentRoot, 0);
+
+        assertEquals(0, changes.size(),
+                "With windowSize=5, only the last 5 values (all 200) should be used as baseline. " +
+                "Value 200 matches the baseline — no anomaly. If all 50 values were used, " +
+                "mean≈120 and 200 would incorrectly trigger as anomalous.");
+    }
+
+    @Test
+    public void multi_fingerprint_independent_detection() throws Exception {
+        // Two fingerprints with different baselines — anomaly should be
+        // detected independently per fingerprint
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Alpha: stable at 100
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i * 2, 100.0); // even domain values
+        }
+
+        // Beta: stable at 200 (different baseline)
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "beta", i * 2 + 1, 200.0); // odd domain values
+        }
+
+        // Alpha stays stable — should NOT detect
+        ValueEntity alphaRoot = uploadDataPoint(t, "alpha", 12, 100.0);
+        List<ValueEntity> alphaChanges = nodeService.calculateStdDevAnomalyValues(t.sd, alphaRoot, 0);
+        assertEquals(0, alphaChanges.size(),
+                "Alpha (stable at 100) should have no anomaly — beta's different baseline must not affect alpha");
+
+        // Beta jumps to 500 — should detect for beta fingerprint
+        // domain=13 to avoid collision with last beta domain (5*2+1=11)
+        ValueEntity betaRoot = uploadDataPoint(t, "beta", 13, 500.0);
+        List<ValueEntity> betaChanges = nodeService.calculateStdDevAnomalyValues(t.sd, betaRoot, 0);
+
+        assertEquals(1, betaChanges.size(), "Beta (jumped from 200 to 500) should have 1 anomaly");
+        JsonNode betaData = betaChanges.get(0).data;
+        assertEquals("beta", betaData.get("fingerprint").asText());
+        assertEquals(500.0, betaData.get("value").asDouble(), 0.01);
+        assertEquals(200.0, betaData.get("mean").asDouble(), 0.01,
+                "Mean should be 200 (beta's baseline), not contaminated by alpha's 100");
+    }
+
+    @Test
+    public void out_of_order_uploads_checks_current_upload() throws Exception {
+        // Upload data points out of chronological order.
+        // The current upload's value should always be the one checked for anomaly,
+        // even if it has an earlier domain value than existing data.
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload domain values: 1, 2, 3, 4, 5 — all at y=100 (stable baseline)
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Upload domain=10 (out of order — later than existing, at normal value)
+        ValueEntity normalRoot = uploadDataPoint(t, "alpha", 10, 100.0);
+        List<ValueEntity> normalChanges = nodeService.calculateStdDevAnomalyValues(t.sd, normalRoot, 0);
+        assertEquals(0, normalChanges.size(), "Normal value uploaded out of order should not trigger anomaly");
+
+        // Upload domain=3 (out of order — EARLIER than existing data, with anomalous value)
+        // This tests that the calculation checks the current upload's value (y=500)
+        // not values.getLast() which could be domain=10 (y=100)
+        ValueEntity outOfOrderRoot = uploadDataPoint(t, "alpha", 3, 500.0);
+        List<ValueEntity> outOfOrderChanges = nodeService.calculateStdDevAnomalyValues(t.sd, outOfOrderRoot, 0);
+        assertEquals(1, outOfOrderChanges.size(),
+                "Out-of-order upload with anomalous value should still be detected. " +
+                "The algorithm should check the current upload's value (500), not the latest by domain order (100).");
+        assertEquals(500.0, outOfOrderChanges.get(0).data.get("value").asDouble(), 0.01);
+    }
+
+    @Test
+    public void stale_change_removed_on_reprocessing() throws Exception {
+        // Simulate: first run detects anomaly, then the anomaly value is replaced
+        // by a normal value (e.g., recalculation after correcting data)
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload 5 stable values at y=100
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Upload anomaly at y=500
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 6, 500.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+        assertEquals(1, changes.size(), "Should detect anomaly at y=500");
+
+        // Persist the change value (simulating what WorkService does)
+        tm.begin();
+        for (ValueEntity change : changes) {
+            valueService.create(change);
+        }
+        tm.commit();
+
+        // Verify the persisted change exists
+        List<ValueEntity> persistedBefore = valueService.findMatchingFingerprint(
+                t.sd, NodeEntity.findById(t.sd.getGroupByNode().getId()),
+                valueService.getDescendantValues(anomalyRoot, t.fingerprint).getFirst(),
+                t.sd.getDomainNode(), null, null, -1, -1, true);
+        assertFalse(persistedBefore.isEmpty(), "Should have a persisted change value");
+
+        // Reprocess with the SAME data — anomaly should still be detected
+        // because baseline window (domain <= 6) is still [100,100,100,100,100]
+        List<ValueEntity> reprocessed = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+        assertEquals(1, reprocessed.size(),
+                "Reprocessing same upload should still detect the anomaly (baseline unchanged)");
+    }
+
+    @Test
+    public void anomaly_at_domain_value_is_consistent_across_calls() throws Exception {
+        // Verify that for the same data, multiple calls produce the same result
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 6, 500.0);
+
+        List<ValueEntity> first = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+        List<ValueEntity> second = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+
+        assertEquals(first.size(), second.size(), "Same data should produce same number of anomalies");
+        if (!first.isEmpty()) {
+            assertEquals(first.get(0).data.get("value").asDouble(),
+                    second.get(0).data.get("value").asDouble(), 0.01,
+                    "Same data should produce same anomaly value");
+        }
+    }
+
+    @Test
+    public void multiple_datasets_per_upload() throws Exception {
+        // Upload with multiple split values (datasets) — each should be checked independently
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload 5 stable data points for "alpha" at y=100
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+        // Upload 5 stable data points for "beta" at y=200
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "beta", i + 10, 200.0);
+        }
+
+        // Upload with BOTH fingerprints: alpha normal (y=100), beta anomalous (y=500)
+        tm.begin();
+        ValueEntity root = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+                """
+                { "split": [
+                    { "fingerprint": "alpha", "domain": 6, "y": 100.0 },
+                    { "fingerprint": "beta", "domain": 16, "y": 500.0 }
+                ] }
+                """));
+        root.persist();
+        // Create both datasets
+        com.fasterxml.jackson.databind.JsonNode splitArr = root.data.get("split");
+        for (int i = 0; i < splitArr.size(); i++) {
+            com.fasterxml.jackson.databind.JsonNode ds = splitArr.get(i);
+            ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root));
+            split.persist();
+            new ValueEntity(null, t.domain, ds.get("domain"), List.of(split)).persist();
+            new ValueEntity(null, t.range, ds.get("y"), List.of(split)).persist();
+            new ValueEntity(null, t.fingerprint, ds.get("fingerprint"), List.of(split)).persist();
+        }
+        tm.commit();
+
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, root, 0);
+
+        // Alpha (y=100 matching baseline of 100) should NOT trigger
+        // Beta (y=500 vs baseline of 200) SHOULD trigger
+        assertEquals(1, changes.size(),
+                "Only beta should trigger anomaly. Alpha matches its baseline.");
+        assertEquals("beta", changes.get(0).data.get("fingerprint").asText(),
+                "The anomaly should be for the beta fingerprint");
+    }
+
+    @Test
+    public void datasets_do_not_cross_contaminate_baselines() throws Exception {
+        // Alpha baseline: y=100, Beta baseline: y=1000 (very different).
+        // Upload alpha at y=500 — anomalous relative to alpha baseline (100)
+        // but normal relative to beta baseline (1000).
+        // If baselines cross-contaminate, the combined mean would be ~550
+        // and y=500 might NOT be flagged. Correct scoping means alpha's
+        // baseline is purely [100,100,...] and 500 is clearly anomalous.
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Build up history: 5 uploads, each with BOTH datasets
+        for (int i = 1; i <= 5; i++) {
+            tm.begin();
+            ValueEntity root = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+                    String.format("""
+                    { "split": [
+                        { "fingerprint": "alpha", "domain": %d, "y": 100.0 },
+                        { "fingerprint": "beta", "domain": %d, "y": 1000.0 }
+                    ] }
+                    """, i, i + 100)));
+            root.persist();
+            com.fasterxml.jackson.databind.JsonNode splitArr = root.data.get("split");
+            for (int j = 0; j < splitArr.size(); j++) {
+                com.fasterxml.jackson.databind.JsonNode ds = splitArr.get(j);
+                ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root));
+                split.persist();
+                new ValueEntity(null, t.domain, ds.get("domain"), List.of(split)).persist();
+                new ValueEntity(null, t.range, ds.get("y"), List.of(split)).persist();
+                new ValueEntity(null, t.fingerprint, ds.get("fingerprint"), List.of(split)).persist();
+            }
+            tm.commit();
+        }
+
+        // Upload 6: alpha anomalous (y=500), beta normal (y=1000)
+        tm.begin();
+        ValueEntity root6 = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+                """
+                { "split": [
+                    { "fingerprint": "alpha", "domain": 6, "y": 500.0 },
+                    { "fingerprint": "beta", "domain": 106, "y": 1000.0 }
+                ] }
+                """));
+        root6.persist();
+        com.fasterxml.jackson.databind.JsonNode splitArr6 = root6.data.get("split");
+        for (int j = 0; j < splitArr6.size(); j++) {
+            com.fasterxml.jackson.databind.JsonNode ds = splitArr6.get(j);
+            ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root6));
+            split.persist();
+            new ValueEntity(null, t.domain, ds.get("domain"), List.of(split)).persist();
+            new ValueEntity(null, t.range, ds.get("y"), List.of(split)).persist();
+            new ValueEntity(null, t.fingerprint, ds.get("fingerprint"), List.of(split)).persist();
+        }
+        tm.commit();
+
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, root6, 0);
+
+        // Alpha should trigger (500 vs baseline of 100), beta should NOT (1000 vs baseline of 1000)
+        assertEquals(1, changes.size(),
+                "Only alpha should trigger. If baselines cross-contaminate, " +
+                "the combined mean (~550) would make 500 look normal.");
+        assertEquals("alpha", changes.get(0).data.get("fingerprint").asText());
+        assertEquals(500.0, changes.get(0).data.get("value").asDouble(), 0.01);
+        assertEquals(100.0, changes.get(0).data.get("mean").asDouble(), 0.01,
+                "Mean should be 100 (alpha's baseline), not ~550 (combined)");
+    }
+
+    @Test
+    public void groupBy_scopes_range_values_to_correct_dataset() throws Exception {
+        // Verify that each fingerprint's range values come from its own split branch,
+        // not from all branches in the upload. If groupBy scoping is wrong, the method
+        // would get ALL range values from the upload regardless of which dataset they
+        // belong to, producing incorrect baselines.
+        //
+        // Alpha: y=100 (stable), Beta: y=100 (stable but different dataset)
+        // Upload alpha at y=100 (normal) — should NOT trigger, even though beta has
+        // the same values (proving we're not accidentally mixing datasets)
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // History with both datasets at y=100
+        for (int i = 1; i <= 5; i++) {
+            tm.begin();
+            ValueEntity root = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+                    String.format("""
+                    { "split": [
+                        { "fingerprint": "alpha", "domain": %d, "y": 100.0 },
+                        { "fingerprint": "beta", "domain": %d, "y": 100.0 }
+                    ] }
+                    """, i, i + 100)));
+            root.persist();
+            com.fasterxml.jackson.databind.JsonNode splitArr = root.data.get("split");
+            for (int j = 0; j < splitArr.size(); j++) {
+                com.fasterxml.jackson.databind.JsonNode ds = splitArr.get(j);
+                ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root));
+                split.persist();
+                new ValueEntity(null, t.domain, ds.get("domain"), List.of(split)).persist();
+                new ValueEntity(null, t.range, ds.get("y"), List.of(split)).persist();
+                new ValueEntity(null, t.fingerprint, ds.get("fingerprint"), List.of(split)).persist();
+            }
+            tm.commit();
+        }
+
+        // Upload 6: both datasets normal
+        tm.begin();
+        ValueEntity root6 = new ValueEntity(null, t.root, new com.fasterxml.jackson.databind.ObjectMapper().readTree(
+                """
+                { "split": [
+                    { "fingerprint": "alpha", "domain": 6, "y": 100.0 },
+                    { "fingerprint": "beta", "domain": 106, "y": 100.0 }
+                ] }
+                """));
+        root6.persist();
+        com.fasterxml.jackson.databind.JsonNode splitArr6 = root6.data.get("split");
+        for (int j = 0; j < splitArr6.size(); j++) {
+            com.fasterxml.jackson.databind.JsonNode ds = splitArr6.get(j);
+            ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root6));
+            split.persist();
+            new ValueEntity(null, t.domain, ds.get("domain"), List.of(split)).persist();
+            new ValueEntity(null, t.range, ds.get("y"), List.of(split)).persist();
+            new ValueEntity(null, t.fingerprint, ds.get("fingerprint"), List.of(split)).persist();
+        }
+        tm.commit();
+
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, root6, 0);
+
+        assertEquals(0, changes.size(),
+                "Neither dataset should trigger — both are stable at y=100. " +
+                "If groupBy scoping is wrong, range values from both datasets would " +
+                "be mixed, potentially doubling the sample count or producing " +
+                "unexpected baseline statistics.");
+    }
+
+    @Test
+    public void ordered_sequential_uploads_detect_and_verify() throws Exception {
+        // Mirror the RelativeDifference ordered test pattern:
+        // Upload 1: insufficient data → no change
+        // Upload 2: enough data but within baseline → no change
+        // Upload 3: anomalous value → detect
+        TestTopology t = createTopology(3, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload 1: domain=1, y=100
+        ValueEntity root1 = uploadDataPoint(t, "alpha", 1, 100.0);
+        List<ValueEntity> changes1 = nodeService.calculateStdDevAnomalyValues(t.sd, root1, 0);
+        assertEquals(0, changes1.size(),
+                "Upload 1: only 1 sample, below minDataPoints=3, should produce no anomalies");
+
+        // Upload 2: domain=2, y=101
+        ValueEntity root2 = uploadDataPoint(t, "alpha", 2, 101.0);
+        List<ValueEntity> changes2 = nodeService.calculateStdDevAnomalyValues(t.sd, root2, 0);
+        assertEquals(0, changes2.size(),
+                "Upload 2: only 2 samples, below minDataPoints=3, should produce no anomalies");
+
+        // Upload 3: domain=3, y=100 (stable, 3 samples now, but within baseline)
+        ValueEntity root3 = uploadDataPoint(t, "alpha", 3, 100.0);
+        List<ValueEntity> changes3 = nodeService.calculateStdDevAnomalyValues(t.sd, root3, 0);
+        assertEquals(0, changes3.size(),
+                "Upload 3: 3 samples, all stable ~100, no anomaly");
+
+        // Upload 4: domain=4, y=100 (still stable)
+        ValueEntity root4 = uploadDataPoint(t, "alpha", 4, 100.0);
+        List<ValueEntity> changes4 = nodeService.calculateStdDevAnomalyValues(t.sd, root4, 0);
+        assertEquals(0, changes4.size(),
+                "Upload 4: stable baseline, no anomaly");
+
+        // Upload 5: domain=5, y=200 (anomaly — large jump from baseline of ~100)
+        ValueEntity root5 = uploadDataPoint(t, "alpha", 5, 200.0);
+        List<ValueEntity> changes5 = nodeService.calculateStdDevAnomalyValues(t.sd, root5, 0);
+        assertEquals(1, changes5.size(),
+                "Upload 5: y=200 vs baseline ~100, should detect anomaly");
+
+        JsonNode changeData = changes5.get(0).data;
+        assertEquals(200.0, changeData.get("value").asDouble(), 0.01, "Anomalous value should be 200");
+        assertTrue(changeData.get("mean").asDouble() < 110, "Mean of baseline should be close to 100");
+        assertEquals("above", changeData.get("direction").asText(), "200 > mean, direction should be 'above'");
+        assertEquals("alpha", changeData.get("fingerprint").asText(), "Fingerprint should be alpha");
+        assertEquals(5, changeData.get("domainvalue").asInt(), "Domain value should be 5 (current upload)");
+    }
+
+    @Test
+    public void mid_sequence_upload_uses_correct_baseline() throws Exception {
+        // Upload values at domain 1,2,3,4,5 (all y=100), then 6,7,8,9,10 (all y=100).
+        // Now upload at domain=4 with y=500 (mid-sequence, anomalous).
+        // The baseline should be values with domain <= 4 from previous uploads,
+        // i.e., domains 1,2,3,4 (all y=100). The anomaly should be detected.
+        TestTopology t = createTopology(10, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload 10 stable values
+        for (int i = 1; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Upload at domain=4 with anomalous value — mid-sequence
+        ValueEntity midRoot = uploadDataPoint(t, "alpha", 4, 500.0);
+        List<ValueEntity> midChanges = nodeService.calculateStdDevAnomalyValues(t.sd, midRoot, 0);
+
+        assertEquals(1, midChanges.size(),
+                "Mid-sequence upload at domain=4 with y=500 should detect anomaly. " +
+                "Baseline (domain <= 4) is [100,100,100,100], so 500 is clearly anomalous.");
+        assertEquals(500.0, midChanges.get(0).data.get("value").asDouble(), 0.01);
+        // The domain value in the output should be 4 (the current upload's domain)
+        assertEquals(4, midChanges.get(0).data.get("domainvalue").asInt(),
+                "Output should report the current upload's domain value (4), not the latest (10)");
+    }
+
+    @Test
+    public void mid_sequence_upload_normal_value_no_anomaly() throws Exception {
+        // Upload values at domain 1-10 with small natural variance.
+        // Upload at domain=5 with a value within the variance — mid-sequence.
+        // Should NOT trigger anomaly.
+        TestTopology t = createTopology(10, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        double[] baseline = {100, 102, 98, 101, 99, 103, 97, 100, 102, 98};
+        for (int i = 0; i < baseline.length; i++) {
+            uploadDataPoint(t, "alpha", i + 1, baseline[i]);
+        }
+
+        // Upload mid-sequence at domain=5, y=100 — well within baseline variance
+        ValueEntity midRoot = uploadDataPoint(t, "alpha", 5, 100.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, midRoot, 0);
+
+        assertEquals(0, changes.size(),
+                "Mid-sequence upload at domain=5 with y=100 should not trigger anomaly. " +
+                "Baseline has natural variance ~2, and 100 is squarely in the middle.");
+    }
+
+    @Test
+    public void mid_sequence_baseline_excludes_future_values() throws Exception {
+        // Upload: domain 1-5 at y=100, then domain 6-10 at y=200 (legitimate shift).
+        // Upload at domain=3 with y=100 (mid-sequence, matches OLD baseline).
+        // The baseline for domain=3 should be domains 1,2,3 (all y=100).
+        // Values at domain 6-10 (y=200) should NOT be in the baseline
+        // because they have domain > 3.
+        // y=100 matches the baseline perfectly — no anomaly.
+        TestTopology t = createTopology(10, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+        for (int i = 6; i <= 10; i++) {
+            uploadDataPoint(t, "alpha", i, 200.0);
+        }
+
+        // Upload at domain=3, y=100 — matches OLD baseline, NOT new baseline
+        ValueEntity midRoot = uploadDataPoint(t, "alpha", 3, 100.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, midRoot, 0);
+
+        assertEquals(0, changes.size(),
+                "Mid-sequence upload at domain=3 with y=100 should NOT trigger anomaly. " +
+                "Baseline for domain<=3 is [100,100,100] — value 100 matches perfectly. " +
+                "The shift to 200 at domains 6-10 should not affect this baseline.");
+    }
+
+    @Test
+    public void exact_window_size_boundary() throws Exception {
+        // Regression test for off-by-one in windowSize.
+        // With windowSize=5 and minDataPoints=6, we need exactly 5 baseline values
+        // plus the current value (6 total). If the query fetches windowSize (5) instead
+        // of windowSize+1 (6), the current value consumes a baseline slot, leaving only
+        // 4 baseline + 1 current = 5 total. With minDataPoints=6, the calculator returns
+        // null (insufficient data) and the anomaly is missed.
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 6);
+
+        // Upload exactly 5 baseline values
+        for (int i = 1; i <= 5; i++) {
+            uploadDataPoint(t, "alpha", i, 100.0);
+        }
+
+        // Upload anomaly — with exactly 5 baseline + 1 current = 6 total
+        // minDataPoints=6 requires exactly 6 values to proceed
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 6, 500.0);
+        List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+
+        assertEquals(1, changes.size(),
+                "With exactly windowSize=5 baseline values + 1 current = 6 total, " +
+                "minDataPoints=6 should be met and anomaly detected. " +
+                "If the query fetches windowSize instead of windowSize+1, only 5 values " +
+                "reach the calculator, failing the minDataPoints check.");
+        assertEquals(500.0, changes.get(0).data.get("value").asDouble(), 0.01);
+    }
+
+    @Test
+    public void recalculate_simulation_produces_consistent_results() throws Exception {
+        // Simulate the recalculate flow: StdDev runs once per root value.
+        // Upload a series with an anomaly at the end, verify detection.
+        // Then re-run calculateStdDevAnomalyValues for each root value
+        // (mimicking what recalculate does) and verify the final result
+        // is consistent — same anomalies, no accumulation.
+        TestTopology t = createTopology(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 3);
+
+        // Upload 5 stable values + 1 anomaly
+        List<ValueEntity> roots = new java.util.ArrayList<>();
+        for (int i = 1; i <= 5; i++) {
+            roots.add(uploadDataPoint(t, "alpha", i, 100.0));
+        }
+        ValueEntity anomalyRoot = uploadDataPoint(t, "alpha", 6, 500.0);
+        roots.add(anomalyRoot);
+
+        // Initial detection: only the anomaly root should produce a change
+        List<ValueEntity> initialChanges = nodeService.calculateStdDevAnomalyValues(t.sd, anomalyRoot, 0);
+        assertEquals(1, initialChanges.size(), "Should detect 1 anomaly");
+
+        // Persist the change
+        tm.begin();
+        for (ValueEntity change : initialChanges) {
+            valueService.create(change);
+        }
+        tm.commit();
+
+        // Simulate recalculate: run for EACH root value
+        // Non-anomalous roots should produce 0 changes.
+        // The anomaly root should re-detect the anomaly.
+        // Stale cleanup should delete the old persisted change and
+        // the new one replaces it (or keeps it if unchanged).
+        for (ValueEntity root : roots) {
+            List<ValueEntity> changes = nodeService.calculateStdDevAnomalyValues(t.sd, root, 0);
+            if (!changes.isEmpty()) {
+                tm.begin();
+                for (ValueEntity change : changes) {
+                    valueService.create(change);
+                }
+                tm.commit();
+            }
+        }
+
+        // After simulated recalculation, verify exactly 1 anomaly remains
+        tm.begin();
+        List<ValueEntity> finalPersisted = ValueEntity.find("node.id", t.sd.id).list();
+        assertEquals(1, finalPersisted.size(),
+                "After simulated recalculation (running StdDev per root), " +
+                "should still have exactly 1 anomaly (y=500). " +
+                "If changes accumulated, cleanup is broken. " +
+                "Found: " + finalPersisted.size());
+        assertEquals(500.0, finalPersisted.get(0).data.get("value").asDouble(), 0.01,
+                "The persisted anomaly should be for y=500");
+        tm.commit();
+    }
+}


### PR DESCRIPTION
Standard-deviation-based anomaly detection: detects values that exceed mean ± (deviations × stddev) of the preceding windowSize data points within the same fingerprint group.

Entity:
- StdDevAnomaly extends NodeEntity implements DetectionNode
- @DiscriminatorValue('sd'), sources: [fingerprint, groupBy, range, domain]
- Config: windowSize (default 40), deviations (default 4.0), direction (UPPER/LOWER/BOTH enum), minDataPoints (default 10)

API:
- NodeType.STDDEV_ANOMALY added
- StdDevAnomalyConfig record with Direction enum
- Wired into NodeService.createConfigured() and calculateValues()

Detection logic (calculateStdDevAnomalyValues):
- For each fingerprint: get range values ordered by domain across all uploads via findMatchingFingerprint
- Compute SummaryStatistics (mean, stddev) of baseline window
- Zero-stddev guard: floor at max(|mean| * 0.001, 1e-10)
- Check current value against mean ± deviations * stddev
- Output: {value, mean, stddev, deviations, direction, threshold, fingerprint, domainvalue}
