### PR TITLE
Streamline local development workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ dependency-reduced-pom.xml
 perf_test/states.yaml
 perf_test/qDup.jar
 jmh-result.*
+
+# Locally generated CLI jar
+/h5m.jar
+/h5m.db
+/h5m.db-shm
+/h5m.db-wal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: dev-cli
+
+dev-cli:
+	mvn clean package -Pcli -Dh5m.cli.native=false -DskipTests
+	cp target/cli/h5m.jar .
+	mvn clean quarkus:dev -DskipTests

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,8 @@ quarkus.banner.enabled=false
 %cli.quarkus.datasource.db-kind=sqlite
 %cli.quarkus.quinoa=false
 
+%dev.quarkus.datasource.db-kind=sqlite
+
 # CORS for frontend development (dev profile only)
 %dev.quarkus.http.cors=true
 %dev.quarkus.http.cors.origins=/.*/


### PR DESCRIPTION
This PR introduces a few improvements to make local development significantly easier and faster, specifically when iterating on the CLI alongside Quarkus Dev mode. It automates the build/run cycle.

cli and quarkus:dev work together