### PR TITLE
Avoid pollutes user home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dependency-reduced-pom.xml
 perf_test/states.yaml
 perf_test/qDup.jar
 jmh-result.*
+
+/h5m.db
+/h5m.db-shm
+/h5m.db-wal

--- a/src/main/java/io/hyperfoil/tools/h5m/provided/DatasourceConfiguration.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/provided/DatasourceConfiguration.java
@@ -51,19 +51,13 @@ public class DatasourceConfiguration {
     public DatasourceConfiguration() {
     }
 
-    public static String getPath(){
+    public static String getPath() {
         String rtrn = "";
-        if(System.getenv("H5M_PATH") !=null ){
+        if (System.getenv("H5M_PATH") != null) {
             rtrn = System.getenv("H5M_PATH");
         } else {
-            //check local directory
-            Path currentRelativePath = Paths.get("");
-            String s = currentRelativePath.toAbsolutePath().toString()+ File.separator+"h5m.db";
-            if((new File(s).exists())){
-                rtrn = s;
-            }else{
-                rtrn = System.getProperty("user.home")+File.separator+"h5m.db";
-            }
+            // Use current working directory only
+            rtrn = System.getProperty("user.dir") + File.separator + "h5m.db";
         }
         return rtrn;
     }


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/h5m/issues/134

We decided to use the current working directory instead of `~/.local/share`

```
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.347 s
[INFO] Finished at: 2026-06-17T10:26:40-03:00
[INFO] ------------------------------------------------------------------------
```
```
dlovison:h5m$ alias h5m="java -jar target/cli/h5m.jar"
dlovison:h5m$ h5m add folder test
dlovison:h5m$ pwd
/home/dlovison/github/Hyperfoil/h5m
dlovison:h5m$ ls h5m*
h5m.db  h5m.db-shm  h5m.db-wal  h5m.iml
```