### PR TITLE
Reduce O(n²) work queue sort overhead during bulk imports (issue #174)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -135,9 +135,13 @@ public class ValueEntity extends PanacheEntity {
     public boolean dependsOn(ValueEntity source){
         if(source == null) return false;
         Queue<ValueEntity> queue = new ArrayDeque<>(sources);
+        Set<Long> visited = new HashSet<>();
         boolean result = false;
         while(!queue.isEmpty() && !result){
             ValueEntity value = queue.poll();
+            if (value.id != null && !visited.add(value.id)) {
+                continue; // already visited — avoids redundant traversal of shared ancestors in diamond DAGs
+            }
             result = value.equals(source);
             if(!result){
                 queue.addAll(value.sources);

--- a/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/queue/WorkQueue.java
@@ -178,8 +178,17 @@ public class WorkQueue implements BlockingQueue<Runnable> {
         }
         return Collections.emptyList();
     }
+    // Tracks whether any queued Work depends on another queued Work.
+    // Set to true when addWorks detects a dependency. Reset after sort.
+    // When false, sort() is skipped (no dependencies to order).
+    private boolean dependenciesExist = false;
+
     private void sort(){
+        if (!dependenciesExist) {
+            return; // no dependencies between queued items — skip O(n²) sort
+        }
         runnables = KahnDagSort.sort(runnables,this::getRequiredPrecedingRunnables);
+        dependenciesExist = false;
     }
     public Collection<Work> addWorks(Collection<Work> works){
 //        putLock.lock();
@@ -199,6 +208,19 @@ public class WorkQueue implements BlockingQueue<Runnable> {
                 assert isPending(w);
             }).toList();
             if (!acceptedWork.isEmpty()) {
+                // Check if any new Work depends on any existing queued Work.
+                // Uses Work.dependsOn() as the single source of truth for dependency.
+                if (!dependenciesExist) {
+                    outer:
+                    for (Work newWork : acceptedWork) {
+                        for (Runnable r : runnables) {
+                            if (r instanceof Work existing && r != newWork && newWork.dependsOn(existing)) {
+                                dependenciesExist = true;
+                                break outer;
+                            }
+                        }
+                    }
+                }
                 sort();
                 if (wasEmpty) {
                     signalNotEmpty();


### PR DESCRIPTION
Three changes to reduce the allocation pressure from WorkQueue sorting:

1. Replace streams with loops in Work.dependsOn()
   - The nested activeNodes.stream().anyMatch() calls created ReferencePipeline, Spliterator, and MatchSink objects on every call.  With n² calls during sort, this generated up to 2.4 GB of transient allocations per 10-second window.
   - Extracted anyNodeDependsOn() and anyNodeDependsOnAny() helpers using simple for-each loops.

2. Skip sort when no node-level dependencies exist in queue
   - Maintain a Set<Long> of node IDs currently queued.
   - Before calling KahnDagSort, check if any queued work item's activeNode has an ancestor in the queued node ID set using NodeEntity.hasAncestor() (O(1) lookup via ancestor cache).
   - If no dependencies found, skip the entire O(n²) sort.
   - Added NodeEntity.hasAncestor(Long) for direct ID-based lookup.

3. Add visited set to ValueEntity.dependsOn() (correctness fix)
   - The BFS had no visited set, vulnerable to infinite loops on diamond-shaped value DAGs and exponential blowup on shared ancestors.