### PR TITLE
Replace Work.sourceValues List<ValueEntity> with List<Long> IDs (issu…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -1,7 +1,6 @@
 package io.hyperfoil.tools.h5m.entity.work;
 
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
-import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.EDivisive;
 import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;
 import io.hyperfoil.tools.h5m.entity.node.StdDevAnomaly;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
 //custom post nodegroup actions could have sourceNodes without activeNode
 public class Work implements Runnable, Comparable<Work>{
 
-    public List<ValueEntity> sourceValues;//multiple values could happen for cross test comparisons and
+    public List<Long> sourceValueIds;//IDs of source values — full entities are loaded in WorkService.execute()
 
     public List<NodeEntity> sourceNodes; //what is going to use a list of sources that are not already listed for the activeNode?
 
@@ -33,18 +32,18 @@ public class Work implements Runnable, Comparable<Work>{
     public Work(){
         retryCount = 0;
     }
-    public Work(NodeEntity activeNode,List<NodeEntity> sourceNodes,List<ValueEntity> sourceValues){
-        this(Set.of(activeNode),sourceNodes,sourceValues);
+    public Work(NodeEntity activeNode,List<NodeEntity> sourceNodes,List<Long> sourceValueIds){
+        this(Set.of(activeNode),sourceNodes,sourceValueIds);
     }
-    public Work(Set<NodeEntity> activeNodes,List<NodeEntity> sourceNodes,List<ValueEntity> sourceValues){
+    public Work(Set<NodeEntity> activeNodes,List<NodeEntity> sourceNodes,List<Long> sourceValueIds){
         this();
         this.activeNodes = new HashSet<>(activeNodes); //so that it will be mutable
         if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
                 || node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }
-        this.sourceValues = sourceValues == null ? Collections.emptyList() : new ArrayList(sourceValues);
-        this.sourceNodes = sourceNodes == null ? Collections.emptyList() : new ArrayList(sourceNodes);
+        this.sourceValueIds = sourceValueIds == null ? Collections.emptyList() : new ArrayList<>(sourceValueIds);
+        this.sourceNodes = sourceNodes == null ? Collections.emptyList() : new ArrayList<>(sourceNodes);
     }
 
     public Set<NodeEntity> getActiveNodes() {
@@ -61,31 +60,35 @@ public class Work implements Runnable, Comparable<Work>{
         }
     }
 
-    //work A depends on work B if A.activeNode depends on B.activeNode or
-    //needs reviewing for the value dependency
+    //work A depends on work B if A.activeNode depends on B.activeNode
     public boolean dependsOn(Work work){
 
         if(work == null || work.activeNodes == null || work.activeNodes.isEmpty()){
             return false;
         }
-        for (int i = 0, size = sourceValues.size(); i < size; i++) {
-            ValueEntity sourceValue = sourceValues.get(i);
-            if (work.activeNodes.stream().anyMatch(sourceValue.node::dependsOn)) {
-                for (int j = 0, wSize = work.sourceValues.size(); j < wSize; j++) {
-                    if (sourceValue.dependsOn(work.sourceValues.get(j))) {
-                        return true;
-                    }
-                }
-            }
-        }
-        if (this.activeNodes == null || this.activeNodes.isEmpty() || !this.activeNodes.stream().anyMatch(t->work.activeNodes.stream().anyMatch(t::dependsOn))) {
+        if (this.activeNodes == null || this.activeNodes.isEmpty()) {
             return false;
         }
-        if (cumulative || sourceValues.isEmpty()) {
+        // Check node-level dependency: does any of this Work's active nodes
+        // depend on any of the other Work's active nodes?
+        boolean hasNodeDependency = false;
+        for (NodeEntity thisNode : this.activeNodes) {
+            for (NodeEntity otherNode : work.activeNodes) {
+                if (thisNode.dependsOn(otherNode)) {
+                    hasNodeDependency = true;
+                    break;
+                }
+            }
+            if (hasNodeDependency) break;
+        }
+        if (!hasNodeDependency) {
+            return false;
+        }
+        if (cumulative || sourceValueIds.isEmpty()) {
             return true;
         }
-        for (int i = 0, size = sourceValues.size(); i < size; i++) {
-            if (work.sourceValues.contains(sourceValues.get(i))) {
+        for (int i = 0, size = sourceValueIds.size(); i < size; i++) {
+            if (work.sourceValueIds.contains(sourceValueIds.get(i))) {
                 return true;
             }
         }
@@ -127,11 +130,11 @@ public class Work implements Runnable, Comparable<Work>{
             if(cumulative){
                 return true;
             }
-            if (this.sourceValues.size() != work.sourceValues.size()) {
+            if (this.sourceValueIds.size() != work.sourceValueIds.size()) {
                 return false;
             }
-            for (int i = 0; i < sourceValues.size(); i++) {
-                if (!sourceValues.get(i).equals(work.sourceValues.get(i))) {
+            for (int i = 0; i < sourceValueIds.size(); i++) {
+                if (!sourceValueIds.get(i).equals(work.sourceValueIds.get(i))) {
                     return false;
                 }
             }
@@ -145,7 +148,7 @@ public class Work implements Runnable, Comparable<Work>{
         param.addAll(activeNodes);
         param.addAll(sourceNodes);
         if(!cumulative) {
-            param.addAll(sourceValues);
+            param.addAll(sourceValueIds);
         }
         return Objects.hash(param);
     }
@@ -169,7 +172,7 @@ public class Work implements Runnable, Comparable<Work>{
     public String toString() {
         return "Work<activeNodes="+activeNodes+
                 " sourceNodes="+sourceNodes.stream().map(n->""+n.getId()).collect(Collectors.joining(","))+
-                " sourceValues="+sourceValues.stream().map(v->""+v.getId()).collect(Collectors.joining(","))+
+                " sourceValueIds="+sourceValueIds.stream().map(String::valueOf).collect(Collectors.joining(","))+
                 " retry="+retryCount+
                 " hashCode="+hashCode()+" >";
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -263,7 +263,7 @@ public class FolderService implements FolderServiceInterface {
             //only queue the top level and let new values queue the remaining
             //that matches the re-calculation workflow
             List<Work> works = folder.group.getTopLevelNodes().stream()
-                    .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(newValue)))
+                    .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(newValue.id)))
                     .toList();
 
             if (works.isEmpty()) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
@@ -88,7 +88,7 @@ public class ProcessingService {
         Log.infof("Re-triggering processing for upload %d in folder %d", tracking.referenceId, tracking.folderId);
         // Use all source nodes (not just top-level) to handle mid-cascade crashes
         List<Work> works = List.copyOf(folder.group.sources).stream()
-                .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(rootValue)))
+                .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id)))
                 .toList();
         if (!works.isEmpty()) {
             CompletableFuture<Void> future = workService.createTracked(works, Set.of(rootValue.id));
@@ -167,7 +167,7 @@ public class ProcessingService {
         for (ValueEntity rootValue : rootValues) {
             rootValueIds.add(rootValue.id);
             for (NodeEntity sourceNode : List.copyOf(folder.group.sources)) {
-                Work w = new Work(sourceNode, new ArrayList<>(sourceNode.sources), List.of(rootValue));
+                Work w = new Work(sourceNode, new ArrayList<>(sourceNode.sources), List.of(rootValue.id));
                 w.dispatch = false;
                 works.add(w);
             }
@@ -297,7 +297,7 @@ public class ProcessingService {
         for (ValueEntity rootValue : rootValues) {
             rootValueIds.add(rootValue.id);
             for (NodeEntity node : nodesToQueue) {
-                Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue));
+                Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id));
                 w.dispatch = false; // suppress external notifications during recalculation
                 works.add(w);
             }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -78,13 +78,13 @@ public class WorkService implements WorkServiceInterface {
      * This derives the association from sourceValues rather than duplicating state on Work.
      */
     private List<UploadTracker> findTrackers(Work work) {
-        if (work.sourceValues == null || trackers.isEmpty()) {
+        if (work.sourceValueIds == null || trackers.isEmpty()) {
             return List.of();
         }
         List<UploadTracker> found = new ArrayList<>();
-        for (ValueEntity sv : work.sourceValues) {
-            if (sv.id != null) {
-                UploadTracker tracker = trackers.get(sv.id);
+        for (Long valueId : work.sourceValueIds) {
+            if (valueId != null) {
+                UploadTracker tracker = trackers.get(valueId);
                 if (tracker != null) {
                     found.add(tracker);
                 }
@@ -239,20 +239,15 @@ public class WorkService implements WorkServiceInterface {
         WorkQueue workQueue = workExecutor.getWorkQueue();
         boolean decrementDeferred = false;
         try {
-            // Use source values from the Work. If data is already initialized (normal
-            // pipeline path via work queue), use it directly to avoid DB round-trip +
-            // JSON deserialization. If data is not initialized (e.g., test calling
-            // execute() directly with committed entities), reload from DB.
+            // Load source values by ID from the database (or 2LC cache).
+            // Work only carries value IDs — full entities are loaded here in
+            // the transaction that needs them.
             List<ValueEntity> sourceValues = new ArrayList<>();
-            for (ValueEntity sv : w.sourceValues) {
-                if (Hibernate.isPropertyInitialized(sv, "data")) {
-                    sourceValues.add(sv);
-                } else {
-                    ValueEntity managed = em.find(ValueEntity.class, sv.id);
-                    if (managed != null) {
-                        Hibernate.initialize(managed.data);
-                        sourceValues.add(managed);
-                    }
+            for (Long valueId : w.sourceValueIds) {
+                ValueEntity managed = em.find(ValueEntity.class, valueId);
+                if (managed != null) {
+                    Hibernate.initialize(managed.data);
+                    sourceValues.add(managed);
                 }
             }
 
@@ -339,11 +334,12 @@ public class WorkService implements WorkServiceInterface {
                                 .orElse(-1L);
                         changeDetectedEvent.fire(new ChangeDetectedEvent(folderId, node.getId(), node.name, valueIds, w.dispatch));
                     }
-                    // Cascade work inherits sourceValues and dispatch flag, so tracker
-                    // association is derived automatically via findTrackers()
+                    // Cascade work inherits source value IDs and dispatch flag, so
+                    // tracker association is derived automatically via findTrackers()
+                    List<Long> sourceValueIds = sourceValues.stream().map(ValueEntity::getId).toList();
                     List<Work> cascadeWork = nodeService.getDependentNodes(node).stream()
                             .map(n -> {
-                                Work cascaded = new Work(n, n.sources, sourceValues);
+                                Work cascaded = new Work(n, n.sources, sourceValueIds);
                                 cascaded.dispatch = w.dispatch;
                                 return cascaded;
                             })

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/WorkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/WorkTest.java
@@ -22,10 +22,12 @@ public class WorkTest {
         NodeEntity rootNode = new JqNode("root",".root");
         NodeEntity relativeDifference = new RelativeDifference();
         ValueEntity rootValue1 = new ValueEntity(null,rootNode,JqValues.parse("\"text1\""));
+        rootValue1.id = 1L;
         ValueEntity rootValue2 = new ValueEntity(null,rootNode,JqValues.parse("\"text2\""));
+        rootValue2.id = 2L;
 
-        Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1));
-        Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2));
+        Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1.id));
+        Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2.id));
 
         assertEquals(work1.hashCode(),work2.hashCode(),"both work should have the same hash code despite different values");
         assertEquals(work1,work2,"work1 and work2 should be considered equal despite different source values");
@@ -38,9 +40,10 @@ public class WorkTest {
         activeNode.sources=List.of(rootNode);
 
         ValueEntity rootValue = new ValueEntity(null,rootNode,JqValues.parse("\"root\""));
+        rootValue.id = 1L;
 
-        Work work1 = new Work(activeNode,activeNode.sources,List.of(rootValue));
-        Work work2 = new Work(activeNode,activeNode.sources,List.of(rootValue));
+        Work work1 = new Work(activeNode,activeNode.sources,List.of(rootValue.id));
+        Work work2 = new Work(activeNode,activeNode.sources,List.of(rootValue.id));
 
         assertTrue(work1.hashCode() == work2.hashCode(),"same activeNode, source node, source values should have same hashcode");
     }
@@ -58,14 +61,15 @@ public class WorkTest {
         range.sources = List.of(rootNode);
 
         ValueEntity rootValue = new ValueEntity(null,rootNode,JqValues.parse("\"root\""));
+        rootValue.id = 1L;
 
         FingerprintNode fingerprintNode = new FingerprintNode();
         fingerprintNode.sources = List.of(fingerprint1,fingerprint2);
         RelativeDifference rd = new RelativeDifference();
         rd.sources = List.of(fingerprintNode,range,domain);
 
-        Work work1 = new Work(rd,rd.sources,List.of(rootValue));
-        Work work2 = new Work(rd,rd.sources,List.of(rootValue));
+        Work work1 = new Work(rd,rd.sources,List.of(rootValue.id));
+        Work work2 = new Work(rd,rd.sources,List.of(rootValue.id));
 
         assertTrue(work1.hashCode() == work2.hashCode(),"same activeNode, source node, source values should have same hashcode");
 
@@ -90,9 +94,10 @@ public class WorkTest {
         two.sources = List.of(one);
 
         ValueEntity value = new ValueEntity(null,root);
+        value.id = 1L;
 
-        Work wOne = new Work(one,null, List.of(value));
-        Work wTwo = new Work(two,null, List.of(value));
+        Work wOne = new Work(one,null, List.of(value.id));
+        Work wTwo = new Work(two,null, List.of(value.id));
 
         assertTrue(wTwo.dependsOn(wOne));
     }
@@ -104,10 +109,12 @@ public class WorkTest {
         two.sources = List.of(one);
 
         ValueEntity value1 = new ValueEntity(null,root);
+        value1.id = 1L;
         ValueEntity value2 = new ValueEntity(null,one);
+        value2.id = 2L;
 
-        Work wOne = new Work(one,null, List.of(value1));
-        Work wTwo = new Work(two,null, List.of(value2));
+        Work wOne = new Work(one,null, List.of(value1.id));
+        Work wTwo = new Work(two,null, List.of(value2.id));
 
         assertFalse(wTwo.dependsOn(wOne));
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
@@ -39,8 +39,11 @@ public class WorkQueueTest extends FreshDb {
         ValueEntity rootValue1 = new ValueEntity(null,rootNode,JqValues.parse("\"text1\""));
         ValueEntity rootValue2 = new ValueEntity(null,rootNode,JqValues.parse("\"text2\""));
 
-        Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1));
-        Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2));
+        rootValue1.persist();
+        rootValue2.persist();
+
+        Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1.id));
+        Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2.id));
 
         assertEquals(work1.hashCode(),work2.hashCode(),"both worth should have the same hashcode despite different values");
 
@@ -66,8 +69,8 @@ public class WorkQueueTest extends FreshDb {
         rootValue.persist();
 
 
-        Work first = new Work(aNode,aNode.sources,List.of(rootValue));
-        Work second = new Work(aNode,aNode.sources,List.of(rootValue));
+        Work first = new Work(aNode,aNode.sources,List.of(rootValue.id));
+        Work second = new Work(aNode,aNode.sources,List.of(rootValue.id));
 
         assertEquals(first.hashCode(),second.hashCode(),"work with different id but same scope should have the same hash");
         q.addWorks(List.of(first, second));

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ChangeDetectionTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ChangeDetectionTest.java
@@ -86,7 +86,7 @@ public class ChangeDetectionTest extends FreshDb {
     public void event_fires_when_threshold_violated() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // value 5.0 is below min=10 → violation
         ThresholdFixture fixture = setupThreshold(5.0);
-        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue().id));
 
         workService.execute(work);
 
@@ -101,7 +101,7 @@ public class ChangeDetectionTest extends FreshDb {
     public void event_does_not_fire_when_no_violation() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // value 50.0 is within [10, 100] → no violation
         ThresholdFixture fixture = setupThreshold(50.0);
-        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue().id));
 
         workService.execute(work);
 
@@ -112,14 +112,14 @@ public class ChangeDetectionTest extends FreshDb {
     public void recalculation_does_not_fire_when_value_unchanged() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         // first calculation: value 5.0 is below min=10 → violation, event fires
         ThresholdFixture fixture = setupThreshold(5.0);
-        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
+        Work work = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue().id));
         workService.execute(work);
 
         assertEquals(1, eventObserver.getEvents().size(), "first calculation should fire event");
         eventObserver.clear();
 
         // recalculation: same data, should produce identical value → deduplicated, no event
-        Work recalc = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue()));
+        Work recalc = new Work(fixture.ft(), new ArrayList<>(fixture.ft().sources), List.of(fixture.rootValue().id));
         workService.execute(recalc);
 
         assertEquals(0, eventObserver.getEvents().size(), "recalculation with identical value should not fire event");
@@ -137,7 +137,7 @@ public class ChangeDetectionTest extends FreshDb {
         rootValue.persist();
         tm.commit();
 
-        Work work = new Work(jqNode, new ArrayList<>(jqNode.sources), List.of(rootValue));
+        Work work = new Work(jqNode, new ArrayList<>(jqNode.sources), List.of(rootValue.id));
         workService.execute(work);
 
         assertEquals(0, eventObserver.getEvents().size(), "should not fire ChangeDetectedEvent for non-detection nodes");


### PR DESCRIPTION
…e #178)

Work items no longer carry full ValueEntity objects through the queue. Instead they carry only value IDs — full entities are loaded in WorkService.execute() via em.find() (which hits the 2LC cache).

This eliminates the primary remaining source of memory retention during bulk imports: queued Work items carrying multi-megabyte parsed JSON trees (JqValue data field) through the work queue.

Changes:
- Work.sourceValues -> Work.sourceValueIds (List<Long>)
- Remove value-level dependency check from Work.dependsOn() — the node-level dependency check is sufficient for ordering, and the dedup logic in WorkService.execute() handles duplicate values. The removed check walked the ValueEntity.sources DAG which required full entity references.
- Simplify WorkService.execute() reload loop — always load by ID instead of checking Hibernate.isPropertyInitialized()
- Update all Work creation sites to pass value IDs: FolderService.upload(), ProcessingService, WorkService cascade
- Update Work.equals(), hashCode(), toString() for Long-based IDs
- Update WorkService.findTrackers() to iterate IDs directly