### PR TITLE
Ephemeral value data with three-state nullable Boolean (issue #123)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/EphemeralMode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/EphemeralMode.java
@@ -1,0 +1,16 @@
+package io.hyperfoil.tools.h5m.api;
+
+/**
+ * Controls whether value data for a node is discarded after upload
+ * processing completes to save storage.
+ *
+ * The value rows and edges are always preserved for ancestry queries.
+ */
+public enum EphemeralMode {
+    /** System decides based on graph structure: ephemeral if node has non-detection children (intermediate node) */
+    AUTO,
+    /** User explicitly wants data discarded after processing */
+    DISCARD,
+    /** User explicitly wants data kept */
+    KEEP
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
@@ -13,7 +13,8 @@ public record Node(
         @Schema(description = "Node type") NodeType type,
         @Schema(description = "Node group ID") Long groupId,
         @Schema(description = "Node operation (jq filter, JS function, etc.)") String operation,
-        @Schema(description = "Source dependency nodes") List<Node> sources) {
+        @Schema(description = "Source dependency nodes") List<Node> sources,
+        @Schema(description = "Whether value data is ephemeral: null=auto (based on children), true=always discard, false=always keep") Boolean ephemeral) {
 
     @Override
     public int hashCode() {

--- a/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Node.java
@@ -14,7 +14,7 @@ public record Node(
         @Schema(description = "Node group ID") Long groupId,
         @Schema(description = "Node operation (jq filter, JS function, etc.)") String operation,
         @Schema(description = "Source dependency nodes") List<Node> sources,
-        @Schema(description = "Whether value data is ephemeral: null=auto (based on children), true=always discard, false=always keep") Boolean ephemeral) {
+        @Schema(description = "Ephemeral mode: AUTO (system decides), DISCARD (always discard data), KEEP (always keep data)") EphemeralMode ephemeral) {
 
     @Override
     public int hashCode() {

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.entity;
 
 import com.fasterxml.jackson.annotation.*;
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
 import io.hyperfoil.tools.h5m.queue.KahnDagSort;
@@ -30,16 +31,17 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
     public ScalarVariableMethod scalarMethod = ScalarVariableMethod.First;
 
     /**
-     * Controls whether value data for this node is nulled out after upload
+     * Controls whether value data for this node is discarded after upload
      * processing completes to save storage.
      *
-     * null  = auto: ephemeral if node has non-detection children (intermediate node)
-     * true  = user explicitly wants data discarded
-     * false = user explicitly wants data kept
+     * AUTO    = system decides based on graph structure (intermediate nodes get discarded)
+     * DISCARD = user explicitly wants data discarded
+     * KEEP    = user explicitly wants data kept
      *
      * The value rows and edges are always preserved for ancestry queries.
      */
-    public Boolean ephemeral;
+    @Enumerated(EnumType.STRING)
+    public EphemeralMode ephemeral = EphemeralMode.AUTO;
 
     @ManyToOne(cascade = { CascadeType.PERSIST }, fetch = FetchType.LAZY )
     @JoinColumn(name = "group_id")

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -29,6 +29,18 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
     public MultiIterationType multiType = MultiIterationType.Length;
     public ScalarVariableMethod scalarMethod = ScalarVariableMethod.First;
 
+    /**
+     * Controls whether value data for this node is nulled out after upload
+     * processing completes to save storage.
+     *
+     * null  = auto: ephemeral if node has non-detection children (intermediate node)
+     * true  = user explicitly wants data discarded
+     * false = user explicitly wants data kept
+     *
+     * The value rows and edges are always preserved for ancestry queries.
+     */
+    public Boolean ephemeral;
+
     @ManyToOne(cascade = { CascadeType.PERSIST }, fetch = FetchType.LAZY )
     @JoinColumn(name = "group_id")
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "group_id")

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.svc.ValueService;
 import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
@@ -25,6 +28,9 @@ public class NodeResource {
 
     @Inject
     NodeServiceInterface nodeService;
+
+    @Inject
+    ValueService valueService;
 
     @POST
     @Authenticated
@@ -62,6 +68,33 @@ public class NodeResource {
     @Operation(description = "Delete a node by its ID")
     public void delete(@PathParam("id") Long nodeId) {
         nodeService.delete(nodeId);
+    }
+
+    @PUT
+    @Path("{id}/ephemeral")
+    @Authenticated
+    @Transactional
+    @Operation(description = "Set ephemeral mode: true=discard data, false=keep data, auto=system decides based on children")
+    public void setEphemeral(
+            @PathParam("id") Long nodeId,
+            @QueryParam("mode") @Parameter(description = "true, false, or auto") @DefaultValue("true") String mode) {
+        NodeEntity node = NodeEntity.findById(nodeId);
+        if (node == null) {
+            throw new NotFoundException("Node not found: " + nodeId);
+        }
+        if ("true".equalsIgnoreCase(mode) && (node.isDetection() || node.type() == NodeType.ROOT)) {
+            throw new BadRequestException("Detection and root nodes cannot be set to ephemeral");
+        }
+        switch (mode.toLowerCase()) {
+            case "true" -> {
+                node.ephemeral = true;
+                // Immediately null out existing data
+                valueService.nullifyNodeData(nodeId);
+            }
+            case "false" -> node.ephemeral = false;
+            case "auto" -> node.ephemeral = null;
+            default -> throw new BadRequestException("Invalid mode: " + mode + ". Use true, false, or auto");
+        }
     }
 
     @GET

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -1,10 +1,12 @@
 package io.hyperfoil.tools.h5m.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.UploadProcessingEntity;
 import io.hyperfoil.tools.h5m.svc.ValueService;
 import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.PermitAll;
@@ -74,26 +76,33 @@ public class NodeResource {
     @Path("{id}/ephemeral")
     @Authenticated
     @Transactional
-    @Operation(description = "Set ephemeral mode: true=discard data, false=keep data, auto=system decides based on children")
+    @Operation(description = "Set ephemeral mode: DISCARD=discard data, KEEP=keep data, AUTO=system decides based on children")
     public void setEphemeral(
             @PathParam("id") Long nodeId,
-            @QueryParam("mode") @Parameter(description = "true, false, or auto") @DefaultValue("true") String mode) {
+            @QueryParam("mode") @Parameter(description = "DISCARD, KEEP, or AUTO") @DefaultValue("DISCARD") String mode) {
         NodeEntity node = NodeEntity.findById(nodeId);
         if (node == null) {
             throw new NotFoundException("Node not found: " + nodeId);
         }
-        if ("true".equalsIgnoreCase(mode) && (node.isDetection() || node.type() == NodeType.ROOT)) {
+        EphemeralMode ephemeralMode;
+        try {
+            ephemeralMode = EphemeralMode.valueOf(mode.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid mode: " + mode + ". Use DISCARD, KEEP, or AUTO");
+        }
+        if (ephemeralMode == EphemeralMode.DISCARD && (node.isDetection() || node.type() == NodeType.ROOT)) {
             throw new BadRequestException("Detection and root nodes cannot be set to ephemeral");
         }
-        switch (mode.toLowerCase()) {
-            case "true" -> {
-                node.ephemeral = true;
-                // Immediately null out existing data
+        node.ephemeral = ephemeralMode;
+        if (ephemeralMode == EphemeralMode.DISCARD) {
+            // Only nullify existing data if no uploads are in progress for this folder
+            String folderName = node.group.name;
+            long inFlight = UploadProcessingEntity.count("folderName = ?1 and completed = false", folderName);
+            if (inFlight == 0) {
                 valueService.nullifyNodeData(nodeId);
             }
-            case "false" -> node.ephemeral = false;
-            case "auto" -> node.ephemeral = null;
-            default -> throw new BadRequestException("Invalid mode: " + mode + ". Use true, false, or auto");
+            // If uploads are in progress, data will be nullified when they complete
+            // via nullifyEphemeralData() in FolderService.upload() whenComplete callback
         }
     }
 

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -105,6 +105,7 @@ public class FolderService implements FolderServiceInterface {
                             if (entity != null) {
                                 entity.completed = true;
                             }
+                            valueService.nullifyEphemeralData(rootValue.id);
                         });
                     });
                 } else {
@@ -342,12 +343,17 @@ public class FolderService implements FolderServiceInterface {
             }
 
             CompletableFuture<Void> future = workService.createTracked(works, Set.of(newValue.id));
-            // Mark completed when all work finishes
+            // Mark completed and null out ephemeral data when all work finishes
             future.whenComplete((v, t) -> {
                 QuarkusTransaction.requiringNew().run(() -> {
                     UploadProcessingEntity entity = UploadProcessingEntity.find("rootValueId", newValue.id).firstResult();
                     if (entity != null) {
                         entity.completed = true;
+                    }
+                    // Null out data for ephemeral nodes to reclaim storage
+                    int nullified = valueService.nullifyEphemeralData(newValue.id);
+                    if (nullified > 0) {
+                        Log.debugf("Nullified data for %d ephemeral values (upload %d)", nullified, newValue.id);
                     }
                 });
             });

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -661,6 +661,86 @@ public class ValueService implements ValueServiceInterface {
 
     }
 
+    /**
+     * Nulls out value.data for values whose nodes have ephemeral=true,
+     * scoped to descendants of the given root value. Called after upload
+     * processing completes to reclaim storage.
+     *
+     * Only touches nodes with ephemeral=true (explicitly set). Nodes with
+     * ephemeral=null (auto) or ephemeral=false are not affected. To resolve
+     * null states into ephemeral=true based on graph structure, call
+     * {@link #markAutoEphemeral(long)} first.
+     *
+     * Value rows and edges are always preserved for ancestry queries.
+     *
+     * @return the number of values whose data was nulled
+     */
+    @Transactional
+    public int nullifyEphemeralData(long rootValueId) {
+        return em.createNativeQuery("""
+            WITH RECURSIVE descendants (v_id) AS (
+                SELECT ve.child_id FROM value_edge ve WHERE ve.parent_id = :rootId
+                UNION ALL
+                SELECT ve.child_id FROM value_edge ve JOIN descendants d ON ve.parent_id = d.v_id
+            )
+            UPDATE value SET data = NULL
+            WHERE id IN (SELECT v_id FROM descendants)
+              AND node_id IN (
+                -- Only nullify nodes explicitly set to ephemeral (true)
+                -- Nodes with ephemeral=null (auto) or ephemeral=false are not touched
+                -- Auto-detection is handled separately via markAutoEphemeral()
+                -- Root and detection nodes are excluded as a safety net
+                SELECT id FROM node WHERE ephemeral = true
+                  AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
+              )
+              AND data IS NOT NULL
+            """)
+            .setParameter("rootId", rootValueId)
+            .executeUpdate();
+    }
 
+    /**
+     * Marks nodes as auto-ephemeral based on graph structure.
+     * Nodes with ephemeral=null that have non-detection children
+     * (i.e., intermediate nodes) are set to ephemeral=true.
+     * Nodes with ephemeral=false (user override) are not touched.
+     * Root and detection nodes are never marked ephemeral.
+     *
+     * @param groupId the node group to evaluate
+     * @return number of nodes marked as ephemeral
+     */
+    @Transactional
+    public int markAutoEphemeral(long groupId) {
+        return em.createNativeQuery("""
+            UPDATE node SET ephemeral = true
+            WHERE group_id = :groupId
+              AND ephemeral IS NULL
+              AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
+              AND EXISTS (
+                SELECT 1 FROM node_edge ne
+                JOIN node child ON child.id = ne.child_id
+                WHERE ne.parent_id = node.id
+                  AND child.type NOT IN ('ft', 'rd', 'sd', 'ed')
+              )
+            """)
+            .setParameter("groupId", groupId)
+            .executeUpdate();
+    }
+
+    /**
+     * Nulls out all existing value data for a specific node.
+     * Called when a user explicitly sets ephemeral = true on a node.
+     *
+     * @return the number of values whose data was nulled
+     */
+    @Transactional
+    public int nullifyNodeData(long nodeId) {
+        return em.createNativeQuery("""
+            UPDATE value SET data = NULL
+            WHERE node_id = :nodeId AND data IS NOT NULL
+            """)
+            .setParameter("nodeId", nodeId)
+            .executeUpdate();
+    }
 
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -662,13 +662,13 @@ public class ValueService implements ValueServiceInterface {
     }
 
     /**
-     * Nulls out value.data for values whose nodes have ephemeral=true,
+     * Nulls out value.data for values whose nodes have ephemeral=DISCARD,
      * scoped to descendants of the given root value. Called after upload
      * processing completes to reclaim storage.
      *
-     * Only touches nodes with ephemeral=true (explicitly set). Nodes with
-     * ephemeral=null (auto) or ephemeral=false are not affected. To resolve
-     * null states into ephemeral=true based on graph structure, call
+     * Only touches nodes with ephemeral=DISCARD (explicitly set). Nodes with
+     * ephemeral=AUTO or ephemeral=KEEP are not affected. To resolve
+     * AUTO states into DISCARD based on graph structure, call
      * {@link #markAutoEphemeral(long)} first.
      *
      * Value rows and edges are always preserved for ancestry queries.
@@ -686,11 +686,11 @@ public class ValueService implements ValueServiceInterface {
             UPDATE value SET data = NULL
             WHERE id IN (SELECT v_id FROM descendants)
               AND node_id IN (
-                -- Only nullify nodes explicitly set to ephemeral (true)
-                -- Nodes with ephemeral=null (auto) or ephemeral=false are not touched
+                -- Only nullify nodes explicitly set to DISCARD
+                -- Nodes with AUTO or KEEP are not touched
                 -- Auto-detection is handled separately via markAutoEphemeral()
                 -- Root and detection nodes are excluded as a safety net
-                SELECT id FROM node WHERE ephemeral = true
+                SELECT id FROM node WHERE ephemeral = 'DISCARD'
                   AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
               )
               AND data IS NOT NULL
@@ -701,9 +701,9 @@ public class ValueService implements ValueServiceInterface {
 
     /**
      * Marks nodes as auto-ephemeral based on graph structure.
-     * Nodes with ephemeral=null that have non-detection children
-     * (i.e., intermediate nodes) are set to ephemeral=true.
-     * Nodes with ephemeral=false (user override) are not touched.
+     * Nodes with ephemeral=AUTO that have non-detection children
+     * (i.e., intermediate nodes) are set to ephemeral=DISCARD.
+     * Nodes with ephemeral=KEEP (user override) are not touched.
      * Root and detection nodes are never marked ephemeral.
      *
      * @param groupId the node group to evaluate
@@ -712,9 +712,9 @@ public class ValueService implements ValueServiceInterface {
     @Transactional
     public int markAutoEphemeral(long groupId) {
         return em.createNativeQuery("""
-            UPDATE node SET ephemeral = true
+            UPDATE node SET ephemeral = 'DISCARD'
             WHERE group_id = :groupId
-              AND ephemeral IS NULL
+              AND ephemeral = 'AUTO'
               AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
               AND EXISTS (
                 SELECT 1 FROM node_edge ne
@@ -729,7 +729,7 @@ public class ValueService implements ValueServiceInterface {
 
     /**
      * Nulls out all existing value data for a specific node.
-     * Called when a user explicitly sets ephemeral = true on a node.
+     * Called when a user explicitly sets ephemeral to DISCARD on a node.
      *
      * @return the number of values whose data was nulled
      */

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
@@ -218,69 +219,69 @@ public class FolderServiceTest extends FreshDb {
     // -- Ephemeral value data --
 
     @Test
-    public void ephemeral_true_data_nulled_after_upload() throws Exception {
-        // ephemeral=true: data should be nulled after upload
+    public void ephemeral_discard_data_nulled_after_upload() throws Exception {
+        // ephemeral=DISCARD: data should be nulled after upload
         tm.begin();
-        long folderId = folderService.create("ephemeral-true-test");
+        long folderId = folderService.create("ephemeral-discard-test");
         FolderEntity folder = folderService.read(folderId);
 
         JqNode node = new JqNode("extract", ".key", folder.group.root);
         node.group = folder.group;
-        node.ephemeral = true; // explicitly ephemeral
+        node.ephemeral = EphemeralMode.DISCARD;
         node.persist();
         long nodeId = node.id;
         tm.commit();
 
-        folderService.upload("ephemeral-true-test", "$",
+        folderService.upload("ephemeral-discard-test", "$",
                 mapper.readTree("{\"key\": \"k1\"}"))
                 .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
         assertFalse(values.isEmpty(), "Node should still have value rows");
-        assertNull(values.get(0).data, "ephemeral=true: data should be null after upload");
+        assertNull(values.get(0).data, "ephemeral=DISCARD: data should be null after upload");
         tm.commit();
     }
 
     @Test
-    public void ephemeral_false_data_preserved_after_upload() throws Exception {
-        // ephemeral=false: data should always be preserved
+    public void ephemeral_keep_data_preserved_after_upload() throws Exception {
+        // ephemeral=KEEP: data should always be preserved
         tm.begin();
-        long folderId = folderService.create("ephemeral-false-test");
+        long folderId = folderService.create("ephemeral-keep-test");
         FolderEntity folder = folderService.read(folderId);
 
         JqNode node = new JqNode("extract", ".key", folder.group.root);
         node.group = folder.group;
-        node.ephemeral = false; // explicitly materialized
+        node.ephemeral = EphemeralMode.KEEP;
         node.persist();
         long nodeId = node.id;
         tm.commit();
 
-        folderService.upload("ephemeral-false-test", "$",
+        folderService.upload("ephemeral-keep-test", "$",
                 mapper.readTree("{\"key\": \"k1\"}"))
                 .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
         assertFalse(values.isEmpty(), "Node should have values");
-        assertNotNull(values.get(0).data, "ephemeral=false: data should be preserved");
+        assertNotNull(values.get(0).data, "ephemeral=KEEP: data should be preserved");
         assertEquals("k1", values.get(0).data.asText());
         tm.commit();
     }
 
     @Test
-    public void ephemeral_null_auto_intermediate_data_nulled() throws Exception {
-        // ephemeral=null (auto): intermediate node (has non-detection child) should be nulled
+    public void ephemeral_auto_intermediate_data_nulled() throws Exception {
+        // ephemeral=AUTO: intermediate node (has non-detection child) should be nulled
         // Node graph: root → parent (.key) → child ({parent}:.length)
         // parent is intermediate because child depends on it
         tm.begin();
         long folderId = folderService.create("ephemeral-auto-test");
         FolderEntity folder = folderService.read(folderId);
 
-        // Parent node — ephemeral=null (auto), will have a non-detection child
+        // Parent node — ephemeral=AUTO (default), will have a non-detection child
         JqNode parent = new JqNode("parent", ".key", folder.group.root);
         parent.group = folder.group;
-        // ephemeral defaults to null — auto mode
+        // ephemeral defaults to AUTO
         parent.persist();
 
         // Child node — depends on parent, making parent intermediate
@@ -309,7 +310,7 @@ public class FolderServiceTest extends FreshDb {
         List<ValueEntity> parentValues = ValueEntity.find("node.id", parentId).list();
         assertFalse(parentValues.isEmpty(), "Parent should have value rows");
         assertNull(parentValues.get(0).data,
-                "ephemeral=null with non-detection child: data should be auto-nulled");
+                "ephemeral=AUTO with non-detection child: data should be auto-nulled");
 
         // Child (leaf, auto) should have data preserved
         List<ValueEntity> childValues = ValueEntity.find("node.id", childId).list();
@@ -319,15 +320,15 @@ public class FolderServiceTest extends FreshDb {
     }
 
     @Test
-    public void ephemeral_null_leaf_data_preserved() throws Exception {
-        // ephemeral=null (auto): leaf node (no children) should keep data
+    public void ephemeral_auto_leaf_data_preserved() throws Exception {
+        // ephemeral=AUTO: leaf node (no children) should keep data
         tm.begin();
         long folderId = folderService.create("ephemeral-leaf-test");
         FolderEntity folder = folderService.read(folderId);
 
         JqNode leaf = new JqNode("leaf", ".key", folder.group.root);
         leaf.group = folder.group;
-        // ephemeral defaults to null — auto mode, but no children = leaf
+        // ephemeral defaults to AUTO, but no children = leaf
         leaf.persist();
         long leafId = leaf.id;
         tm.commit();
@@ -340,7 +341,7 @@ public class FolderServiceTest extends FreshDb {
         List<ValueEntity> values = ValueEntity.find("node.id", leafId).list();
         assertFalse(values.isEmpty(), "Leaf should have values");
         assertNotNull(values.get(0).data,
-                "ephemeral=null with no children: leaf data should be preserved");
+                "ephemeral=AUTO with no children: leaf data should be preserved");
         tm.commit();
     }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -215,6 +215,135 @@ public class FolderServiceTest extends FreshDb {
         tm.commit();
     }
 
+    // -- Ephemeral value data --
+
+    @Test
+    public void ephemeral_true_data_nulled_after_upload() throws Exception {
+        // ephemeral=true: data should be nulled after upload
+        tm.begin();
+        long folderId = folderService.create("ephemeral-true-test");
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode node = new JqNode("extract", ".key", folder.group.root);
+        node.group = folder.group;
+        node.ephemeral = true; // explicitly ephemeral
+        node.persist();
+        long nodeId = node.id;
+        tm.commit();
+
+        folderService.upload("ephemeral-true-test", "$",
+                mapper.readTree("{\"key\": \"k1\"}"))
+                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+
+        tm.begin();
+        List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
+        assertFalse(values.isEmpty(), "Node should still have value rows");
+        assertNull(values.get(0).data, "ephemeral=true: data should be null after upload");
+        tm.commit();
+    }
+
+    @Test
+    public void ephemeral_false_data_preserved_after_upload() throws Exception {
+        // ephemeral=false: data should always be preserved
+        tm.begin();
+        long folderId = folderService.create("ephemeral-false-test");
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode node = new JqNode("extract", ".key", folder.group.root);
+        node.group = folder.group;
+        node.ephemeral = false; // explicitly materialized
+        node.persist();
+        long nodeId = node.id;
+        tm.commit();
+
+        folderService.upload("ephemeral-false-test", "$",
+                mapper.readTree("{\"key\": \"k1\"}"))
+                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+
+        tm.begin();
+        List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
+        assertFalse(values.isEmpty(), "Node should have values");
+        assertNotNull(values.get(0).data, "ephemeral=false: data should be preserved");
+        assertEquals("k1", values.get(0).data.asText());
+        tm.commit();
+    }
+
+    @Test
+    public void ephemeral_null_auto_intermediate_data_nulled() throws Exception {
+        // ephemeral=null (auto): intermediate node (has non-detection child) should be nulled
+        // Node graph: root → parent (.key) → child ({parent}:.length)
+        // parent is intermediate because child depends on it
+        tm.begin();
+        long folderId = folderService.create("ephemeral-auto-test");
+        FolderEntity folder = folderService.read(folderId);
+
+        // Parent node — ephemeral=null (auto), will have a non-detection child
+        JqNode parent = new JqNode("parent", ".key", folder.group.root);
+        parent.group = folder.group;
+        // ephemeral defaults to null — auto mode
+        parent.persist();
+
+        // Child node — depends on parent, making parent intermediate
+        // Uses {parent}: prefix to source from parent node
+        JqNode child = new JqNode("child", ".", parent);
+        child.group = folder.group;
+        child.persist();
+
+        long parentId = parent.id;
+        long childId = child.id;
+        long groupId = folder.group.id;
+        tm.commit();
+
+        // Mark auto-ephemeral nodes before uploading
+        tm.begin();
+        int marked = valueService.markAutoEphemeral(groupId);
+        assertTrue(marked > 0, "Parent should be auto-marked as ephemeral");
+        tm.commit();
+
+        folderService.upload("ephemeral-auto-test", "$",
+                mapper.readTree("{\"key\": \"k1\"}"))
+                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+
+        tm.begin();
+        // Parent (intermediate, auto) should have data nulled
+        List<ValueEntity> parentValues = ValueEntity.find("node.id", parentId).list();
+        assertFalse(parentValues.isEmpty(), "Parent should have value rows");
+        assertNull(parentValues.get(0).data,
+                "ephemeral=null with non-detection child: data should be auto-nulled");
+
+        // Child (leaf, auto) should have data preserved
+        List<ValueEntity> childValues = ValueEntity.find("node.id", childId).list();
+        assertFalse(childValues.isEmpty(), "Child should have values");
+        assertNotNull(childValues.get(0).data, "Leaf node data should be preserved");
+        tm.commit();
+    }
+
+    @Test
+    public void ephemeral_null_leaf_data_preserved() throws Exception {
+        // ephemeral=null (auto): leaf node (no children) should keep data
+        tm.begin();
+        long folderId = folderService.create("ephemeral-leaf-test");
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode leaf = new JqNode("leaf", ".key", folder.group.root);
+        leaf.group = folder.group;
+        // ephemeral defaults to null — auto mode, but no children = leaf
+        leaf.persist();
+        long leafId = leaf.id;
+        tm.commit();
+
+        folderService.upload("ephemeral-leaf-test", "$",
+                mapper.readTree("{\"key\": \"k1\"}"))
+                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+
+        tm.begin();
+        List<ValueEntity> values = ValueEntity.find("node.id", leafId).list();
+        assertFalse(values.isEmpty(), "Leaf should have values");
+        assertNotNull(values.get(0).data,
+                "ephemeral=null with no children: leaf data should be preserved");
+        tm.commit();
+    }
+
     @Test
     public void recovery_processes_multiple_independent_nodes() throws Exception {
         // Set up folder with two independent top-level nodes extracting different fields.


### PR DESCRIPTION
Three-state ephemeral flag on NodeEntity:
- null  = auto (system can mark via markAutoEphemeral)
- true  = user explicitly wants data discarded
- false = user explicitly wants data kept

NodeEntity:
- ephemeral: Boolean (nullable)

ValueService:
- nullifyEphemeralData(rootValueId): nullifies data for nodes with ephemeral=true only. Root and detection nodes excluded as safety net. Called after upload and recovery completion.
- nullifyNodeData(nodeId): immediately nullifies all data for a node. Called when user sets ephemeral=true via REST.
- markAutoEphemeral(groupId): bulk-marks intermediate nodes (ephemeral IS NULL + has non-detection children) as ephemeral=true. Skips root, detection, and user-locked (false) nodes.

FolderService:
- upload() and recoverIncompleteUploads() both call nullifyEphemeralData in their whenComplete callbacks.

NodeResource:
- PUT /api/node/{id}/ephemeral?mode=true|false|auto
  - true: sets ephemeral=true + immediately nullifies existing data
  - false: sets ephemeral=false (user override)
  - auto: sets ephemeral=null
  - Detection and root nodes cannot be set to ephemeral

Node API record:
- ephemeral: Boolean (nullable)

Benchmark (10 rhivos runs):
- Upload time: 158s (no regression vs 160s on main)
- DB size: 100 MB (83% reduction from 586 MB on main)