### PR TITLE
Fix native build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: ['temurin', 'graalvm']
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java 25
+      - name: Set up Java 25 (${{ matrix.distribution }})
         uses: actions/setup-java@v4
         with:
           java-version: '25'
-          distribution: 'temurin'
+          distribution: ${{ matrix.distribution }}
           cache: 'maven'
 
       - name: Build and test
@@ -25,7 +29,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.distribution }}
           path: |
             **/target/surefire-reports/
             **/target/failsafe-reports/

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,8 @@
         <!-- testcontainers -->
         <testcontainers.junit.version>2.0.3</testcontainers.junit.version>
         <testcontainers.postgresql.version>1.21.4</testcontainers.postgresql.version>
+
+        <zstd-jni.version>1.5.7-11</zstd-jni.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -547,6 +549,13 @@
                     <name>cli</name>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.github.luben</groupId>
+                    <artifactId>zstd-jni</artifactId>
+                    <version>${zstd-jni.version}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -570,6 +579,7 @@
                                         <quarkus.management.port>8080</quarkus.management.port>
                                         <!-- port does not appear to work, it still defaults to 9000 -->
                                         <quarkus.native.enabled>${h5m.cli.native}</quarkus.native.enabled>
+                                        <quarkus.native.additional-build-args>--add-exports=jdk.internal.vm.ci/jdk.vm.ci.meta=org.graalvm.truffle.runtime,--add-exports=jdk.internal.vm.ci/jdk.vm.ci.code=org.graalvm.truffle.runtime,--add-exports=jdk.internal.vm.ci/jdk.vm.ci.runtime=org.graalvm.truffle.runtime,--add-exports=jdk.internal.vm.ci/jdk.vm.ci.code.stack=org.graalvm.truffle.runtime</quarkus.native.additional-build-args>
                                         <quarkus.profile>cli</quarkus.profile>
                                         <quarkus.package.output-directory>cli</quarkus.package.output-directory>
                                     </properties>


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/h5m/issues/129

```
dlovison:h5m$ java -version
openjdk version "25.0.2" 2026-01-20
OpenJDK Runtime Environment GraalVM CE 25.0.2+10.1 (build 25.0.2+10-jvmci-b01)
OpenJDK 64-Bit Server VM GraalVM CE 25.0.2+10.1 (build 25.0.2+10-jvmci-b01, mixed mode, sharing)
```

```
mvn clean package -Pcli
```

---

```
dlovison:h5m$ java -version
openjdk version "25.0.3" 2026-04-21 LTS
OpenJDK Runtime Environment Temurin-25.0.3+9 (build 25.0.3+9-LTS)
OpenJDK 64-Bit Server VM Temurin-25.0.3+9 (build 25.0.3+9-LTS, mixed mode, sharing)
```

```
mvn clean package -Pcli -Dh5m.cli.native=false
```


