### PR TITLE
Upload REST end point in FolderResource now returns Upload Id immediately

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/Upload.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Upload.java
@@ -1,0 +1,17 @@
+package io.hyperfoil.tools.h5m.api;
+
+import jakarta.json.bind.annotation.JsonbTransient;
+
+import java.util.concurrent.CompletableFuture;
+
+public class Upload {
+    public final long uploadId;
+
+    @JsonbTransient
+    public final CompletableFuture<Void> future;
+
+    public Upload(long uploadId, CompletableFuture<Void> future) {
+        this.uploadId = uploadId;
+        this.future = future;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
@@ -3,13 +3,13 @@ package io.hyperfoil.tools.h5m.api.svc;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.h5m.api.FolderSummary;
+import io.hyperfoil.tools.h5m.api.Upload;
 import io.hyperfoil.tools.h5m.svc.RecalculationTracker;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Service interface for managing Folders.
@@ -56,15 +56,16 @@ public interface FolderServiceInterface {
 
     /**
      * Uploads data to a specific path within a folder.
-     * Returns a CompletableFuture that completes when all processing
-     * (including cascaded work) finishes for this upload.
+     * Returns immediately with an {@link Upload} containing the upload ID and a future
+     * that completes when all processing finishes.
      *
      * @param name The name of the folder.
      * @param path The path within the folder.
      * @param data The JSON data to upload.
-     * @return A future that completes when all work for this upload is done.
+     * @return an Upload with the upload ID (safe to return to callers) and
+     *         a future (for callers that need to await completion).
      */
-    CompletableFuture<Void> upload(String name, String path, JqValue data);
+    Upload upload(String name, String path, JqValue data);
 
     /**
      * Recalculates all values in the folder by reprocessing each root value

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
@@ -128,7 +128,7 @@ public class LoadLegacyRuns implements Callable<Integer> {
                                 sb.append(buf, 0, charsRead);
                             }
                             JqValue data = JqValues.parse(sb.toString());
-                            batchFutures.add(folderService.upload(folder.name(),null,data));
+                            batchFutures.add(folderService.upload(folder.name(),null,data).future);
                             count++;
                             batchCount++;
                             if(batch > 0 && batchCount >= batch){

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -18,11 +18,8 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-import io.smallrye.common.annotation.Blocking;
-
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 @Path("/api/folder")
 @Produces(MediaType.APPLICATION_JSON)
@@ -89,13 +86,15 @@ public class FolderResource {
     @POST
     @Path("{name}/upload")
     @Authenticated
-    @Blocking
-    @Operation(description = "Upload JSON data to a folder. Returns when all processing completes.")
-    public CompletionStage<Void> upload(
+    @Operation(description = "Upload JSON data to a folder. Returns immediately with an uploadId.")
+    public long upload(
             @PathParam("name") String name,
             @QueryParam("path") @Parameter(description = "Path within the folder") String path,
             JqValue data) {
-        return folderService.upload(name, path, data);
+        if (data == null) {
+            throw new BadRequestException("Missing request body");
+        }
+        return folderService.upload(name, path, data).uploadId;
     }
 
     @POST

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.Upload;
 import io.hyperfoil.tools.jjq.value.JqArray;
 import io.hyperfoil.tools.jjq.value.JqNull;
 import io.hyperfoil.tools.jjq.value.JqNumber;
@@ -240,14 +241,15 @@ public class FolderService implements FolderServiceInterface {
     }
 
     /**
-     * Uploads data and returns a future that completes when all processing finishes.
+     * Uploads data and returns an UploadHandle containing the upload ID and a future
+     * that completes when all processing finishes.
      * Uses QuarkusTransaction to control the transaction boundary explicitly —
      * the transaction commits when the lambda returns, before we return the future.
      * This avoids the deadlock that occurs with @Transactional + CompletableFuture
      * return types (Quarkus defers commit waiting for the future to complete).
      */
     @Override
-    public CompletableFuture<Void> upload(String name, String path, JqValue data){
+    public Upload upload(String name, String path, JqValue data) {
         return QuarkusTransaction.requiringNew().call(() -> {
             FolderEntity folder = em.createQuery(
                     "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
@@ -268,7 +270,7 @@ public class FolderService implements FolderServiceInterface {
 
             if (works.isEmpty()) {
                 tracking.completed = true;
-                return CompletableFuture.<Void>completedFuture(null);
+                return new Upload(newValue.id, CompletableFuture.completedFuture(null));
             }
 
             CompletableFuture<Void> future = workService.createTracked(works, Set.of(newValue.id));
@@ -278,7 +280,11 @@ public class FolderService implements FolderServiceInterface {
                     ProcessingTrackerEntity entity = ProcessingTrackerEntity.find(
                             "type = ?1 and referenceId = ?2", ProcessingType.UPLOAD, newValue.id).firstResult();
                     if (entity != null) {
-                        entity.completed = true;
+                        if (t != null) {
+                            Log.errorf(t, "Upload %d failed during processing", newValue.id);
+                        } else {
+                            entity.completed = true;
+                        }
                     }
                     // Null out data for ephemeral nodes to reclaim storage
                     int nullified = valueService.nullifyEphemeralData(newValue.id);
@@ -289,7 +295,7 @@ public class FolderService implements FolderServiceInterface {
                     }
                 });
             });
-            return future;
+            return new Upload(newValue.id, future);
         });
     }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/benchmark/ClosureBenchmarkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/benchmark/ClosureBenchmarkTest.java
@@ -75,7 +75,7 @@ public class ClosureBenchmarkTest extends FreshDb {
             long uploadStart = System.currentTimeMillis();
 
             folderService.upload("rhivos-perf-comprehensive", "$", runData[fileIndex])
-                    .orTimeout(120, TimeUnit.SECONDS).join();
+                    .future.orTimeout(120, TimeUnit.SECONDS).join();
 
             long uploadEnd = System.currentTimeMillis();
             System.out.printf("[BENCHMARK] Upload %d/%d (%s): %d ms%n",

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -3,7 +3,9 @@ package io.hyperfoil.tools.h5m.rest;
 import io.hyperfoil.tools.jjq.value.*;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.api.ProcessingType;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.ProcessingTrackerEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
@@ -171,7 +173,7 @@ public class RestEndpointTest extends FreshDb {
                 .body("{\"key\": \"value\"}")
                 .when().post("/api/folder/upload-test/upload")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
 
         given()
                 .when().get("/api/folder/upload-test/structure")
@@ -477,7 +479,7 @@ public class RestEndpointTest extends FreshDb {
                 .body("{\"key\": \"hello\"}")
                 .when().post("/api/folder/e2e-test/upload")
                 .then()
-                .statusCode(204);
+                .statusCode(200);
 
         // Wait for the work queue to finish processing the upload
         long deadline = System.currentTimeMillis() + 10_000;
@@ -514,7 +516,7 @@ public class RestEndpointTest extends FreshDb {
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
             folderService.upload("rhivos-perf-comprehensive", "$", runData)
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         given()
@@ -537,7 +539,7 @@ public class RestEndpointTest extends FreshDb {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
                 folderService.upload("rhivos-perf-comprehensive", "$", runData)
-                        .orTimeout(30, TimeUnit.SECONDS).join();
+                        .future.orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
 
@@ -558,7 +560,7 @@ public class RestEndpointTest extends FreshDb {
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
             folderService.upload("rhivos-perf-comprehensive", "$", runData)
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Find the root value ID — the upload itself
@@ -860,7 +862,7 @@ public class RestEndpointTest extends FreshDb {
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
             folderService.upload("rhivos-perf-comprehensive", "$", runData)
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Get view data — should return filtered results with only start_time and end_time columns
@@ -903,7 +905,7 @@ public class RestEndpointTest extends FreshDb {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
                 folderService.upload("rhivos-perf-comprehensive", "$", runData)
-                        .orTimeout(30, TimeUnit.SECONDS).join();
+                        .future.orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
 
@@ -981,12 +983,12 @@ public class RestEndpointTest extends FreshDb {
         given().contentType(MediaType.APPLICATION_JSON)
                 .body("{\"throughput\": 115, \"build_id\": 201}")
                 .when().post("/api/folder/lv-test/upload")
-                .then().statusCode(204);
+                .then().statusCode(200);
 
         given().contentType(MediaType.APPLICATION_JSON)
                 .body("{\"throughput\": 100, \"build_id\": 202}")
                 .when().post("/api/folder/lv-test/upload")
-                .then().statusCode(204);
+                .then().statusCode(200);
 
         long deadline = System.currentTimeMillis() + 10_000;
         while (!workService.isIdle() && System.currentTimeMillis() < deadline) {
@@ -1015,6 +1017,93 @@ public class RestEndpointTest extends FreshDb {
                 .when().get("/api/folder/123/labelValues")
                 .then()
                 .statusCode(404);
+    }
+
+    @Test
+    public void upload_returns_uploadId() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        createFolder("upload-id-test");
+
+        Long uploadId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"cpu\": 95}")
+                .when().post("/api/folder/upload-id-test/upload")
+                .then()
+                .statusCode(200)
+                .extract().as(Long.class);
+
+        assertTrue(uploadId > 0, "uploadId should be a positive number");
+
+        tm.begin();
+        ProcessingTrackerEntity entity = ProcessingTrackerEntity
+                .find("type = ?1 and referenceId = ?2", ProcessingType.UPLOAD, uploadId)
+                .firstResult();
+        assertNotNull(entity, "ProcessingTrackerEntity should exist for the returned uploadId");
+        assertEquals(uploadId, entity.referenceId, "referenceId in DB should match the returned uploadId");
+        tm.commit();
+
+    }
+
+    @Test
+    public void FolderUpload_empty_body_returns_error() {
+        createFolder("test-empty");
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .when().post("/api/folder/test-empty/upload")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void FolderUpload_tracking_record_created() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        createFolder("test-tracking");
+        Long uploadId = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"cpu\": 95}")
+                .when().post("/api/folder/test-tracking/upload")
+                .then()
+                .extract().as(Long.class);
+
+        tm.begin();
+        ProcessingTrackerEntity entity = ProcessingTrackerEntity.find(
+                "type = ?1 and referenceId = ?2", ProcessingType.UPLOAD, uploadId).firstResult();
+        tm.commit();
+        assertNotNull(entity);
+        assertTrue(entity.completed);
+    }
+
+    @Test
+    public void Upload_nonExistingFolder_returns_error() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"cpu\": 95}")
+                .when().post("/api/folder/test-folderg/upload")
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    public void multiple_uploads_return_unique_ids() {
+        createFolder("upload-unique-ids-test");
+
+        Long uploadId1 = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"cpu\": 95}")
+                .when().post("/api/folder/upload-unique-ids-test/upload")
+                .then()
+                .statusCode(200)
+                .extract().as(Long.class);
+
+        Long uploadId2 = given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"cpu\": 99}")
+                .when().post("/api/folder/upload-unique-ids-test/upload")
+                .then()
+                .statusCode(200)
+                .extract().as(Long.class);
+
+        assertNotEquals(uploadId1, uploadId2, "Each upload should return a unique ID");
+
+
     }
 
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
@@ -112,7 +112,7 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 0; i < series.length; i++) {
             String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", series[i], i);
             folderService.upload(folderName, "$", JqValues.parse(json))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         return edId;
@@ -245,7 +245,7 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 0; i < 10; i++) {
             double v = i < 5 ? 100.0 : 200.0;
             folderService.upload(folderName, "$", JqValues.parse(String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", v, i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         tm.begin();
@@ -256,7 +256,7 @@ public class EDivisiveTest extends FreshDb {
         // Upload more data — all at 200 (extending the second segment)
         for (int i = 0; i < 5; i++) {
             folderService.upload(folderName, "$", JqValues.parse(String.format("{\"v\": 200.0, \"fp\": \"default\", \"d\": %d}", 10 + i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         tm.begin();
@@ -371,19 +371,19 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 0; i < 10; i++) {
             folderService.upload(folderName, "$", JqValues.parse(
                     String.format("{\"v\": 100.0, \"fp\": \"alpha\", \"d\": %d}", i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
         for (int i = 10; i < 20; i++) {
             folderService.upload(folderName, "$", JqValues.parse(
                     String.format("{\"v\": 200.0, \"fp\": \"alpha\", \"d\": %d}", i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Beta: completely stable at 500 (no change points expected)
         for (int i = 0; i < 20; i++) {
             folderService.upload(folderName, "$", JqValues.parse(
                     String.format("{\"v\": 500.0, \"fp\": \"beta\", \"d\": %d}", i + 100)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         tm.begin();
@@ -450,7 +450,7 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 0; i < 20; i++) {
             folderService.upload(folderName, "$", JqValues.parse(
                     String.format("{\"v\": 100.0, \"fp\": \"default\", \"d\": %d}", i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         tm.begin();
@@ -466,7 +466,7 @@ public class EDivisiveTest extends FreshDb {
         // The key point: the upload should not crash and should re-analyze correctly.
         folderService.upload(folderName, "$", JqValues.parse(
                 "{\"v\": 100.0, \"fp\": \"default\", \"d\": 15}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> afterOoo = ValueEntity.find("node.id", edId).list();
@@ -827,7 +827,7 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 0; i < 5; i++) {
             String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", 200.0 + (i % 3), 20 + i);
             folderService.upload("recalc-pipeline-test", "$", JqValues.parse(json))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Count change points after additional uploads

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -236,7 +236,7 @@ public class FolderServiceTest extends FreshDb {
 
         folderService.upload("ephemeral-discard-test", "$",
                 JqValues.parse("{\"key\": \"k1\"}"))
-                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+                .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
@@ -261,7 +261,7 @@ public class FolderServiceTest extends FreshDb {
 
         folderService.upload("ephemeral-keep-test", "$",
                 JqValues.parse("{\"key\": \"k1\"}"))
-                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+                .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> values = ValueEntity.find("node.id", nodeId).list();
@@ -301,7 +301,7 @@ public class FolderServiceTest extends FreshDb {
 
         folderService.upload("ephemeral-auto-test", "$",
                 JqValues.parse("{\"key\": \"k1\"}"))
-                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+                .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         // Parent (intermediate, auto) should have data nulled
@@ -333,7 +333,7 @@ public class FolderServiceTest extends FreshDb {
 
         folderService.upload("ephemeral-leaf-test", "$",
                 JqValues.parse("{\"key\": \"k1\"}"))
-                .orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+                .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
         tm.begin();
         List<ValueEntity> values = ValueEntity.find("node.id", leafId).list();
@@ -396,5 +396,52 @@ public class FolderServiceTest extends FreshDb {
         ProcessingTrackerEntity updatedTracking = ProcessingTrackerEntity.find("referenceId", rootValueId).firstResult();
         assertTrue(updatedTracking.completed, "Tracking record should be marked completed after recovery");
         tm.commit();
+    }
+    
+    @Test
+    public void upload_id_matches_root_value() throws Exception {
+        tm.begin();
+        folderService.create("upload-root-match-test");
+        tm.commit();
+
+        long uploadId = folderService.upload("upload-root-match-test", null,
+                JqValues.parse("{\"cpu\": 95}")).uploadId;
+
+        tm.begin();
+        ValueEntity rootValue = ValueEntity.findById(uploadId);
+        assertNotNull(rootValue, "Upload ID should correspond to a root ValueEntity");
+        assertEquals(uploadId, rootValue.id, "upload should return the root value id");
+        tm.commit();
+    }
+
+    @Test
+    public void upload_creates_processing_tracker() throws Exception {
+        tm.begin();
+        folderService.create("upload-tracker-svc-test");
+        tm.commit();
+
+        long uploadId = folderService.upload("upload-tracker-svc-test", null,
+                JqValues.parse("{\"cpu\": 95}")).uploadId;
+
+        tm.begin();
+        ProcessingTrackerEntity entity = ProcessingTrackerEntity.find(
+                "type = ?1 and referenceId = ?2", ProcessingType.UPLOAD, uploadId).firstResult();
+        assertNotNull(entity, "ProcessingTrackerEntity should be created on upload");
+        assertEquals(uploadId, entity.referenceId);
+        tm.commit();
+    }
+
+    @Test
+    public void upload_returns_unique_ids_per_upload() throws Exception {
+        tm.begin();
+        folderService.create("upload-unique-svc-test");
+        tm.commit();
+
+        long id1 = folderService.upload("upload-unique-svc-test", null,
+                JqValues.parse("{\"cpu\": 95}")).uploadId;
+        long id2 = folderService.upload("upload-unique-svc-test", null,
+                JqValues.parse("{\"cpu\": 99}")).uploadId;
+
+        assertNotEquals(id1, id2, "Each upload should return a unique ID");
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
@@ -116,7 +116,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload data
         folderService.upload("recalc-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify values exist
         tm.begin();
@@ -172,7 +172,7 @@ public class RecalculateTest extends FreshDb {
         // Upload a value that exceeds the threshold
         eventObserver.clear();
         folderService.upload("recalc-notify-test", "$", JqValues.parse("{\"y\": 100, \"fp\": \"default\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Upload should dispatch notifications
         List<ChangeDetectedEvent> uploadEvents = new ArrayList<>(eventObserver.getEvents());
@@ -225,7 +225,7 @@ public class RecalculateTest extends FreshDb {
         // Upload
         folderService.upload("selective-test", "$",
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify initial values — nodeA is intermediate (AUTO), so its data
         // is nullified by ephemeral cleanup. nodeB and nodeC are leaves, data preserved.
@@ -300,7 +300,7 @@ public class RecalculateTest extends FreshDb {
         for (int i = 0; i < 3; i++) {
             folderService.upload("multi-recalc-test", "$",
                     JqValues.parse(String.format("{\"y\": %d, \"fp\": \"default\"}", 100 + i * 10)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Count change detection values after uploads
@@ -345,7 +345,7 @@ public class RecalculateTest extends FreshDb {
         // Upload data
         folderService.upload("update-recalc-test", "$",
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify initial value
         tm.begin();
@@ -395,7 +395,7 @@ public class RecalculateTest extends FreshDb {
         for (int i = 0; i < 3; i++) {
             folderService.upload("progress-test", "$",
                     JqValues.parse(String.format("{\"key\": \"value_%d\"}", i)))
-                    .orTimeout(30, TimeUnit.SECONDS).join();
+                    .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Start recalculation — returns tracker immediately
@@ -458,7 +458,7 @@ public class RecalculateTest extends FreshDb {
         // Upload data with 2 items (datasets) per upload
         folderService.upload("split-recalc-test", "$", JqValues.parse(
                 "{\"items\": [{\"v\": 10}, {\"v\": 20}]}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify the JQ .items[] produced 2 values
         tm.begin();
@@ -473,7 +473,7 @@ public class RecalculateTest extends FreshDb {
         // Upload a second data point
         folderService.upload("split-recalc-test", "$", JqValues.parse(
                 "{\"items\": [{\"v\": 30}, {\"v\": 40}]}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify we now have 4 values (2 per upload × 2 uploads)
         tm.begin();
@@ -540,7 +540,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload data
         folderService.upload("ephemeral-recalc-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: extract data should be NULL (ephemeral), transform data should be present
         tm.begin();
@@ -613,7 +613,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload data
         folderService.upload("chain-recalc-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify after upload: A and B are nullified, C has data
         tm.begin();
@@ -696,7 +696,7 @@ public class RecalculateTest extends FreshDb {
         // Upload data
         folderService.upload("mixed-recalc-test", "$",
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify after upload: A has data (KEEP), B is NULL (DISCARD)
         tm.begin();
@@ -749,7 +749,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         folderService.upload("toplevel-recalc-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         tm.begin();
         assertEquals("hello", ValueEntity.find("node.id", nodeAId).<ValueEntity>list().get(0).data.asText());
@@ -871,7 +871,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         folderService.upload("tracking-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Recalculate and wait
         folderService.recalculate("tracking-test").getFuture()
@@ -905,7 +905,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload data
         folderService.upload("recovery-recalc-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Simulate crash: create incomplete recalculation tracker
         tm.begin();
@@ -969,7 +969,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload data
         folderService.upload("recovery-ephemeral-test", "$", JqValues.parse("{\"key\": \"hello\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: A and B nullified, C has data
         tm.begin();
@@ -1052,7 +1052,7 @@ public class RecalculateTest extends FreshDb {
         // Upload initial data
         folderService.upload("mid-process-test", "$",
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify initial values
         tm.begin();
@@ -1152,7 +1152,7 @@ public class RecalculateTest extends FreshDb {
         // Upload initial data
         folderService.upload("mid-ephemeral-test", "$",
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
-                .orTimeout(30, TimeUnit.SECONDS).join();
+                .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: A and B nullified, C has data
         tm.begin();


### PR DESCRIPTION
### Problem statement
     
  The /api/folder/{name}/upload endpoint was synchronous — it blocked until all node processing (JQ transformations, change detection, etc.) completed before returning, meaning:
  - No way to identify which upload triggered which processing
  - No way to correlate an upload to its ProcessingTrackerEntity record for crash recovery
  - Long-running uploads would hold the HTTP connection open                                                                     

  ### Approach

  Added UploadHandle.java — a single class that carries both the upload identity and the processing future (Similar pattern to that of Recalculation):

  ```
public class UploadHandle {
      public final long uploadId;       // serialized to client
      @JsonbTransient
      public final CompletableFuture<Void> future;  // internal use only
  }
```

  Refactored the core upload logic into a private executeUpload() method that returns UploadHandle. Two public methods delegate to it:
  - upload() (existing interface method) — extracts .future for java method callers like LoadLegacyRuns that need to await completion
  - uploadGetId() (new) — returns the full UploadHandle for the REST layer

  The REST endpoint now mirrors the recalculate pattern — returns UploadHandle directly:

  public UploadHandle upload(...) {
      if (data == null) throw new BadRequestException("Missing request body");
      return folderService.uploadGetId(name, path, data);
  }

  Also fixed a bug where entity.completed = true was set unconditionally in whenComplete, even on failure. Now only set on success (t == null).

  ### Outcome

  - Upload returns immediately example -  {"uploadId": 42}
  - uploadId is the ValueEntity ID of the uploaded root value — directly queryable in the DB
  - Existing callers (LoadLegacyRuns, CLI) are unaffected — upload() signature unchanged
  - Added tests in RestEndpointTest and FolderServiceTest covering: positive ID, uniqueness, tracker creation, ID-to-value match, empty body rejection

### To test via swagger

1. Enter into dev moe. - mvn quarkus:dev
2. route to swagger-ui page - http://localhost:8080/q/swagger-ui/
3. create a folder first - POST /api/folder/{test-uploadId}
4. upload with body using same folder name - POST /api/folder/test-uploadId/upload. - body - {"cpu": 92}
5. Response received - Response body{   "uploadId": 201 }
