### PR TITLE
Implement e-divisive (Hunter) change detection using jhunter (issue #…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <!-- dependencies -->
         <lib.duckdb>1.4.4.0</lib.duckdb>
         <lib.jdbi>3.41.3</lib.jdbi>
+        <lib.jhunter>0.1.0</lib.jhunter>
         <lib.jjq>0.1.6</lib.jjq>
         <lib.jmh>1.37</lib.jmh>
 
@@ -102,6 +103,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>io.hyperfoil.tools</groupId>
+            <artifactId>jhunter-core</artifactId>
+            <version>${lib.jhunter}</version>
+        </dependency>
         <dependency>
             <groupId>io.hyperfoil.tools</groupId>
             <artifactId>jjq-core</artifactId>

--- a/src/main/java/io/hyperfoil/tools/h5m/api/EDivisiveConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/EDivisiveConfig.java
@@ -1,0 +1,29 @@
+package io.hyperfoil.tools.h5m.api;
+
+/**
+ * Configuration for the E-Divisive (Hunter) change detection algorithm.
+ *
+ * <p>The algorithm detects distributional change points in a time series by
+ * splitting the series at candidate points and testing whether the segments
+ * before and after the split come from different distributions.
+ *
+ * <p><b>Minimum data requirements:</b> The split phase uses a sliding window
+ * of size {@code windowLen} on each side of a candidate change point.
+ * The practical minimum series length for detection is roughly {@code 2 * windowLen}
+ * (enough data on both sides of a change point). However, the significance test
+ * (Welch's t-test) may require more data depending on {@code maxPvalue} — smaller
+ * p-value thresholds need more data points to reach statistical significance.
+ * With the default {@code windowLen=50}, at least 100+ data points are recommended
+ * for reliable detection.
+ *
+ * @param windowLen sliding window size for the split phase (must be >= 3, default 50).
+ *                  Larger values improve detection accuracy but require more data.
+ * @param maxPvalue significance threshold; change points with p-value above this are
+ *                  discarded (default 0.001). Lower values require stronger evidence,
+ *                  which may need more data points to achieve.
+ * @param minMagnitude minimum relative change magnitude to report, e.g., 0.1 = 10% (default 0.0)
+ * @param maxSeriesLength maximum number of most recent data points to analyze (default 500).
+ *                        Bounds computation time for long-running tests.
+ * @param fingerprintFilter optional jq filter to select specific fingerprint values
+ */
+public record EDivisiveConfig(int windowLen, double maxPvalue, double minMagnitude, int maxSeriesLength, String fingerprintFilter) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddCmd.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable;
         AddRelativeDifference.class,
         AddFixedThreshold.class,
         AddStdDevAnomaly.class,
+        AddEDivisive.class,
         AddNotification.class,
     }
 )

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
@@ -1,0 +1,150 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
+import io.hyperfoil.tools.h5m.api.Node;
+import io.hyperfoil.tools.h5m.api.NodeGroup;
+import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.svc.NodeGroupServiceInterface;
+import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
+import io.hyperfoil.tools.h5m.entity.node.EDivisive;
+import jakarta.inject.Inject;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+@CommandLine.Command(name = "edivisive", separator = " ", description = "add an e-divisive (Hunter) change detection node", mixinStandardHelpOptions = true)
+public class AddEDivisive implements Callable<Integer> {
+
+    @CommandLine.Option(names = {"to"}, description = "target group / test")
+    String groupName;
+
+    @CommandLine.Option(names = {"range"}, arity = "1", description = "node that produces the value to inspect")
+    String rangeName;
+
+    @CommandLine.Option(names = {"domain"}, arity = "1", required = true, description = "node used to sort the range values (required for e-divisive)")
+    String domainName;
+
+    @CommandLine.Option(names = {"windowLen"}, arity = "0..1", description = "sliding window size for the split phase (min 3)",
+            defaultValue = "" + EDivisive.DEFAULT_WINDOW_LEN)
+    int windowLen;
+
+    @CommandLine.Option(names = {"maxPvalue"}, arity = "0..1", description = "significance threshold for change points",
+            defaultValue = "" + EDivisive.DEFAULT_MAX_PVALUE)
+    double maxPvalue;
+
+    @CommandLine.Option(names = {"minMagnitude"}, arity = "0..1", description = "minimum relative change magnitude to report (e.g., 0.1 = 10%)",
+            defaultValue = "" + EDivisive.DEFAULT_MIN_MAGNITUDE)
+    double minMagnitude;
+
+    @CommandLine.Option(names = {"maxSeriesLength"}, arity = "0..1", description = "maximum number of recent data points to analyze",
+            defaultValue = "" + EDivisive.DEFAULT_MAX_SERIES_LENGTH)
+    int maxSeriesLength;
+
+    @CommandLine.Option(names = {"fingerprint"}, description = "node names to use as fingerprint")
+    List<String> fingerprints;
+
+    @CommandLine.Option(names = {"--fingerprint-filter", "-ff"}, arity = "0..1", description = "jq filter expression for fingerprints")
+    String fingerprintFilter;
+
+    @CommandLine.Option(names = {"by"}, description = "grouping node", arity = "0..1")
+    public String groupBy;
+
+    @CommandLine.Parameters(index = "0", arity = "1", description = "node name")
+    String name;
+
+    @Inject
+    NodeGroupServiceInterface nodeGroupService;
+
+    @Inject
+    NodeServiceInterface nodeService;
+
+    @Override
+    public Integer call() throws Exception {
+        if (name == null || name.isEmpty()) {
+            System.err.println("missing node name");
+            return 1;
+        }
+        if (groupName == null || groupName.isEmpty()) {
+            System.err.println("missing group name");
+            return 1;
+        }
+        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        if (foundGroup == null) {
+            System.err.println("node group with name " + groupName + " does not exist");
+            return 1;
+        }
+
+        List<Node> foundNodes = nodeService.findNodeByFqdn(name, foundGroup.id());
+        if (!foundNodes.isEmpty()) {
+            System.err.println(groupName + " already has " + name + " node(s)\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+        }
+
+        if (rangeName == null || rangeName.isEmpty()) {
+            System.err.println("Missing range");
+            return 1;
+        }
+        foundNodes = nodeService.findNodeByFqdn(rangeName, foundGroup.id());
+        if (foundNodes.isEmpty()) {
+            System.err.println("could not find matching range node by name " + rangeName);
+            return 1;
+        } else if (foundNodes.size() > 1) {
+            System.err.println("found more than one matching range node by name " + rangeName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+            return 1;
+        }
+        Node rangeNode = foundNodes.getFirst();
+
+        // domainName is required=true, so always present
+        foundNodes = nodeService.findNodeByFqdn(domainName, foundGroup.id());
+        if (foundNodes.isEmpty()) {
+            System.err.println("could not find matching domain node by name " + domainName);
+            return 1;
+        } else if (foundNodes.size() > 1) {
+            System.err.println("found more than one matching domain node by name " + domainName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+            return 1;
+        }
+        Node domainNode = foundNodes.getFirst();
+
+        Node groupByNode = null;
+        if (groupBy != null && !groupBy.isEmpty()) {
+            foundNodes = nodeService.findNodeByFqdn(groupBy, foundGroup.id());
+            if (foundNodes.isEmpty()) {
+                System.err.println("could not find matching group by node with name " + groupBy);
+                return 1;
+            } else if (foundNodes.size() > 1) {
+                System.err.println("found more than one matching group by node for name " + groupBy + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+                return 1;
+            }
+            groupByNode = foundNodes.getFirst();
+        }
+        if (groupByNode == null) {
+            groupByNode = foundGroup.root();
+        }
+
+        List<Long> fingerprintNodes = new ArrayList<>();
+        if (fingerprints != null && !fingerprints.isEmpty()) {
+            List<String> fingerprintNames = fingerprints.stream().flatMap(fp -> Arrays.stream(fp.split(","))).map(String::trim).filter(v -> !v.isBlank()).toList();
+            for (String fingerprintName : fingerprintNames) {
+                foundNodes = nodeService.findNodeByFqdn(fingerprintName, foundGroup.id());
+                if (foundNodes.isEmpty()) {
+                    System.err.println("could not find matching fingerprint node by name " + fingerprintName);
+                    return 1;
+                } else if (foundNodes.size() > 1) {
+                    System.err.println("found more than one matching fingerprint node by name " + fingerprintName + "\n  " + foundNodes.stream().map(Node::fqdn).collect(Collectors.joining("\n  ")));
+                    return 1;
+                }
+                fingerprintNodes.add(foundNodes.getFirst().id());
+            }
+        }
+
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        List<Long> sources = List.of(fingerprintId, groupByNode.id(), rangeNode.id(), domainNode.id());
+        nodeService.createConfigured(name, foundGroup.id(), NodeType.EDIVISIVE, sources,
+                new EDivisiveConfig(windowLen, maxPvalue, minMagnitude, maxSeriesLength, fingerprintFilter));
+
+        return 0;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/EDivisive.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/EDivisive.java
@@ -2,15 +2,43 @@ package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.yaup.json.Json;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.Transient;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @DiscriminatorValue("ed")
-public class EDivisive extends NodeEntity {
-    @Override
-    protected NodeEntity shallowCopy() {
-        return new EDivisive();
+public class EDivisive extends NodeEntity implements DetectionNode {
+
+    private static final String WINDOW_LEN = "windowLen";
+    public static final int DEFAULT_WINDOW_LEN = 50;
+    private static final String MAX_PVALUE = "maxPvalue";
+    public static final double DEFAULT_MAX_PVALUE = 0.001;
+    private static final String MIN_MAGNITUDE = "minMagnitude";
+    public static final double DEFAULT_MIN_MAGNITUDE = 0.0;
+    private static final String MAX_SERIES_LENGTH = "maxSeriesLength";
+    public static final int DEFAULT_MAX_SERIES_LENGTH = 500;
+    private static final String FINGERPRINT_FILTER = "fingerprintFilter";
+
+    @Transient
+    private Json config;
+
+    public EDivisive() {
+        config = new Json();
+    }
+
+    public EDivisive(String name, String operation) {
+        super(name, operation);
+        if (operation != null && !operation.isBlank()) {
+            config = Json.fromString(operation);
+        } else {
+            config = new Json();
+        }
     }
 
     @Override
@@ -18,5 +46,107 @@ public class EDivisive extends NodeEntity {
         return NodeType.EDIVISIVE;
     }
 
+    @PostLoad
+    public void loadConfig() {
+        if (this.config == null || this.config.isEmpty()) {
+            if (this.operation != null && !this.operation.isBlank()) {
+                config = Json.fromString(this.operation);
+            } else {
+                config = new Json();
+            }
+        }
+    }
 
+    public void setNodes(NodeEntity fingerprint, NodeEntity groupBy, NodeEntity range, NodeEntity domain) {
+        List<NodeEntity> sources = new ArrayList<>();
+        sources.add(fingerprint);
+        sources.add(groupBy);
+        sources.add(range);
+        if (domain != null) {
+            sources.add(domain);
+        }
+        this.sources = sources;
+    }
+
+    @Override
+    @Transient
+    public NodeEntity getFingerprintNode() {
+        return sources.get(0);
+    }
+
+    @Override
+    @Transient
+    public NodeEntity getGroupByNode() {
+        return sources.get(1);
+    }
+
+    @Transient
+    public NodeEntity getRangeNode() {
+        return sources.get(2);
+    }
+
+    @Transient
+    public NodeEntity getDomainNode() {
+        return sources.size() > 3 ? sources.get(3) : null;
+    }
+
+    @Transient
+    public int getWindowLen() {
+        return (int) config.getLong(WINDOW_LEN, DEFAULT_WINDOW_LEN);
+    }
+
+    public void setWindowLen(int windowLen) {
+        config.set(WINDOW_LEN, windowLen);
+        operation = config.toString();
+    }
+
+    @Transient
+    public double getMaxPvalue() {
+        Object val = config.get(MAX_PVALUE);
+        if (val instanceof Number n) return n.doubleValue();
+        return DEFAULT_MAX_PVALUE;
+    }
+
+    public void setMaxPvalue(double maxPvalue) {
+        config.set(MAX_PVALUE, maxPvalue);
+        operation = config.toString();
+    }
+
+    @Transient
+    public double getMinMagnitude() {
+        Object val = config.get(MIN_MAGNITUDE);
+        if (val instanceof Number n) return n.doubleValue();
+        return DEFAULT_MIN_MAGNITUDE;
+    }
+
+    public void setMinMagnitude(double minMagnitude) {
+        config.set(MIN_MAGNITUDE, minMagnitude);
+        operation = config.toString();
+    }
+
+    @Transient
+    public int getMaxSeriesLength() {
+        return (int) config.getLong(MAX_SERIES_LENGTH, DEFAULT_MAX_SERIES_LENGTH);
+    }
+
+    public void setMaxSeriesLength(int maxSeriesLength) {
+        config.set(MAX_SERIES_LENGTH, maxSeriesLength);
+        operation = config.toString();
+    }
+
+    @Override
+    @Transient
+    public String getFingerprintFilter() {
+        return config.getString(FINGERPRINT_FILTER);
+    }
+
+    public void setFingerprintFilter(String fingerprintFilter) {
+        config.set(FINGERPRINT_FILTER, fingerprintFilter);
+        operation = config.toString();
+    }
+
+    @Override
+    protected NodeEntity shallowCopy() {
+        return new EDivisive(name, operation);
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -2,6 +2,7 @@ package io.hyperfoil.tools.h5m.entity.work;
 
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.node.EDivisive;
 import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;
 import io.hyperfoil.tools.h5m.entity.node.StdDevAnomaly;
 import io.hyperfoil.tools.h5m.svc.WorkService;
@@ -39,7 +40,7 @@ public class Work implements Runnable, Comparable<Work>{
         this();
         this.activeNodes = new HashSet<>(activeNodes); //so that it will be mutable
         if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
-                || node instanceof StdDevAnomaly)){
+                || node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }
         this.sourceValues = sourceValues == null ? Collections.emptyList() : new ArrayList(sourceValues);
@@ -53,7 +54,7 @@ public class Work implements Runnable, Comparable<Work>{
     public void setActiveNodes(Set<NodeEntity> activeNodes) {
         this.activeNodes = activeNodes;
         if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
-                || node instanceof StdDevAnomaly)){
+                || node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }else{
             this.cumulative = false;

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -67,6 +67,7 @@ public class FolderService implements FolderServiceInterface {
     ApiMapper apiMapper;
 
 
+
     @Override
     @Transactional
     public long create(String name){
@@ -146,7 +147,7 @@ public class FolderService implements FolderServiceInterface {
             JOIN node r ON r.id = g.root_id
             LEFT JOIN value rv ON rv.node_id = r.id
             LEFT JOIN node n ON n.group_id = g.id AND n.id != r.id
-            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN ('ft', 'rd', 'sd')
+            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN ('ft', 'rd', 'sd', 'ed')
             LEFT JOIN value dv ON dv.node_id = dn.id
             GROUP BY f.id, f.name
             ORDER BY f.name
@@ -409,6 +410,16 @@ public class FolderService implements FolderServiceInterface {
                     RelativeDifference rd = new RelativeDifference(name, operation);
                     rd.sources = new ArrayList<>(sources);
                     yield rd;
+                }
+                case "sd" -> {
+                    StdDevAnomaly sd = new StdDevAnomaly(name, operation);
+                    sd.sources = new ArrayList<>(sources);
+                    yield sd;
+                }
+                case "ed" -> {
+                    EDivisive ed = new EDivisive(name, operation);
+                    ed.sources = new ArrayList<>(sources);
+                    yield ed;
                 }
                 default -> {
                     Log.warnf("Unknown node type '%s' for node '%s', treating as jq", type, name);

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -3,11 +3,15 @@ package io.hyperfoil.tools.h5m.svc;
 import io.hyperfoil.tools.jjq.jsonata.JsonataCompiler;
 import io.hyperfoil.tools.jjq.jsonata.JsonataException;
 import io.hyperfoil.tools.jjq.value.*;
+import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
 import io.hyperfoil.tools.h5m.api.FixedThresholdConfig;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.RelativeDifferenceConfig;
 import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.jhunter.Analysis;
+import io.hyperfoil.tools.jhunter.AnalysisOptions;
+import io.hyperfoil.tools.jhunter.ChangePoint;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
@@ -18,6 +22,7 @@ import io.hyperfoil.tools.h5m.entity.node.*;
 import io.hyperfoil.tools.h5m.pasted.ProxyJq;
 import io.hyperfoil.tools.h5m.pasted.ProxyJqObject;
 import io.hyperfoil.tools.h5m.pasted.Util;
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -112,6 +117,7 @@ public class NodeService implements NodeServiceInterface {
             case FIXED_THRESHOLD -> new FixedThreshold(name, toFixedThresholdConfig(configuration).toJsonString());
             case RELATIVE_DIFFERENCE -> new RelativeDifference(name, toRelativeDifferenceConfig(configuration).toJsonString());
             case STDDEV_ANOMALY -> new StdDevAnomaly(name, toStdDevAnomalyConfig(configuration).toJsonString());
+            case EDIVISIVE -> new EDivisive(name, toEDivisiveConfig(configuration).toJsonString());
             default -> throw new IllegalArgumentException("Invalid node type " + type.display());
         };
         node.group = NodeGroupEntity.findById(groupId);
@@ -171,6 +177,23 @@ public class NodeService implements NodeServiceInterface {
             if (v instanceof JqObject obj) return obj;
         }
         throw new IllegalArgumentException("Invalid StdDevAnomaly configuration: " + config);
+    }
+
+    /** Convert configuration (Map from REST or record from CLI) to JqObject for EDivisive. */
+    private static JqObject toEDivisiveConfig(Object config) {
+        if (config instanceof EDivisiveConfig ed) {
+            JqObject.Builder b = JqObject.builder();
+            b.put("windowLen", (long) ed.windowLen());
+            b.put("maxPvalue", ed.maxPvalue());
+            b.put("minMagnitude", ed.minMagnitude());
+            b.put("maxSeriesLength", (long) ed.maxSeriesLength());
+            if (ed.fingerprintFilter() != null) b.put("fingerprintFilter", ed.fingerprintFilter());
+            return b.build();
+        } else if (config instanceof Map<?, ?>) {
+            JqValue v = JqValues.fromJavaObject(config);
+            if (v instanceof JqObject obj) return obj;
+        }
+        throw new IllegalArgumentException("Invalid EDivisive configuration: " + config);
     }
 
     @Transactional
@@ -419,6 +442,13 @@ public class NodeService implements NodeServiceInterface {
                 for(int rIdx=0; rIdx<roots.size(); rIdx++){
                     ValueEntity root =  roots.get(rIdx);
                     rtrn.addAll(calculateStdDevAnomalyValues(sd, root, rtrn.size()));
+                }
+                break;
+            case EDIVISIVE:
+                EDivisive ed = (EDivisive) node;
+                for(int rIdx=0; rIdx<roots.size(); rIdx++){
+                    ValueEntity root = roots.get(rIdx);
+                    rtrn.addAll(calculateEDivisiveValues(ed, root, rtrn.size()));
                 }
                 break;
             default:
@@ -684,6 +714,166 @@ public class NodeService implements NodeServiceInterface {
             }
         } catch (Exception e) {
             e.printStackTrace();
+        }
+        return rtrn;
+    }
+
+    /**
+     * Calculates e-divisive change points for the given root value.
+     * Collects the most recent maxSeriesLength range values per fingerprint
+     * (ordered by domain node), deletes existing e-divisive values within the
+     * analysis window, then calls jhunter to detect change points and creates
+     * a ValueEntity for each.
+     *
+     * A domain node is required for e-divisive — the algorithm needs a
+     * meaningful ordering to produce useful results. Change points outside
+     * the maxSeriesLength window are preserved from previous analyses.
+     *
+     * Note: uploads with domain values older than the maxSeriesLength window
+     * (e.g., backported runs) will not be included in the analysis.
+     * A manual recalculate with a larger maxSeriesLength can cover them.
+     *
+     * E-divisive Work is marked as cumulative, so the work queue deduplicates
+     * multiple Work items for the same node in a batch — only one runs.
+     * During recalculation (where Work is queued for every root value),
+     * the cumulative flag ensures e-divisive blocks until all extraction
+     * Work completes, and Work.equals() ignores sourceValues for cumulative
+     * Work, so duplicate cascade-created e-divisive Work items are
+     * deduplicated by WorkQueue.hasWork(). Result: e-divisive runs exactly
+     * once per recalculation batch, analyzing the full series.
+     */
+    @Transactional
+    public List<ValueEntity> calculateEDivisiveValues(EDivisive ed, ValueEntity root, int startingOrdinal) throws IOException {
+        List<ValueEntity> rtrn = new ArrayList<>();
+        try {
+            if (ed.getDomainNode() == null) {
+                Log.errorf("e-divisive node %s requires a domain node for meaningful ordering", ed.name);
+                return rtrn;
+            }
+
+            NodeEntity groupBy = NodeEntity.findById(ed.getGroupByNode().getId());
+            List<ValueEntity> fingerprintValues = valueService.getDescendantValues(root, ed.getFingerprintNode());
+            String fpFilter = ed.getFingerprintFilter();
+            int maxSeriesLength = ed.getMaxSeriesLength();
+            for (int fIdx = 0; fIdx < fingerprintValues.size(); fIdx++) {
+                ValueEntity fingerprintValue = fingerprintValues.get(fIdx);
+                if (fpFilter != null && !evaluateFingerprintFilter(fpFilter, fingerprintValue.data)) {
+                    continue;
+                }
+
+                // Check if this upload contributed a range value for this fingerprint.
+                // Scope through the groupBy ancestor to handle multi-dataset uploads.
+                List<ValueEntity> groupByValues = valueService.getAncestor(fingerprintValue, groupBy);
+                if (groupByValues.isEmpty()) {
+                    continue;
+                }
+                ValueEntity groupByValue = groupByValues.getFirst();
+                List<ValueEntity> currentRangeValues = valueService.getDescendantValues(groupByValue, ed.getRangeNode());
+                if (currentRangeValues.isEmpty()) {
+                    continue; // this upload didn't produce a range value for this fingerprint
+                }
+
+                // Collect the most recent maxSeriesLength range values for this fingerprint,
+                // ordered by domain ascending. The limit is applied in SQL.
+                // preceedingValues=true fetches the most recent values and returns them
+                // in ascending order (findMatchingFingerprint reverses internally).
+                List<ValueEntity> rangeValues = valueService.findMatchingFingerprint(
+                        ed.getRangeNode(), groupBy, fingerprintValue,
+                        ed.getDomainNode(), null,
+                        maxSeriesLength, 0, true);
+
+                if (rangeValues.size() < ed.getWindowLen()) {
+                    continue;
+                }
+
+                // Extract double[] from range values
+                double[] series = new double[rangeValues.size()];
+                int validCount = 0;
+                for (int i = 0; i < rangeValues.size(); i++) {
+                    Double d = rangeValues.get(i).data != null ? rangeValues.get(i).data.tryDouble() : null;
+                    if (d != null) {
+                        series[validCount++] = d;
+                    }
+                }
+
+                if (validCount < ed.getWindowLen()) {
+                    continue;
+                }
+
+                // Trim array if some values were non-numeric
+                if (validCount < series.length) {
+                    series = Arrays.copyOf(series, validCount);
+                }
+
+                // Run jhunter analysis
+                AnalysisOptions options = new AnalysisOptions(
+                        ed.getWindowLen(), ed.getMaxPvalue(), ed.getMinMagnitude());
+                List<ChangePoint> changePoints = Analysis.computeChangePoints(series, options);
+
+                // Delete existing e-divisive change points within the analysis window.
+                // E-divisive recomputes the entire window each time, so all old change points
+                // within the window are replaced by the new results. Change points outside the
+                // window (from older analyses with values that fell out of maxSeriesLength) are
+                // preserved — they represent historical detections that are no longer in scope.
+                Set<Long> windowRangeIds = new HashSet<>();
+                for (ValueEntity rv : rangeValues) {
+                    if (rv.id != null) windowRangeIds.add(rv.id);
+                }
+                List<ValueEntity> existingEdValues = valueService.findMatchingFingerprint(
+                        ed, groupBy, fingerprintValue, (NodeEntity) null);
+                for (ValueEntity existing : existingEdValues) {
+                    JqValue rangeIdNode = existing.data != null ? existing.data.getField("rangeValueId") : JqNull.NULL;
+                    if (!rangeIdNode.isNull() && windowRangeIds.contains((long) rangeIdNode.asDouble(0.0))) {
+                        valueService.delete(existing);
+                    }
+                }
+
+                // Create a ValueEntity for each detected change point
+                for (ChangePoint cp : changePoints) {
+                    JqObject.Builder dataBuilder = JqObject.builder();
+                    dataBuilder.put("index", (long) cp.index());
+                    dataBuilder.put("pvalue", cp.pvalue());
+                    dataBuilder.put("meanBefore", cp.meanBefore());
+                    dataBuilder.put("meanAfter", cp.meanAfter());
+                    dataBuilder.put("stdBefore", cp.stdBefore());
+                    dataBuilder.put("stdAfter", cp.stdAfter());
+                    dataBuilder.put("magnitude", cp.magnitude());
+                    // Hazard level: symmetric measure for triage sorting (MongoDB/ICPE 2020)
+                    if (cp.meanBefore() != 0.0 && cp.meanAfter() > 0.0) {
+                        dataBuilder.put("hazardLevel", Math.log(cp.meanAfter() / cp.meanBefore()));
+                    }
+                    dataBuilder.put("fingerprint", fingerprintValue.data);
+                    // Reference the range and domain values at the change point index
+                    if (cp.index() < rangeValues.size()) {
+                        ValueEntity rangeAtCp = rangeValues.get(cp.index());
+                        // Store range value ID for windowed deletion on recomputation
+                        if (rangeAtCp.id != null) {
+                            dataBuilder.put("rangeValueId", rangeAtCp.id);
+                        }
+                        // Find the domain value that shares the same groupBy ancestor as
+                        // the range value at the change point. This handles split/dataset
+                        // scoping correctly (siblings in the DAG, not ancestors).
+                        List<ValueEntity> rangeGroupBy = valueService.getAncestor(rangeAtCp, groupBy);
+                        if (!rangeGroupBy.isEmpty()) {
+                            List<ValueEntity> domainValues = valueService.getDescendantValues(rangeGroupBy.getFirst(), ed.getDomainNode());
+                            if (!domainValues.isEmpty()) {
+                                dataBuilder.put("domainvalue", domainValues.getFirst().data);
+                            }
+                        }
+                    }
+                    JqValue data = dataBuilder.build();
+
+                    ValueEntity changeValue = new ValueEntity(root.folder, ed, data);
+                    changeValue.idx = startingOrdinal + rtrn.size();
+                    List<ValueEntity> foundParents = valueService.getAncestor(fingerprintValue, groupBy);
+                    if (foundParents.size() == 1) {
+                        changeValue.sources = foundParents;
+                    }
+                    rtrn.add(changeValue);
+                }
+            }
+        } catch (Exception e) {
+            Log.errorf(e, "Error in e-divisive calculation for node %s: %s", ed.name, e.getMessage());
         }
         return rtrn;
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
@@ -1,0 +1,845 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.jjq.value.JqValue;
+import io.hyperfoil.tools.jjq.value.JqValues;
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
+import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.node.EDivisive;
+import io.hyperfoil.tools.h5m.entity.node.FingerprintNode;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.TransactionManager;
+import org.junit.jupiter.api.Test;
+
+import io.hyperfoil.tools.h5m.entity.node.SplitNode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class EDivisiveTest extends FreshDb {
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    FolderService folderService;
+
+    @Inject
+    NodeService nodeService;
+
+    @Inject
+    WorkService workService;
+
+    @Inject
+    ValueService valueService;
+
+    @Inject
+    EntityManager em;
+
+    private void awaitIdle(long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        int stableChecks = 0;
+        while (stableChecks < 5) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Work queue drain timed out after " + timeoutMs + "ms");
+            }
+            if (workService.isIdle()) {
+                stableChecks++;
+            } else {
+                stableChecks = 0;
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    /**
+     * Creates a folder with a value node and an e-divisive detection node,
+     * then uploads a series of numeric values.
+     * Returns the e-divisive node ID for querying results.
+     */
+    private long setupAndUpload(String folderName, double[] series, int windowLen, double maxPvalue) throws Exception {
+        tm.begin();
+        long folderId = folderService.create(folderName);
+        FolderEntity folder = folderService.read(folderId);
+
+        // Create nodes: root -> value (extracts .v), domain (extracts .d) -> fingerprint -> edivisive
+        JqNode valueNode = new JqNode("value", ".v", folder.group.root);
+        valueNode.group = folder.group;
+        valueNode.ephemeral = EphemeralMode.KEEP; // keep data for assertions
+        valueNode.persist();
+
+        JqNode domainNode = new JqNode("domain", ".d", folder.group.root);
+        domainNode.group = folder.group;
+        domainNode.ephemeral = EphemeralMode.KEEP;
+        domainNode.persist();
+
+        JqNode fpSource = new JqNode("fpSource", ".fp", folder.group.root);
+        fpSource.group = folder.group;
+        fpSource.persist();
+
+        FingerprintNode fp = new FingerprintNode("fp", "", List.of(fpSource));
+        fp.group = folder.group;
+        fp.persist();
+
+        EDivisive ed = new EDivisive();
+        ed.name = "changedetect";
+        ed.setWindowLen(windowLen);
+        ed.setMaxPvalue(maxPvalue);
+        ed.setMinMagnitude(0.0);
+        ed.setMaxSeriesLength(500);
+        ed.setNodes(fp, folder.group.root, valueNode, domainNode);
+        ed.group = folder.group;
+        ed.persist();
+        long edId = ed.id;
+
+        tm.commit();
+
+        // Upload each value as a separate run with an incrementing domain value
+        for (int i = 0; i < series.length; i++) {
+            String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", series[i], i);
+            folderService.upload(folderName, "$", JqValues.parse(json))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        return edId;
+    }
+
+    @Test
+    public void step_function_detects_single_change_point() throws Exception {
+        // Series with a clear step: 10 values at mean=100, then 10 values at mean=200
+        double[] series = new double[20];
+        for (int i = 0; i < 10; i++) series[i] = 100.0 + (i % 3); // slight noise
+        for (int i = 10; i < 20; i++) series[i] = 200.0 + (i % 3);
+
+        long edId = setupAndUpload("step-test", series, 5, 0.05);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertEquals(1, edValues.size(), "Should detect exactly 1 change point");
+
+        // Verify the change point data structure
+        ValueEntity cp = edValues.get(0);
+        assertNotNull(cp.data, "Change point should have data");
+        assertTrue(cp.data.has("index"), "Should have index field");
+        assertTrue(cp.data.has("meanBefore"), "Should have meanBefore field");
+        assertTrue(cp.data.has("meanAfter"), "Should have meanAfter field");
+        assertTrue(cp.data.has("pvalue"), "Should have pvalue field");
+        assertTrue(cp.data.has("magnitude"), "Should have magnitude field");
+        assertTrue(cp.data.has("fingerprint"), "Should have fingerprint field");
+
+        // The algorithm is deterministic (Welch's t-test) — change point should be exactly at index 10
+        int cpIndex = cp.data.getField("index").asInt(0);
+        assertEquals(10, cpIndex, "Change point should be at index 10");
+
+        // meanBefore should be around 100, meanAfter around 200
+        double meanBefore = cp.data.getField("meanBefore").asDouble(0.0);
+        double meanAfter = cp.data.getField("meanAfter").asDouble(0.0);
+        assertTrue(meanBefore < 150, "meanBefore should be near 100, was " + meanBefore);
+        assertTrue(meanAfter > 150, "meanAfter should be near 200, was " + meanAfter);
+
+        // Verify sources — change point should be linked to the groupBy value
+        assertNotNull(cp.sources, "Change point should have sources");
+        assertFalse(cp.sources.isEmpty(), "Change point should have at least one source");
+
+        tm.commit();
+    }
+
+    @Test
+    public void flat_series_no_change_points() throws Exception {
+        // Flat series with slight noise — should detect no change points
+        double[] series = new double[20];
+        for (int i = 0; i < 20; i++) series[i] = 100.0 + (i % 3);
+
+        long edId = setupAndUpload("flat-test", series, 5, 0.001);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertTrue(edValues.isEmpty(), "Flat series should have no change points");
+        tm.commit();
+    }
+
+    @Test
+    public void multiple_change_points() throws Exception {
+        // Series with two distinct shifts: 100 -> 200 -> 50
+        double[] series = new double[30];
+        for (int i = 0; i < 10; i++) series[i] = 100.0;
+        for (int i = 10; i < 20; i++) series[i] = 200.0;
+        for (int i = 20; i < 30; i++) series[i] = 50.0;
+
+        long edId = setupAndUpload("multi-cp-test", series, 5, 0.05);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertEquals(2, edValues.size(),
+                "Should detect exactly 2 change points, found " + edValues.size());
+        tm.commit();
+    }
+
+    @Test
+    public void insufficient_data_no_crash() throws Exception {
+        // Very short series — less than windowLen
+        double[] series = {1.0, 2.0};
+
+        long edId = setupAndUpload("short-test", series, 5, 0.05);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertTrue(edValues.isEmpty(), "Insufficient data should produce no change points");
+        tm.commit();
+    }
+
+    @Test
+    public void recomputation_updates_change_points() throws Exception {
+        // Upload initial series with a step
+        String folderName = "recomp-test";
+
+        tm.begin();
+        long folderId = folderService.create(folderName);
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode valueNode = new JqNode("value", ".v", folder.group.root);
+        valueNode.group = folder.group;
+        valueNode.ephemeral = EphemeralMode.KEEP;
+        valueNode.persist();
+
+        JqNode domainNode = new JqNode("domain", ".d", folder.group.root);
+        domainNode.group = folder.group;
+        domainNode.ephemeral = EphemeralMode.KEEP;
+        domainNode.persist();
+
+        JqNode fpSource = new JqNode("fpSource", ".fp", folder.group.root);
+        fpSource.group = folder.group;
+        fpSource.persist();
+
+        FingerprintNode fp = new FingerprintNode("fp", "", List.of(fpSource));
+        fp.group = folder.group;
+        fp.persist();
+
+        EDivisive ed = new EDivisive();
+        ed.name = "changedetect";
+        ed.setWindowLen(5);
+        ed.setMaxPvalue(0.05);
+        ed.setMinMagnitude(0.0);
+        ed.setMaxSeriesLength(500);
+        ed.setNodes(fp, folder.group.root, valueNode, domainNode);
+        ed.group = folder.group;
+        ed.persist();
+        long edId = ed.id;
+        tm.commit();
+
+        // Upload first batch: step from 100 to 200
+        for (int i = 0; i < 10; i++) {
+            double v = i < 5 ? 100.0 : 200.0;
+            folderService.upload(folderName, "$", JqValues.parse(String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", v, i)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        tm.begin();
+        List<ValueEntity> firstBatch = ValueEntity.find("node.id", edId).list();
+        int firstCount = firstBatch.size();
+        tm.commit();
+
+        // Upload more data — all at 200 (extending the second segment)
+        for (int i = 0; i < 5; i++) {
+            folderService.upload(folderName, "$", JqValues.parse(String.format("{\"v\": 200.0, \"fp\": \"default\", \"d\": %d}", 10 + i)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        tm.begin();
+        List<ValueEntity> secondBatch = ValueEntity.find("node.id", edId).list();
+        // The key assertion: change points should be recomputed, not accumulated.
+        // The step at index 5 should still be detected, so we expect 1 change point.
+        // Old change points within the window must be deleted before new ones are created.
+        assertEquals(firstCount, secondBatch.size(),
+                "Change points should be recomputed, not accumulated. " +
+                "First batch: " + firstCount + ", second batch: " + secondBatch.size() + ". " +
+                "The step is still present, so the same number of change points should exist.");
+
+        // Verify the change point IDs are DIFFERENT (old ones deleted, new ones created)
+        if (!firstBatch.isEmpty() && !secondBatch.isEmpty()) {
+            // The IDs should differ because old values were deleted and new ones created
+            Set<Long> firstIds = new HashSet<>();
+            for (ValueEntity v : firstBatch) firstIds.add(v.id);
+            boolean anyNewId = false;
+            for (ValueEntity v : secondBatch) {
+                if (!firstIds.contains(v.id)) {
+                    anyNewId = true;
+                    break;
+                }
+            }
+            assertTrue(anyNewId,
+                    "Change point entities should have new IDs after recomputation, " +
+                    "proving old ones were deleted and new ones created");
+        }
+        tm.commit();
+    }
+
+    @Test
+    public void rest_createConfigured_edivisive() throws Exception {
+        // Test that the createConfigured path works for EDIVISIVE nodes
+        tm.begin();
+        long folderId = folderService.create("rest-ed-test");
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode rangeNode = new JqNode("range", ".y", folder.group.root);
+        rangeNode.group = folder.group;
+        rangeNode.persist();
+
+        JqNode fpSource = new JqNode("fpSource", ".fp", folder.group.root);
+        fpSource.group = folder.group;
+        fpSource.persist();
+
+        long groupId = folder.group.id;
+        long rangeId = rangeNode.id;
+        long fpSourceId = fpSource.id;
+        tm.commit();
+
+        Long fpNodeId = nodeService.createConfigured("_fp-test", groupId, NodeType.FINGERPRINT, List.of(fpSourceId), null);
+        Long edNodeId = nodeService.createConfigured("ed-test", groupId, NodeType.EDIVISIVE,
+                List.of(fpNodeId, folder.group.root.id, rangeId),
+                new EDivisiveConfig(10, 0.01, 0.0, 200, null));
+
+        assertNotNull(edNodeId, "Should return a valid node ID");
+
+        // Clear the persistence context to force a fresh load with @PostLoad
+        tm.begin();
+        em.clear();
+        NodeEntity edNode = NodeEntity.findById(edNodeId);
+        assertNotNull(edNode, "Node should be persisted");
+        assertTrue(edNode instanceof EDivisive, "Node should be EDivisive type");
+        EDivisive ed = (EDivisive) edNode;
+        assertEquals(10, ed.getWindowLen(), "windowLen should be 10");
+        assertEquals(0.01, ed.getMaxPvalue(), 0.0001, "maxPvalue should be 0.01");
+        assertEquals(200, ed.getMaxSeriesLength());
+        tm.commit();
+    }
+
+    @Test
+    public void multi_fingerprint_independent_detection() throws Exception {
+        // Two fingerprints with different baselines — change points should be
+        // detected independently per fingerprint
+        String folderName = "multi-fp-test";
+        tm.begin();
+        long folderId = folderService.create(folderName);
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode valueNode = new JqNode("value", ".v", folder.group.root);
+        valueNode.group = folder.group;
+        valueNode.ephemeral = EphemeralMode.KEEP;
+        valueNode.persist();
+
+        JqNode domainNode = new JqNode("domain", ".d", folder.group.root);
+        domainNode.group = folder.group;
+        domainNode.ephemeral = EphemeralMode.KEEP;
+        domainNode.persist();
+
+        JqNode fpSource = new JqNode("fpSource", ".fp", folder.group.root);
+        fpSource.group = folder.group;
+        fpSource.persist();
+
+        FingerprintNode fp = new FingerprintNode("fp", "", List.of(fpSource));
+        fp.group = folder.group;
+        fp.persist();
+
+        EDivisive ed = new EDivisive();
+        ed.name = "changedetect";
+        ed.setWindowLen(5);
+        ed.setMaxPvalue(0.05);
+        ed.setMinMagnitude(0.0);
+        ed.setMaxSeriesLength(500);
+        ed.setNodes(fp, folder.group.root, valueNode, domainNode);
+        ed.group = folder.group;
+        ed.persist();
+        long edId = ed.id;
+        tm.commit();
+
+        // Alpha: stable at 100 for 10 uploads, then step to 200
+        for (int i = 0; i < 10; i++) {
+            folderService.upload(folderName, "$", JqValues.parse(
+                    String.format("{\"v\": 100.0, \"fp\": \"alpha\", \"d\": %d}", i)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+        for (int i = 10; i < 20; i++) {
+            folderService.upload(folderName, "$", JqValues.parse(
+                    String.format("{\"v\": 200.0, \"fp\": \"alpha\", \"d\": %d}", i)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        // Beta: completely stable at 500 (no change points expected)
+        for (int i = 0; i < 20; i++) {
+            folderService.upload(folderName, "$", JqValues.parse(
+                    String.format("{\"v\": 500.0, \"fp\": \"beta\", \"d\": %d}", i + 100)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+
+        // Alpha has a step (100→200), beta is flat (500). The FingerprintNode produces
+        // computed fingerprint data (not the raw "alpha"/"beta" string), so we verify
+        // by checking total change points and their meanBefore/meanAfter values.
+        // With independent fingerprints, only alpha's step should produce a change point.
+        assertEquals(1, edValues.size(),
+                "Should have exactly 1 change point (alpha's step). " +
+                "Beta (stable) should not contribute any. Found: " + edValues.size());
+
+        // Verify the change point has correct mean values for alpha's 100→200 step
+        ValueEntity cp = edValues.get(0);
+        assertTrue(cp.data.getField("meanBefore").asDouble(0.0) < 150,
+                "meanBefore should be ~100 (alpha's baseline)");
+        assertTrue(cp.data.getField("meanAfter").asDouble(0.0) > 150,
+                "meanAfter should be ~200 (alpha's shifted level)");
+        tm.commit();
+    }
+
+    @Test
+    public void out_of_order_upload_reanalyzes_window() throws Exception {
+        // Upload values 1-20, then upload a value at domain=15 with a different range.
+        // The e-divisive should re-analyze the full window and update change points.
+        String folderName = "ooo-test";
+
+        tm.begin();
+        long folderId = folderService.create(folderName);
+        FolderEntity folder = folderService.read(folderId);
+
+        JqNode valueNode = new JqNode("value", ".v", folder.group.root);
+        valueNode.group = folder.group;
+        valueNode.ephemeral = EphemeralMode.KEEP;
+        valueNode.persist();
+
+        JqNode domainNode = new JqNode("domain", ".d", folder.group.root);
+        domainNode.group = folder.group;
+        domainNode.ephemeral = EphemeralMode.KEEP;
+        domainNode.persist();
+
+        JqNode fpSource = new JqNode("fpSource", ".fp", folder.group.root);
+        fpSource.group = folder.group;
+        fpSource.persist();
+
+        FingerprintNode fp = new FingerprintNode("fp", "", List.of(fpSource));
+        fp.group = folder.group;
+        fp.persist();
+
+        EDivisive ed = new EDivisive();
+        ed.name = "changedetect";
+        ed.setWindowLen(5);
+        ed.setMaxPvalue(0.05);
+        ed.setMinMagnitude(0.0);
+        ed.setMaxSeriesLength(500);
+        ed.setNodes(fp, folder.group.root, valueNode, domainNode);
+        ed.group = folder.group;
+        ed.persist();
+        long edId = ed.id;
+        tm.commit();
+
+        // Upload stable series at y=100
+        for (int i = 0; i < 20; i++) {
+            folderService.upload(folderName, "$", JqValues.parse(
+                    String.format("{\"v\": 100.0, \"fp\": \"default\", \"d\": %d}", i)))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        tm.begin();
+        List<ValueEntity> beforeOoo = ValueEntity.find("node.id", edId).list();
+        int changesBefore = beforeOoo.size();
+        tm.commit();
+
+        assertEquals(0, changesBefore, "Stable series should have 0 change points before out-of-order upload");
+
+        // Out-of-order upload at domain=15 (mid-sequence) with a very different value
+        // This won't necessarily change the analysis since e-divisive looks at the
+        // most recent N values. domain=15 is within the window.
+        // The key point: the upload should not crash and should re-analyze correctly.
+        folderService.upload(folderName, "$", JqValues.parse(
+                "{\"v\": 100.0, \"fp\": \"default\", \"d\": 15}"))
+                .orTimeout(30, TimeUnit.SECONDS).join();
+
+        tm.begin();
+        List<ValueEntity> afterOoo = ValueEntity.find("node.id", edId).list();
+        tm.commit();
+
+        assertEquals(0, afterOoo.size(),
+                "Out-of-order upload with same value should not create change points");
+    }
+
+    @Test
+    public void strengthen_change_point_assertions() throws Exception {
+        // Step function with detailed assertions on all output JSON fields
+        double[] series = new double[20];
+        for (int i = 0; i < 10; i++) series[i] = 100.0;
+        for (int i = 10; i < 20; i++) series[i] = 200.0;
+
+        long edId = setupAndUpload("strong-assert-test", series, 5, 0.05);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertEquals(1, edValues.size(), "Should detect exactly 1 change point");
+
+        ValueEntity cp = edValues.get(0);
+        JqValue data = cp.data;
+
+        // All required fields present
+        assertFalse(data.getField("index").isNull(), "Should have index");
+        assertFalse(data.getField("pvalue").isNull(), "Should have pvalue");
+        assertFalse(data.getField("meanBefore").isNull(), "Should have meanBefore");
+        assertFalse(data.getField("meanAfter").isNull(), "Should have meanAfter");
+        assertFalse(data.getField("stdBefore").isNull(), "Should have stdBefore");
+        assertFalse(data.getField("stdAfter").isNull(), "Should have stdAfter");
+        assertFalse(data.getField("magnitude").isNull(), "Should have magnitude");
+        assertFalse(data.getField("fingerprint").isNull(), "Should have fingerprint");
+        assertFalse(data.getField("rangeValueId").isNull(), "Should have rangeValueId");
+        assertFalse(data.getField("domainvalue").isNull(), "Should have domainvalue");
+        assertFalse(data.getField("hazardLevel").isNull(), "Should have hazardLevel");
+
+        // Value assertions
+        assertEquals(10, data.getField("index").asInt(0), "Change point should be at index 10");
+        assertEquals(100.0, data.getField("meanBefore").asDouble(0.0), 1.0, "meanBefore should be ~100");
+        assertEquals(200.0, data.getField("meanAfter").asDouble(0.0), 1.0, "meanAfter should be ~200");
+        assertTrue(data.getField("pvalue").asDouble(0.0) < 0.05, "pvalue should be < 0.05");
+        assertTrue(data.getField("magnitude").asDouble(0.0) > 0.0, "magnitude should be positive");
+        assertFalse(data.getField("fingerprint").isNull(), "fingerprint should be present");
+        assertTrue(data.getField("stdBefore").asDouble(0.0) >= 0, "stdBefore should be >= 0");
+        assertTrue(data.getField("stdAfter").asDouble(0.0) >= 0, "stdAfter should be >= 0");
+
+        // hazardLevel for 100→200: log(200/100) = log(2) ≈ 0.693
+        double hazard = data.getField("hazardLevel").asDouble(0.0);
+        assertEquals(0.693, hazard, 0.1, "hazardLevel should be ~log(2)");
+
+        // Sources should be linked
+        assertNotNull(cp.sources, "Should have sources");
+        assertFalse(cp.sources.isEmpty(), "Should have at least one source");
+        tm.commit();
+    }
+
+    @Test
+    public void hazard_level_computed() throws Exception {
+        // Step function that should produce a change point with a hazard level
+        double[] series = new double[20];
+        for (int i = 0; i < 10; i++) series[i] = 100.0;
+        for (int i = 10; i < 20; i++) series[i] = 200.0;
+
+        long edId = setupAndUpload("hazard-test", series, 5, 0.05);
+
+        tm.begin();
+        List<ValueEntity> edValues = ValueEntity.find("node.id", edId).list();
+        assertFalse(edValues.isEmpty(), "Should detect a change point");
+
+        ValueEntity cp = edValues.get(0);
+        assertTrue(cp.data.has("hazardLevel"), "Should have hazardLevel field");
+        double hazardLevel = cp.data.getField("hazardLevel").asDouble(0.0);
+        // |log(200/100)| = |log(2)| ≈ 0.693 (sign depends on direction of change)
+        assertTrue(Math.abs(hazardLevel) > 0.5 && Math.abs(hazardLevel) < 1.0,
+                "Hazard level for 100<->200 should have magnitude ~0.693, was " + hazardLevel);
+        tm.commit();
+    }
+
+    // --- Direct-call tests (mirror StdDev patterns) ---
+
+    /**
+     * Helper: creates the node topology for direct calculateEDivisiveValues calls.
+     * root → split → [range (.y), domain (.d), fingerprint (.fp)]
+     */
+    private record DirectTopology(
+            NodeEntity root, SplitNode split, NodeEntity range,
+            NodeEntity domain, NodeEntity fingerprint, EDivisive ed
+    ) {}
+
+    private DirectTopology createDirectTopology(int windowLen, double maxPvalue) throws Exception {
+        tm.begin();
+        NodeEntity rootNode = new io.hyperfoil.tools.h5m.entity.node.RootNode();
+        rootNode.persist();
+        SplitNode splitNode = new SplitNode("split", "split", List.of(rootNode));
+        splitNode.persist();
+        NodeEntity rangeNode = new JqNode("range", ".y", splitNode);
+        rangeNode.persist();
+        NodeEntity domainNode = new JqNode("domain", ".d", splitNode);
+        domainNode.persist();
+        NodeEntity fingerprintNode = new JqNode("fingerprint", ".fp", splitNode);
+        fingerprintNode.persist();
+
+        EDivisive ed = new EDivisive();
+        ed.name = "ed-direct";
+        ed.setWindowLen(windowLen);
+        ed.setMaxPvalue(maxPvalue);
+        ed.setMinMagnitude(0.0);
+        ed.setMaxSeriesLength(500);
+        ed.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
+        ed.persist();
+        tm.commit();
+
+        return new DirectTopology(rootNode, splitNode, rangeNode, domainNode, fingerprintNode, ed);
+    }
+
+    private ValueEntity uploadDirectDataPoint(DirectTopology t, String fingerprint, int domain, double range) throws Exception {
+        tm.begin();
+        ValueEntity root = new ValueEntity(null, t.root, JqValues.parse(
+                String.format("{\"split\":[{\"fp\":\"%s\",\"d\":%d,\"y\":%s}]}", fingerprint, domain, range)));
+        root.persist();
+        ValueEntity split = new ValueEntity(null, t.split, root.data.getField("split").getElement(0), List.of(root));
+        split.persist();
+        new ValueEntity(null, t.domain, split.data.getField("d"), List.of(split)).persist();
+        new ValueEntity(null, t.range, split.data.getField("y"), List.of(split)).persist();
+        new ValueEntity(null, t.fingerprint, split.data.getField("fp"), List.of(split)).persist();
+        tm.commit();
+        return root;
+    }
+
+    @Test
+    public void multiple_datasets_per_upload_independent() throws Exception {
+        // Upload with multiple datasets (split values) — each fingerprint should
+        // produce independent e-divisive results.
+        // Alpha: stable at 100, then step to 200
+        // Beta: completely stable at 500
+        DirectTopology t = createDirectTopology(5, 0.05);
+
+        // Build up history with separate uploads per fingerprint
+        for (int i = 0; i < 10; i++) {
+            uploadDirectDataPoint(t, "alpha", i, 100.0);
+        }
+        for (int i = 10; i < 20; i++) {
+            uploadDirectDataPoint(t, "alpha", i, 200.0);
+        }
+        for (int i = 0; i < 20; i++) {
+            uploadDirectDataPoint(t, "beta", i + 100, 500.0);
+        }
+
+        // Upload with BOTH datasets — this triggers e-divisive for both fingerprints
+        tm.begin();
+        ValueEntity root = new ValueEntity(null, t.root, JqValues.parse(
+                "{\"split\":[{\"fp\":\"alpha\",\"d\":20,\"y\":200.0},{\"fp\":\"beta\",\"d\":120,\"y\":500.0}]}"));
+        root.persist();
+        JqValue splitArr = root.data.getField("split");
+        for (int i = 0; i < splitArr.length(); i++) {
+            JqValue ds = splitArr.getElement(i);
+            ValueEntity split = new ValueEntity(null, t.split, ds, List.of(root));
+            split.persist();
+            new ValueEntity(null, t.domain, ds.getField("d"), List.of(split)).persist();
+            new ValueEntity(null, t.range, ds.getField("y"), List.of(split)).persist();
+            new ValueEntity(null, t.fingerprint, ds.getField("fp"), List.of(split)).persist();
+        }
+        tm.commit();
+
+        List<ValueEntity> changes = nodeService.calculateEDivisiveValues(t.ed, root, 0);
+
+        // Alpha has a step (100→200) → should detect 1 change point
+        // Beta is flat (500) → should detect 0
+        // Total should be 1
+        assertEquals(1, changes.size(),
+                "Only alpha's step (100→200) should produce a change point. " +
+                "Beta (stable at 500) should contribute none. " +
+                "If datasets cross-contaminate, we'd see incorrect results.");
+
+        // Verify the change point is for alpha's step
+        ValueEntity cp = changes.get(0);
+        assertTrue(cp.data.getField("meanBefore").asDouble(0.0) < 150,
+                "meanBefore should be ~100 (alpha's baseline), not contaminated by beta's 500");
+        assertTrue(cp.data.getField("meanAfter").asDouble(0.0) > 150 && cp.data.getField("meanAfter").asDouble(0.0) < 250,
+                "meanAfter should be ~200 (alpha's shifted level)");
+    }
+
+    @Test
+    public void non_sequential_domain_values() throws Exception {
+        // Upload domain values out of chronological order.
+        // E-divisive fetches the most recent N values by domain order,
+        // so the analysis window should contain the data regardless of upload order.
+        DirectTopology t = createDirectTopology(5, 0.05);
+
+        // Upload in scrambled order: first the "after" values, then the "before" values
+        // Series should be: domain 0-9 at y=100, domain 10-19 at y=200
+        // But upload order: 10,12,14,16,18 (y=200), then 0,2,4,6,8 (y=100),
+        // then fill in the gaps
+        for (int i = 10; i < 20; i += 2) {
+            uploadDirectDataPoint(t, "alpha", i, 200.0);
+        }
+        for (int i = 0; i < 10; i += 2) {
+            uploadDirectDataPoint(t, "alpha", i, 100.0);
+        }
+        for (int i = 1; i < 10; i += 2) {
+            uploadDirectDataPoint(t, "alpha", i, 100.0);
+        }
+        for (int i = 11; i < 20; i += 2) {
+            uploadDirectDataPoint(t, "alpha", i, 200.0);
+        }
+
+        // Final upload triggers analysis
+        ValueEntity lastRoot = uploadDirectDataPoint(t, "alpha", 20, 200.0);
+        List<ValueEntity> changes = nodeService.calculateEDivisiveValues(t.ed, lastRoot, 0);
+
+        // Despite scrambled upload order, the analysis should see the full series
+        // in domain order: [100,100,...,200,200,...] and detect the change point
+        assertEquals(1, changes.size(),
+                "E-divisive should detect the step function regardless of upload order. " +
+                "The domain ordering ensures values are analyzed in the correct sequence.");
+        assertTrue(changes.get(0).data.getField("meanBefore").asDouble(0.0) < 150,
+                "meanBefore should be ~100");
+        assertTrue(changes.get(0).data.getField("meanAfter").asDouble(0.0) > 150,
+                "meanAfter should be ~200");
+    }
+
+    @Test
+    public void change_point_removed_when_step_disappears() throws Exception {
+        // Upload a step function, verify change point exists.
+        // Then upload enough data to "fill in" the step with a gradual ramp.
+        // The old change point should be removed on recomputation.
+        DirectTopology t = createDirectTopology(5, 0.001);
+
+        // Sharp step: 10 values at 100, then 10 at 200
+        for (int i = 0; i < 10; i++) {
+            uploadDirectDataPoint(t, "alpha", i, 100.0);
+        }
+        for (int i = 10; i < 20; i++) {
+            uploadDirectDataPoint(t, "alpha", i, 200.0);
+        }
+
+        ValueEntity root20 = uploadDirectDataPoint(t, "alpha", 20, 200.0);
+        List<ValueEntity> beforeFill = nodeService.calculateEDivisiveValues(t.ed, root20, 0);
+
+        // Persist the change points
+        tm.begin();
+        for (ValueEntity cp : beforeFill) {
+            valueService.create(cp);
+        }
+        tm.commit();
+
+        assertTrue(beforeFill.size() >= 1,
+                "Sharp step should produce at least 1 change point");
+
+        // Now upload a gradual ramp from 100 to 200 that fills in the step.
+        // This adds smooth transition data to the window.
+        for (int i = 21; i <= 60; i++) {
+            double v = 100.0 + (i - 21) * (100.0 / 40.0); // gradual ramp
+            uploadDirectDataPoint(t, "alpha", i, v);
+        }
+
+        // Trigger recomputation — with the gradual ramp in the window,
+        // the sharp step at index 10 may change or disappear
+        ValueEntity rootFinal = uploadDirectDataPoint(t, "alpha", 61, 200.0);
+        List<ValueEntity> afterFill = nodeService.calculateEDivisiveValues(t.ed, rootFinal, 0);
+
+        // Verify that old change points within the window were cleaned up.
+        // The old persisted change points should have been deleted by the cleanup
+        // logic inside calculateEDivisiveValues. The new change points (afterFill)
+        // are returned but not yet persisted — that's the caller's responsibility.
+        tm.begin();
+        List<ValueEntity> persistedAfter = ValueEntity.find("node.id", t.ed.id).list();
+        assertEquals(0, persistedAfter.size(),
+                "Old change points should have been deleted during recomputation. " +
+                "The new change points are returned (not yet persisted). " +
+                "If old ones remain, the cleanup is not working.");
+        tm.commit();
+    }
+
+    @Test
+    public void recalculate_produces_consistent_results() throws Exception {
+        // Simulates the recalculate flow: e-divisive runs once per root value,
+        // but due to cumulative dedup in WorkQueue, only one execution should
+        // produce the final result. Here we test that running calculateEDivisiveValues
+        // multiple times (once per root, as recalculate would) produces consistent
+        // change points — the cleanup deletes old results and each run produces
+        // the same analysis since the full series is the same.
+        DirectTopology t = createDirectTopology(5, 0.05);
+
+        // Upload 20 values: step from 100 to 200 at index 10
+        List<ValueEntity> roots = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            roots.add(uploadDirectDataPoint(t, "alpha", i, 100.0));
+        }
+        for (int i = 10; i < 20; i++) {
+            roots.add(uploadDirectDataPoint(t, "alpha", i, 200.0));
+        }
+
+        // Run e-divisive for the LAST root (simulating a single upload trigger)
+        ValueEntity lastRoot = roots.getLast();
+        List<ValueEntity> initialResults = nodeService.calculateEDivisiveValues(t.ed, lastRoot, 0);
+        assertTrue(initialResults.size() >= 1, "Should detect at least 1 change point");
+
+        // Persist the initial change points
+        tm.begin();
+        for (ValueEntity cp : initialResults) {
+            valueService.create(cp);
+        }
+        tm.commit();
+
+        int initialCount = initialResults.size();
+
+        // Now simulate recalculation: run e-divisive for EACH root value
+        // (this is what happens when recalculate() cascades to e-divisive for each root).
+        // With cumulative dedup in WorkQueue, only one would actually run.
+        // Here we run them all sequentially to verify that repeated runs
+        // produce consistent results (cleanup + re-create).
+        List<ValueEntity> lastResults = null;
+        for (ValueEntity root : roots) {
+            lastResults = nodeService.calculateEDivisiveValues(t.ed, root, 0);
+            // Persist each run's results (simulating what WorkService.execute does)
+            tm.begin();
+            for (ValueEntity cp : lastResults) {
+                valueService.create(cp);
+            }
+            tm.commit();
+        }
+
+        // After all runs, the persisted change points should match the last run
+        tm.begin();
+        List<ValueEntity> finalPersisted = ValueEntity.find("node.id", t.ed.id).list();
+        assertEquals(initialCount, finalPersisted.size(),
+                "After simulated recalculation (running e-divisive per root), " +
+                "the final change point count should match the initial count. " +
+                "Initial: " + initialCount + ", final: " + finalPersisted.size() + ". " +
+                "The cleanup in calculateEDivisiveValues should delete old change points " +
+                "before creating new ones, so repeated runs don't accumulate.");
+        tm.commit();
+    }
+
+    @Test
+    public void recalculate_via_pipeline_preserves_change_points() throws Exception {
+        // Full pipeline test: upload data with a step function through the pipeline,
+        // then re-upload all data (simulating recalculate). Change points should
+        // be consistent.
+        double[] series = new double[20];
+        for (int i = 0; i < 10; i++) series[i] = 100.0 + (i % 3);
+        for (int i = 10; i < 20; i++) series[i] = 200.0 + (i % 3);
+
+        long edId = setupAndUpload("recalc-pipeline-test", series, 5, 0.05);
+
+        // Count change points after initial uploads
+        tm.begin();
+        List<ValueEntity> initialCps = ValueEntity.find("node.id", edId).list();
+        int initialCount = initialCps.size();
+        tm.commit();
+
+        assertTrue(initialCount >= 1, "Should have at least 1 change point after initial upload");
+
+        // Upload 5 more values at y=200 (extending the series without adding a new change point)
+        for (int i = 0; i < 5; i++) {
+            String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", 200.0 + (i % 3), 20 + i);
+            folderService.upload("recalc-pipeline-test", "$", JqValues.parse(json))
+                    .orTimeout(30, TimeUnit.SECONDS).join();
+        }
+
+        // Count change points after additional uploads
+        tm.begin();
+        List<ValueEntity> afterMoreUploads = ValueEntity.find("node.id", edId).list();
+        tm.commit();
+
+        // The step at index 10 should still be detected.
+        // Change points should not accumulate — cleanup handles it.
+        assertEquals(initialCount, afterMoreUploads.size(),
+                "After additional uploads extending the series, change point count should " +
+                "remain the same. The step at index 10 is still present. " +
+                "Initial: " + initialCount + ", after more: " + afterMoreUploads.size());
+    }
+}


### PR DESCRIPTION
…114)

- Add jhunter-core 0.1.0 dependency
- Complete EDivisive entity: implements DetectionNode, config parsing, setNodes() with sources [fingerprint, groupBy, range, domain]
- EDivisiveConfig record: windowLen, maxPvalue, minMagnitude, maxSeriesLength, fingerprintFilter
- calculateEDivisiveValues() in NodeService: collects full range value series per fingerprint, limits to maxSeriesLength, deletes existing change points, calls jhunter Analysis.computeChangePoints()
- Output includes: index, pvalue, meanBefore/After, stdBefore/After, magnitude, hazardLevel (log ratio for triage sorting)
- AddEDivisive CLI command following AddRelativeDifference pattern
- Workaround for yaup Json.getDouble() BigDecimal bug (yaup#41)
- 7 tests: step function, flat series, multiple change points, insufficient data, recomputation, REST createConfigured, hazard level