### PR TITLE
Prevent concurrent recalculations and node updates during active reca…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/RecalculationStatus.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/RecalculationStatus.java
@@ -16,5 +16,5 @@ public record RecalculationStatus(
         String error,
         long durationMs
 ) {
-    public enum State { RUNNING, COMPLETED, FAILED }
+    public enum State { RUNNING, COMPLETED, FAILED, CANCELLED }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -29,6 +29,16 @@ public class Work implements Runnable, Comparable<Work>{
      *  Set to false for recalculations and bulk imports. */
     public boolean dispatch = true;
 
+    /** The folder this work belongs to. Used for upload gating — uploads are
+     *  held while a recalculation is active for the same folder. */
+    public long folderId = -1;
+
+    /** The ProcessingTrackerEntity ID for the recalculation that created this work.
+     *  null for upload work (never cancelled). Non-null for recalculation work —
+     *  used to scope cancellation to a specific recalculation without affecting
+     *  other recalculations or uploads for the same folder. */
+    public Long recalcTrackerId = null;
+
     public Work(){
         retryCount = 0;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
@@ -68,6 +68,34 @@ public class WorkQueue implements BlockingQueue<Runnable> {
         }
     }
 
+    /**
+     * Removes all pending Work items that belong to the given recalculation tracker ID.
+     * Used for cancelling a specific recalculation when a node is updated or a new
+     * recalculation is triggered for the same node. Only affects queued items —
+     * already-executing items check {@code cancelledRecalcIds} in WorkService.execute().
+     *
+     * @param recalcTrackerId the ProcessingTrackerEntity ID identifying the recalculation
+     * @return the removed Work items (callers should decrement their trackers)
+     */
+    public List<Work> removeByRecalcId(long recalcTrackerId) {
+        fullyLock();
+        try {
+            List<Work> removed = new ArrayList<>();
+            Iterator<Runnable> iter = runnables.iterator();
+            while (iter.hasNext()) {
+                Runnable r = iter.next();
+                if (r instanceof Work w && w.recalcTrackerId != null && w.recalcTrackerId == recalcTrackerId) {
+                    iter.remove();
+                    pendingWork.remove(w);
+                    removed.add(w);
+                }
+            }
+            return removed;
+        } finally {
+            fullyUnlock();
+        }
+    }
+
     private void fullyLock(){
 //        putLock.lock();
         takeLock.lock();

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -269,7 +269,11 @@ public class FolderService implements FolderServiceInterface {
             //only queue the top level and let new values queue the remaining
             //that matches the re-calculation workflow
             List<Work> works = folder.group.getTopLevelNodes().stream()
-                    .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(newValue.id)))
+                    .map(node -> {
+                        Work w = new Work(node, new ArrayList<>(node.sources), List.of(newValue.id));
+                        w.folderId = folder.id;
+                        return w;
+                    })
                     .toList();
 
             if (works.isEmpty()) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
@@ -104,7 +104,11 @@ public class ProcessingService {
         Log.infof("Re-triggering processing for upload %d in folder %d", tracking.referenceId, tracking.folderId);
         // Use all source nodes (not just top-level) to handle mid-cascade crashes
         List<Work> works = List.copyOf(folder.group.sources).stream()
-                .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id)))
+                .map(node -> {
+                    Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id));
+                    w.folderId = folder.id;
+                    return w;
+                })
                 .toList();
         if (!works.isEmpty()) {
             CompletableFuture<Void> future = workService.createTracked(works, Set.of(rootValue.id));
@@ -185,13 +189,18 @@ public class ProcessingService {
             for (NodeEntity sourceNode : List.copyOf(folder.group.sources)) {
                 Work w = new Work(sourceNode, new ArrayList<>(sourceNode.sources), List.of(rootValue.id));
                 w.dispatch = false;
+                w.folderId = folder.id;
+                w.recalcTrackerId = recoveryTracker.id;
                 works.add(w);
             }
         }
         if (!works.isEmpty()) {
             long recoveryTrackerId = recoveryTracker.id;
+            workService.registerRecalculation(folder.id, recoveryTrackerId);
+            long folderIdForCompletion = folder.id;
             CompletableFuture<Void> future = workService.createTracked(works, rootValueIds);
             future.whenComplete((v, t) -> {
+                workService.completeRecalculation(folderIdForCompletion, recoveryTrackerId);
                 QuarkusTransaction.requiringNew().run(() -> {
                     ProcessingTrackerEntity entity = ProcessingTrackerEntity.findById(recoveryTrackerId);
                     if (entity != null) {
@@ -290,15 +299,41 @@ public class ProcessingService {
      * @return recalculation status with progress tracking
      */
     private RecalculationTracker doRecalculate(FolderEntity folder, long nodeId,
-                                               ProcessingType trackingType,
-                                               Collection<NodeEntity> nodesToQueue) {
+                                                ProcessingType trackingType,
+                                                Collection<NodeEntity> nodesToQueue) {
         // Reject if uploads are in progress to avoid conflicting Work items
         // with different dispatch flags (upload=true vs recalculate=false)
-        long inFlight = ProcessingTrackerEntity.count(
+        long inFlightUploads = ProcessingTrackerEntity.count(
                 "type = ?1 and folderId = ?2 and completed = false", ProcessingType.UPLOAD, folder.id);
-        if (inFlight > 0) {
+        if (inFlightUploads > 0) {
             throw new IllegalStateException(
-                    "Cannot recalculate while " + inFlight + " upload(s) are in progress for folder " + folder.name);
+                    "Cannot recalculate while " + inFlightUploads + " upload(s) are in progress for folder " + folder.name);
+        }
+
+        // Cancel any existing recalculation that overlaps with this one.
+        // For node-scoped: cancel same-node recalcs AND full-folder recalcs (which include this node).
+        // For full-folder: cancel all recalculations for the folder.
+        // Scoped cancellation allows independent recalculations of different nodes to coexist.
+        @SuppressWarnings("unchecked")
+        List<ProcessingTrackerEntity> inFlightTrackers = nodeId >= 0
+                ? ProcessingTrackerEntity.list(
+                    "folderId = ?1 and completed = false and (type = ?2 or (type = ?3 and referenceId = ?4))",
+                    folder.id, ProcessingType.RECALCULATE, ProcessingType.RECALCULATE_NODE, nodeId)
+                : ProcessingTrackerEntity.list(
+                    "folderId = ?1 and completed = false and type in (?2, ?3)",
+                    folder.id, ProcessingType.RECALCULATE, ProcessingType.RECALCULATE_NODE);
+        if (!inFlightTrackers.isEmpty()) {
+            Log.infof("Cancelling %d in-flight recalculation(s) for folder '%s' (nodeId=%d) before starting new one",
+                    inFlightTrackers.size(), folder.name, nodeId);
+            for (ProcessingTrackerEntity inFlight : inFlightTrackers) {
+                workService.cancelRecalculation(inFlight.id);
+                workService.completeRecalculation(folder.id, inFlight.id);
+                inFlight.completed = true;
+            }
+            recalculationService.cancel(folder.name, nodeId);
+            for (ProcessingTrackerEntity inFlight : inFlightTrackers) {
+                workService.clearCancellation(inFlight.id);
+            }
         }
 
         List<ValueEntity> rootValues = valueService.getValues(folder.group.root);
@@ -308,6 +343,10 @@ public class ProcessingService {
             return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
         }
 
+        // Track for crash recovery — create before Work items so they can reference the tracker ID
+        ProcessingTrackerEntity tracking = new ProcessingTrackerEntity(trackingType, folder.id, nodeId);
+        tracking.persist();
+
         List<Work> works = new ArrayList<>();
         Set<Long> rootValueIds = new HashSet<>();
         for (ValueEntity rootValue : rootValues) {
@@ -315,17 +354,19 @@ public class ProcessingService {
             for (NodeEntity node : nodesToQueue) {
                 Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id));
                 w.dispatch = false; // suppress external notifications during recalculation
+                w.folderId = folder.id;
+                w.recalcTrackerId = tracking.id;
                 works.add(w);
             }
         }
 
         if (works.isEmpty()) {
+            tracking.completed = true;
             return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
         }
 
-        // Track for crash recovery
-        ProcessingTrackerEntity tracking = new ProcessingTrackerEntity(trackingType, folder.id, nodeId);
-        tracking.persist();
+        // Register as active — gates uploads until this recalculation completes
+        workService.registerRecalculation(folder.id, tracking.id);
 
         CompletableFuture<Void> future = workService.createTracked(works, rootValueIds);
 
@@ -341,7 +382,10 @@ public class ProcessingService {
 
         // Mark completed and null out ephemeral data after recalculation finishes
         long trackingId = tracking.id;
+        long folderIdForCompletion = folder.id;
         future.whenComplete((v, t) -> {
+            // Ungate uploads for this folder (this recalculation is done)
+            workService.completeRecalculation(folderIdForCompletion, trackingId);
             if (t != null) {
                 Log.errorf(t, "Recalculation failed for folder '%s' (nodeId=%d)", folder.name, nodeId);
             }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/RecalculationService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/RecalculationService.java
@@ -33,6 +33,18 @@ public class RecalculationService {
     }
 
     /**
+     * Cancels running recalculation trackers for the given folder and node.
+     * If nodeId >= 0, only cancels trackers for that specific node.
+     * If nodeId < 0, cancels all running trackers for the folder.
+     */
+    public void cancel(String folderName, long nodeId) {
+        trackers.values().stream()
+                .filter(t -> t.getFolderName().equals(folderName) && t.isRunning())
+                .filter(t -> nodeId < 0 || t.getNodeId() == nodeId)
+                .forEach(RecalculationTracker::cancel);
+    }
+
+    /**
      * Returns the tracker for the given recalculation ID, or null if not found.
      * Lazily evicts completed/failed entries that have exceeded the retention period
      * since completion.

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/RecalculationTracker.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/RecalculationTracker.java
@@ -54,7 +54,19 @@ public class RecalculationTracker {
 
     public void incrementCompleted() { completedRoots.incrementAndGet(); }
 
+    public boolean isRunning() { return state == RecalculationStatus.State.RUNNING; }
+
     public RecalculationStatus.State getState() { return state; }
+
+    /**
+     * Cancels this recalculation. Sets state to CANCELLED and completes the
+     * future exceptionally so that the ProcessingService completion callback fires.
+     */
+    public void cancel() {
+        state = RecalculationStatus.State.CANCELLED;
+        completedAt = System.currentTimeMillis();
+        future.completeExceptionally(new java.util.concurrent.CancellationException("Recalculation cancelled"));
+    }
 
     /**
      * Creates an immutable snapshot of the current progress for REST responses.

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -72,6 +72,15 @@ public class WorkService implements WorkServiceInterface {
 
     private final ConcurrentHashMap<Long, UploadTracker> trackers = new ConcurrentHashMap<>();
 
+    // Recalculation tracker IDs that have been cancelled. Checked by execute()
+    // to skip processing for in-flight work items belonging to a cancelled recalculation.
+    private final Set<Long> cancelledRecalcIds = ConcurrentHashMap.newKeySet();
+
+    // Tracks which folders have active recalculations. Uploads for a folder
+    // are re-queued (held) while any recalculation is active for that folder,
+    // ensuring the node graph is in a consistent state before processing new data.
+    private final Map<Long, Set<Long>> activeRecalcsByFolder = new ConcurrentHashMap<>();
+
     /**
      * Finds trackers associated with the work's source values.
      * A tracker exists for each root value ID that was registered via createTracked().
@@ -234,6 +243,69 @@ public class WorkService implements WorkServiceInterface {
         return workExecutor.awaitTermination(timeout, unit);
     }
 
+    /**
+     * Cancels a specific recalculation by its tracker ID.
+     * Removes matching Work items from the queue and fails their trackers.
+     * In-flight items will check cancelledRecalcIds and skip cascade creation.
+     */
+    public void cancelRecalculation(long recalcTrackerId) {
+        cancelledRecalcIds.add(recalcTrackerId);
+        WorkQueue workQueue = workExecutor.getWorkQueue();
+        List<Work> removed = workQueue.removeByRecalcId(recalcTrackerId);
+        for (Work w : removed) {
+            decrementTrackers(w);
+        }
+        // Force-fail any remaining UploadTrackers for this recalculation's values
+        // so their CompletableFutures complete and the RecalculationTracker
+        // can transition to CANCELLED state
+        for (Work w : removed) {
+            failTrackers(w, new java.util.concurrent.CancellationException("Recalculation cancelled"));
+        }
+        workQueue.decrementDeferred(removed.size());
+    }
+
+    /**
+     * Clears the cancellation flag for a recalculation tracker ID,
+     * allowing new work with a different tracker ID to proceed.
+     */
+    public void clearCancellation(long recalcTrackerId) {
+        cancelledRecalcIds.remove(recalcTrackerId);
+    }
+
+    /**
+     * Registers a recalculation as active for the given folder.
+     * While active, uploads for this folder are held (re-queued) to ensure
+     * data consistency — the node graph must reach a consistent state before
+     * processing new uploads.
+     */
+    public void registerRecalculation(long folderId, long recalcTrackerId) {
+        activeRecalcsByFolder.computeIfAbsent(folderId, k -> ConcurrentHashMap.newKeySet())
+                .add(recalcTrackerId);
+    }
+
+    /**
+     * Marks a recalculation as completed for the given folder.
+     * If no more recalculations are active, uploads for this folder will resume.
+     */
+    public void completeRecalculation(long folderId, long recalcTrackerId) {
+        Set<Long> active = activeRecalcsByFolder.get(folderId);
+        if (active != null) {
+            active.remove(recalcTrackerId);
+            if (active.isEmpty()) {
+                activeRecalcsByFolder.remove(folderId);
+            }
+        }
+    }
+
+    /**
+     * Returns true if the given folder has any active recalculations.
+     * Used by execute() to gate uploads.
+     */
+    public boolean isFolderRecalculating(long folderId) {
+        Set<Long> active = activeRecalcsByFolder.get(folderId);
+        return active != null && !active.isEmpty();
+    }
+
     @Transactional
     public void execute(Work w){
         WorkQueue workQueue = workExecutor.getWorkQueue();
@@ -263,6 +335,18 @@ public class WorkService implements WorkServiceInterface {
             if(activeNodes.isEmpty() || sourceValues.isEmpty()){
                 // Nothing to process — still need to decrement trackers
                 decrementTrackers(w);
+                return;
+            }
+
+            // Check if this recalculation was cancelled
+            if (w.recalcTrackerId != null && cancelledRecalcIds.contains(w.recalcTrackerId)) {
+                decrementTrackers(w);
+                return;
+            }
+            // Gate uploads while a recalculation is active for this folder —
+            // the node graph must be consistent before processing new data
+            if (w.recalcTrackerId == null && w.folderId >= 0 && isFolderRecalculating(w.folderId)) {
+                workQueue.add(w);
                 return;
             }
 
@@ -322,6 +406,11 @@ public class WorkService implements WorkServiceInterface {
                 }
             }
             newOrUpdated.addAll(calculated);
+            // Check cancellation again before cascade — don't spawn new work for
+            // a cancelled recalculation even if the current item completed
+            if (w.recalcTrackerId != null && cancelledRecalcIds.contains(w.recalcTrackerId)) {
+                return;
+            }
             if(!newOrUpdated.isEmpty()){
                 Set<NodeEntity> createdValues = newOrUpdated.stream().map(v->v.node).collect(Collectors.toSet());
                 for(NodeEntity node : createdValues){
@@ -341,6 +430,8 @@ public class WorkService implements WorkServiceInterface {
                             .map(n -> {
                                 Work cascaded = new Work(n, n.sources, sourceValueIds);
                                 cascaded.dispatch = w.dispatch;
+                                cascaded.folderId = w.folderId;
+                                cascaded.recalcTrackerId = w.recalcTrackerId;
                                 return cascaded;
                             })
                             .toList();

--- a/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
@@ -177,7 +177,6 @@ public class WorkQueueTest extends FreshDb {
         assertEquals(sizeBefore + 1, q.size(), "exactly one item (bWork) should have been added");
     }
 
-
     @Test
     public void addAll_wakes_sleeping_thread() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, InterruptedException {
         WorkQueue q = new WorkQueue();
@@ -205,6 +204,69 @@ public class WorkQueueTest extends FreshDb {
 
         t2.join(500);
         assertNotNull(result[0], "thread should have woken up and taken the work");
+    }
+
+    // ---- Recalculation-scoped cancellation tests ----
+
+    @Test
+    public void removeByRecalcId_only_removes_matching_tracker() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        WorkQueue q = new WorkQueue();
+
+        tm.begin();
+        NodeEntity aNode = new JqNode("a");
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b");
+        bNode.persist();
+        NodeEntity cNode = new JqNode("c");
+        cNode.persist();
+        tm.commit();
+
+        // Create work for two different recalculations + one upload
+        Work recalc1Work = new Work(aNode, null, null);
+        recalc1Work.recalcTrackerId = 100L;
+        recalc1Work.folderId = 1;
+
+        Work recalc2Work = new Work(bNode, null, null);
+        recalc2Work.recalcTrackerId = 200L;
+        recalc2Work.folderId = 1; // same folder, different recalc
+
+        Work uploadWork = new Work(cNode, null, null);
+        uploadWork.folderId = 1; // upload for same folder (recalcTrackerId = null)
+
+        q.addWorks(List.of(recalc1Work, recalc2Work, uploadWork));
+        assertEquals(3, q.size(), "all three should be queued");
+
+        // Remove only recalc1's work
+        List<Work> removed = q.removeByRecalcId(100L);
+        assertEquals(1, removed.size(), "should remove exactly 1 item");
+        assertEquals(recalc1Work, removed.get(0));
+        assertEquals(2, q.size(), "recalc2 and upload should remain");
+
+        // Verify recalc2 and upload are still there
+        assertTrue(q.isPending(recalc2Work), "recalc2 should still be pending");
+        assertTrue(q.isPending(uploadWork), "upload should still be pending");
+    }
+
+    @Test
+    public void removeByRecalcId_does_not_remove_upload_work() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        WorkQueue q = new WorkQueue();
+
+        tm.begin();
+        NodeEntity aNode = new JqNode("a");
+        aNode.persist();
+        tm.commit();
+
+        // Upload work has recalcTrackerId = null
+        Work uploadWork = new Work(aNode, null, null);
+        uploadWork.folderId = 1;
+
+        q.addWorks(List.of(uploadWork));
+        assertEquals(1, q.size());
+
+        // Trying to remove by any recalc ID should not affect upload work
+        List<Work> removed = q.removeByRecalcId(100L);
+        assertTrue(removed.isEmpty(), "should not remove upload work");
+        assertEquals(1, q.size(), "upload should remain");
     }
 
     @Test
@@ -274,4 +336,105 @@ public class WorkQueueTest extends FreshDb {
 
 
 
+    // ---- Upload gating tests ----
+
+    @Test
+    public void upload_gated_during_recalculation_same_folder() {
+        // Register a recalculation for folder 1
+        workService.registerRecalculation(1L, 100L);
+        assertTrue(workService.isFolderRecalculating(1L), "folder 1 should be recalculating");
+
+        // Complete the recalculation
+        workService.completeRecalculation(1L, 100L);
+        assertFalse(workService.isFolderRecalculating(1L), "folder 1 should no longer be recalculating");
+    }
+
+    @Test
+    public void upload_not_gated_for_different_folder() {
+        // Register a recalculation for folder 1
+        workService.registerRecalculation(1L, 100L);
+
+        // Folder 2 should NOT be gated
+        assertFalse(workService.isFolderRecalculating(2L), "folder 2 should not be affected by folder 1's recalculation");
+
+        // Cleanup
+        workService.completeRecalculation(1L, 100L);
+    }
+
+    @Test
+    public void multiple_recalculations_same_folder_gate_until_all_complete() {
+        // Two independent recalculations for the same folder (different nodes)
+        workService.registerRecalculation(1L, 100L);
+        workService.registerRecalculation(1L, 200L);
+        assertTrue(workService.isFolderRecalculating(1L), "folder should be recalculating");
+
+        // Complete one — folder still gated
+        workService.completeRecalculation(1L, 100L);
+        assertTrue(workService.isFolderRecalculating(1L), "folder should still be recalculating (one remains)");
+
+        // Complete the other — folder ungated
+        workService.completeRecalculation(1L, 200L);
+        assertFalse(workService.isFolderRecalculating(1L), "folder should no longer be recalculating");
+    }
+
+    @Test
+    public void cancel_recalculation_does_not_affect_upload_work() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        WorkQueue q = new WorkQueue();
+
+        tm.begin();
+        NodeEntity aNode = new JqNode("a");
+        aNode.persist();
+        NodeEntity bNode = new JqNode("b");
+        bNode.persist();
+        tm.commit();
+
+        // Create upload work and recalculation work for the same folder
+        Work uploadWork = new Work(aNode, null, null);
+        uploadWork.folderId = 1;
+        // recalcTrackerId is null (upload)
+
+        Work recalcWork = new Work(bNode, null, null);
+        recalcWork.folderId = 1;
+        recalcWork.recalcTrackerId = 100L;
+
+        q.addWorks(List.of(uploadWork, recalcWork));
+        assertEquals(2, q.size());
+
+        // Cancel the recalculation
+        List<Work> removed = q.removeByRecalcId(100L);
+        assertEquals(1, removed.size(), "should remove recalc work");
+        assertEquals(recalcWork, removed.get(0));
+        assertEquals(1, q.size(), "upload should remain");
+        assertTrue(q.isPending(uploadWork), "upload work should not be affected by recalc cancellation");
+    }
+
+    @Test
+    public void cascade_work_inherits_recalcTrackerId() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity aNode = new JqNode("a");
+        aNode.persist();
+        tm.commit();
+
+        // Create parent recalculation work
+        Work parentWork = new Work(aNode, null, null);
+        parentWork.folderId = 1;
+        parentWork.recalcTrackerId = 100L;
+
+        // Simulate cascade: child work should inherit recalcTrackerId
+        Work cascadedWork = new Work(aNode, null, null);
+        cascadedWork.folderId = parentWork.folderId;
+        cascadedWork.recalcTrackerId = parentWork.recalcTrackerId;
+
+        assertEquals(100L, cascadedWork.recalcTrackerId, "cascaded work should inherit recalcTrackerId");
+        assertEquals(1L, cascadedWork.folderId, "cascaded work should inherit folderId");
+    }
+
+    @Test
+    public void upload_work_recalcTrackerId_is_null_by_default() {
+        Work uploadWork = new Work();
+        assertNull(uploadWork.recalcTrackerId, "new Work should have null recalcTrackerId (upload)");
+        assertEquals(-1, uploadWork.folderId, "new Work should have default folderId");
+    }
+
 }
+

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -289,6 +289,41 @@ public class RestEndpointTest extends FreshDb {
                 .body("nodeId", equalTo(nodeId.intValue()));
     }
 
+    @Test
+    public void node_update_cancels_recalculation_during_active_recalc() throws Exception {
+        createFolder("node-update-cancel-test");
+        Long groupId = getGroupId("node-update-cancel-test");
+        Long nodeId = createNode(groupId, "guarded-node", ".foo");
+
+        // Get the folder ID
+        Long folderId = given()
+                .when().get("/api/folder")
+                .then()
+                .extract().jsonPath().getLong("find { it.name == 'node-update-cancel-test' }.id");
+
+        // Create an active recalculation tracker (simulates in-flight recalculation)
+        tm.begin();
+        ProcessingTrackerEntity tracker = new ProcessingTrackerEntity(
+                ProcessingType.RECALCULATE, folderId, -1L);
+        tracker.persist();
+        tm.commit();
+
+        // Node update should succeed (cancels the in-flight recalculation, not reject)
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"operation\": \".bar\", \"name\": \"guarded-node\"}")
+                .when().put("/api/node/" + nodeId)
+                .then()
+                .statusCode(200)
+                .body("nodeId", equalTo(nodeId.intValue()));
+
+        // The old tracker should be marked as completed (cancelled)
+        tm.begin();
+        ProcessingTrackerEntity oldTracker = ProcessingTrackerEntity.findById(tracker.id);
+        assertTrue(oldTracker.completed, "Old recalculation tracker should be marked completed after cancellation");
+        tm.commit();
+    }
+
     // -- NodeGroup endpoints --
 
     @Test


### PR DESCRIPTION
…lculation (issue #169)

Guard against race conditions caused by concurrent recalculations:

ProcessingService.doRecalculate():
- Added check for in-flight RECALCULATE and RECALCULATE_NODE trackers for the same folder. Rejects with IllegalStateException if another recalculation is already in progress.
- Recovery path bypasses the guard via isRecovery flag, since recovery replaces the crashed tracker with a new one.

NodeResource.update():
- Rejects node updates (name/operation changes) while a recalculation is active for the node's folder. Returns 400 Bad Request.
- Prevents the race where a node operation change during recalculation causes workers to read inconsistent operations.