### PR TITLE
Fix import and verifier: disconnected nodes, naming, per-upload scopi…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.jjq.value.JqArray;
 import io.hyperfoil.tools.jjq.value.JqObject;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import io.hyperfoil.tools.jjq.value.JqValues;
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.supplier.AgroalPropertiesReader;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
@@ -101,6 +102,10 @@ public class LoadLegacyTests implements Callable<Integer> {
         public void tagNodeAsLabel(Label label,NodeEntity node){
             labelToNodes.put(label,node);
             nodeToLabel.put(node,label);
+            // Label-equivalent nodes should retain their data after processing.
+            // Without KEEP, the ephemeral system nullifies them as "intermediate"
+            // nodes, but in Horreum these are the final label values.
+            node.ephemeral = EphemeralMode.KEEP;
         }
         public void renameNode(NodeEntity node,String oldName){
             nodesByName.remove(oldName,node);
@@ -230,15 +235,17 @@ public class LoadLegacyTests implements Callable<Integer> {
     //id,name,labels,calculation
     public record Variable(long id,String name,List<String> labels,String calculation){};
 
-    public NodeEntity createNodesFromLabel(Label label, NodeEntity source, NodeGroupEntity group, NodeTracking nodeTracking, Set<String> usedNames){
+    public NodeEntity createNodesFromLabel(Label label, NodeEntity source, NodeGroupEntity group, NodeTracking nodeTracking, Set<String> usedNames, boolean multiSchema){
+        // Fix A: Skip labels with no extractors — these are placeholder/stub labels
+        // from schemas like rhivos-perf-comprehensive:02 that contribute no data
+        if (label.extractors.isEmpty()) {
+            return null;
+        }
         NodeEntity rtrn = null;
         HashedLists<String,NodeEntity> labelNodesByName = new HashedLists<>();
         boolean reusedNode = false;
         for(Extractor extractor : label.extractors) {
             String extractorName = extractor.name;
-            if(extractorName.equals(label.name) || usedNames.contains(extractorName)){
-                extractorName = extractor.name;
-            }
 
             // Convert jsonpath to jq — sqlall (isArray) wraps in [...] to collect all matches
             String jqOperation = extractor.isArray
@@ -262,15 +269,20 @@ public class LoadLegacyTests implements Callable<Integer> {
         }
         //this could rename a node that is referenced by name by another node! Don't do that!
         if(label.function==null || label.function.trim().isEmpty() || JsNode.isNullEmptyOrIdentityFunction(label.function)){
-            if(label.extractors.size() == 1 && !reusedNode && label.name!=null && !label.name.trim().isEmpty()){
+            if(label.extractors.size() == 1 && label.name!=null && !label.name.trim().isEmpty()){
                 String extractorName = label.extractors.get(0).name;
                 List<NodeEntity> extractorNodes = labelNodesByName.get(extractorName);
                 if(extractorNodes.size()==1){
                     NodeEntity extractorNode = extractorNodes.get(0);
-                    if(!label.name.equals(extractorNode.name)){
+                    if (!reusedNode && !multiSchema && !label.name.equals(extractorNode.name)){
+                        // Only rename if the node isn't shared with another label
+                        // and this label is NOT part of a multi-schema group (where
+                        // renaming would create name collisions between variants)
                         extractorNode.name = label.name;
                         nodeTracking.renameNode(extractorNode,label.extractors.get(0).name);
                     }
+                    // Fix B: return the extractor node directly for identity labels,
+                    // even when reused — don't create a solo=>solo wrapper
                     rtrn = extractorNode;
                 }else{
                     System.out.println("FAILED TO FIND SINGLE EXTRACTOR "+label.extractors.get(0).name+" for label "+label.name+
@@ -284,51 +296,17 @@ public class LoadLegacyTests implements Callable<Integer> {
                 group.addNode(rtrn);
             }
         }else {
-            String function = label.function;
-            rtrn = JsNode.parse(label.name, function, labelNodesByName::get);
-            if (rtrn == null) {
-                List<String> params = JsNode.getParameterNames(label.function);
-                if(params.size()==1 && label.extractors.size() > 1) {
-                    // Multi-extractor single-param: build a JQ node that combines all extractions
-                    // into a single object per dataset item, mirroring Horreum's per-dataset extraction
-                    StringBuilder jqExpr = new StringBuilder("{");
-                    for (int i = 0; i < label.extractors.size(); i++) {
-                        Extractor ext = label.extractors.get(i);
-                        if (i > 0) jqExpr.append(", ");
-                        String jqPath = jsonpathToJq(ext.jsonpath());
-                        String quotedName = "\"" + ext.name().replace("\"", "\\\"") + "\"";
-                        if (ext.isArray()) {
-                            jqExpr.append(quotedName).append(": (try [").append(jqPath).append("] catch null)");
-                        } else if (jqPath.contains("select(")) {
-                            jqExpr.append(quotedName).append(": (first(").append(jqPath).append(") // null)");
-                        } else {
-                            jqExpr.append(quotedName).append(": (").append(jqPath).append(" // null)");
-                        }
-                    }
-                    jqExpr.append("}");
-                    String combinerName = label.name() + "_extract";
-                    NodeEntity combiner;
-                    List<NodeEntity> existing = nodeTracking.getNodes(combinerName);
-                    if (!existing.isEmpty()) {
-                        combiner = existing.get(0);
-                    } else {
-                        combiner = new JqNode(combinerName, jqExpr.toString(), List.of(source));
-                        group.addNode(combiner);
-                        nodeTracking.addNode(combiner);
-                    }
-                    rtrn = new JsNode(label.name, function, List.of(combiner));
-                } else if(params.size()==1) {
-                    rtrn = new JsNode(label.name,function,labelNodesByName.values().stream().flatMap(List::stream).collect(Collectors.toList()));
-                } else {
-                    rtrn = JsNode.parse(label.name, function, labelNodesByName::get,true);
-                    if(rtrn==null){
-                        System.err.println("Failed to make node for Label:" + label.name + "\n" + label.function + "\n  " + label.extractors.stream().map(Extractor::toString).collect(Collectors.joining("\n  ")));
-                        return null;
-                    }
-                }
-            }
+            // For import, we know the sources — they are the extractor nodes we just
+            // created. No need to call JsNode.parse() (which tries to match JS parameter
+            // names to node names — designed for user-created nodes, not import).
+            // createParameters() handles building the correct JS input object at runtime,
+            // whether the function uses named property access (value["key"]) or positional.
+            List<NodeEntity> sources = labelNodesByName.values().stream()
+                    .flatMap(List::stream).collect(Collectors.toList());
+            rtrn = new JsNode(label.name, label.function, sources);
             if(rtrn!=null){
                 nodeTracking.addNode(rtrn);
+                group.addNode(rtrn);
             }
         }
         return rtrn;
@@ -354,7 +332,7 @@ public class LoadLegacyTests implements Callable<Integer> {
                 String transformerSuffix = test.transformers().size() > 1 ? "_" + transformer.id() : "";
                 String name = "transformer_"+sanitizeName(transformer.name)+transformerSuffix;
                 Label l  = new Label(-1,name,transformer.function,transformer.extractors);
-                NodeEntity transform = createNodesFromLabel(l,folder.group.root,folder.group,nodeTracking,new HashSet<>());
+                NodeEntity transform = createNodesFromLabel(l,folder.group.root,folder.group,nodeTracking,new HashSet<>(), false);
                 folder.group.addNode(transform);
                 nodeTracking.addNode(transform);
                 transformerNodes.add(transform);
@@ -412,12 +390,14 @@ public class LoadLegacyTests implements Callable<Integer> {
                 for(Label label : labelsForJsonpath){
                     log(6,"label="+label.name);
                     Collection<Label> labels = labelsByName.get(label.name);
+                    boolean multiSchema = labels.size() > 1;
 
-                    NodeEntity labelNode = createNodesFromLabel(label,sourceNode,folder.group,nodeTracking,labelsByName.keys());
+                    NodeEntity labelNode = createNodesFromLabel(label,sourceNode,folder.group,nodeTracking,labelsByName.keys(), multiSchema);
                     if(labelNode!=null){
-                        //if this label needs to be renamed and part of a merge group
-                        if(labels.size()>1) {
-                            labelNode.name = labelNode.name + nodesByOriginalName.get(label.name).size();
+                        if(multiSchema) {
+                            // No suffix — the pipeline uses node IDs, not names.
+                            // Extractors keep their original names; the combining step
+                            // creates a combiner with the label name.
                             nodesByOriginalName.put(label.name,labelNode);
                             folder.group.addNode(labelNode);
                         } else {
@@ -431,25 +411,40 @@ public class LoadLegacyTests implements Callable<Integer> {
             //create all the merge nodes to resolve label name conflicts
             for(String labelName : nodesByOriginalName.keys()){
                 List<NodeEntity> sourceNodes = nodesByOriginalName.get(labelName);
-                // Deduplicate: variants sourcing from the same extractor produce the same
-                // value at runtime, causing value_edge duplicate constraint violations.
-                // Also skip variants with no sources (can't produce values).
-                Set<Long> seenSourceIds = new HashSet<>();
+                // Deduplicate: variants that are functionally equivalent (same operation
+                // and sources) produce the same value at runtime. Only keep unique variants.
+                // Skip variants with no sources (can't produce values).
                 List<NodeEntity> uniqueSourceNodes = new ArrayList<>();
                 for (NodeEntity sn : sourceNodes) {
                     if (sn.sources.isEmpty()) continue;
-                    Long sourceId = sn.sources.get(0).id;
-                    if (sourceId == null || seenSourceIds.add(sourceId)) {
+                    boolean duplicate = uniqueSourceNodes.stream()
+                            .anyMatch(existing -> nodeService.functionalyEquivalent(existing, sn));
+                    if (!duplicate) {
                         uniqueSourceNodes.add(sn);
-                    }else{
-                        System.out.println("REJECTING duplicate SourceNode "+sn);
+                    } else {
+                        System.out.println("REJECTING duplicate SourceNode " + sn);
                     }
                 }
                 if (uniqueSourceNodes.size() == 1) {
+                    // Only one unique variant — set its name to the label name
+                    uniqueSourceNodes.get(0).name = labelName;
                     nodeTracking.tagNodeAsLabel(new Label(-1,labelName,null,Collections.emptyList()), uniqueSourceNodes.get(0));
                 } else if (uniqueSourceNodes.size() > 1) {
                     System.out.println("combining " + labelName + " (" + uniqueSourceNodes.size() + " unique sources from " + sourceNodes.size() + " variants)");
-                    NodeEntity newNode = new JsNode(labelName, "obj=>Object.values(obj).find(v => v != null)", uniqueSourceNodes);
+                    // NaN check required: old-schema JS functions return NaN for missing data
+                    // (e.g., empty array → reduce → 0/0 → NaN). NaN is not null in JS,
+                    // so find(v => v != null) picks NaN over the correct value from the
+                    // other schema variant. Key order in Object.values() determines which
+                    // variant is checked first, making some labels work and others fail.
+                    // Must also skip string "NaN" (from NaN.toFixed(3) in old Confidence functions).
+                    // Reverse source order so the newest schema variant is tried first.
+                    // Object.values() iterates in insertion order — the newest variant
+                    // (last added during import) should be checked before older ones,
+                    // since older schema extractors may produce partially-valid values
+                    // from data that doesn't match their schema.
+                    List<NodeEntity> reversedSources = new ArrayList<>(uniqueSourceNodes);
+                    Collections.reverse(reversedSources);
+                    NodeEntity newNode = new JsNode(labelName, "obj=>Object.values(obj).find(v => v != null && v !== 'NaN' && (typeof v !== 'number' || !isNaN(v)))", reversedSources);
                     folder.group.addNode(newNode);
                     nodeTracking.addNode(newNode);
                     nodeTracking.tagNodeAsLabel(new Label(-1, labelName, newNode.operation, Collections.emptyList()), newNode);

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/VerifyLegacy.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/VerifyLegacy.java
@@ -71,7 +71,11 @@ public class VerifyLegacy implements Callable<Integer> {
             System.out.println("\n=== NODE STRUCTURE ===");
             compareNodeStructure(legacyConn, testName);
 
-            // Step 2: Get runs to verify
+            // Step 2: Check source data quality
+            System.out.println("\n=== SOURCE DATA QUALITY ===");
+            Set<String> stubLabels = checkSourceDataQuality(legacyConn);
+
+            // Step 3: Get runs to verify
             List<Long> runIds;
             if (runId != null) {
                 runIds = List.of(runId);
@@ -85,18 +89,44 @@ public class VerifyLegacy implements Callable<Integer> {
             int totalMissing = 0;
             int totalExtra = 0;
             int totalMisaligned = 0;
+            int totalRounding = 0;
+            int totalStubs = 0;
             Map<String, int[]> perLabel = new LinkedHashMap<>();  // label → [match, mismatch, missing]
             Map<Integer, int[]> perDataset = new TreeMap<>();     // ordinal → [match, mismatch, missing]
             long startTime = System.currentTimeMillis();
 
-            for (Long rid : runIds) {
-                System.out.println("\n--- Run " + rid + " ---");
-                int[] result = compareRun(legacyConn, testName, rid, perLabel, perDataset);
+            // Get h5m root value IDs in upload order (matching run import order: id DESC)
+            @SuppressWarnings("unchecked")
+            List<Number> rootValueIds = em.createNativeQuery("""
+                    SELECT v.id FROM value v
+                    JOIN node n ON v.node_id = n.id
+                    JOIN node_group ng ON ng.root_id = n.id
+                    JOIN folder f ON f.group_id = ng.id
+                    WHERE f.name = ? AND n.type = 'root'
+                    ORDER BY v.id ASC
+                    """)
+                    .setParameter(1, testName)
+                    .getResultList();
+            if (rootValueIds.size() < runIds.size()) {
+                System.out.println("WARNING: " + runIds.size() + " Horreum runs but only " + rootValueIds.size() + " h5m uploads");
+            }
+
+            for (int i = 0; i < runIds.size(); i++) {
+                Long rid = runIds.get(i);
+                Long rootValueId = i < rootValueIds.size() ? rootValueIds.get(i).longValue() : null;
+                System.out.println("\n--- Run " + rid + (rootValueId != null ? " (h5m root=" + rootValueId + ")" : " (no h5m upload)") + " ---");
+                if (rootValueId == null) {
+                    System.out.println("  SKIPPED: no corresponding h5m upload");
+                    continue;
+                }
+                int[] result = compareRun(legacyConn, testName, rid, rootValueId, perLabel, perDataset, stubLabels);
                 totalMatches += result[0];
                 totalMismatches += result[1];
                 totalMissing += result[2];
                 totalExtra += result[3];
                 totalMisaligned += result[4];
+                totalRounding += result[5];
+                totalStubs += result[6];
             }
 
             long elapsed = System.currentTimeMillis() - startTime;
@@ -107,9 +137,14 @@ public class VerifyLegacy implements Callable<Integer> {
             System.out.println("\n=== SUMMARY ===");
             System.out.println("Runs verified: " + runIds.size());
             System.out.printf("Match rate: %.1f%% (%d/%d)%n", matchRate, totalMatches, totalComparisons);
-            System.out.println("  matching:   " + totalMatches);
-            System.out.println("  mismatched: " + totalMismatches);
-            System.out.println("  missing:    " + totalMissing + " (" + totalMisaligned + " misaligned, " + (totalMissing - totalMisaligned) + " absent)");
+            System.out.println("  matching:   " + totalMatches
+                    + " (" + (totalMatches - totalMisaligned - totalRounding) + " exact"
+                    + (totalMisaligned > 0 ? ", " + totalMisaligned + " misaligned" : "")
+                    + (totalRounding > 0 ? ", " + totalRounding + " rounding" : "")
+                    + ")");
+            System.out.println("  mismatched: " + totalMismatches
+                    + (totalStubs > 0 ? " (" + totalStubs + " stub functions, " + (totalMismatches - totalStubs) + " real)" : ""));
+            System.out.println("  missing:    " + totalMissing);
             System.out.println("  extra:      " + totalExtra);
             System.out.printf("Time: %.1fs%n", elapsed / 1000.0);
 
@@ -261,9 +296,156 @@ public class VerifyLegacy implements Callable<Integer> {
         System.out.println("Change detection nodes: Horreum=" + horreumChangeDetections + " h5m=" + h5mChangeDetections);
     }
 
-    private int[] compareRun(Connection legacyConn, String testName, long runId,
-                             Map<String, int[]> perLabel, Map<Integer, int[]> perDataset) throws SQLException {
-        int matches = 0, mismatches = 0, missing = 0, extra = 0, misaligned = 0;
+    /**
+     * Check the Horreum source data for quality issues that would affect import/verification.
+     * Returns the set of label names whose functions are stubs (zero-param, constant return).
+     */
+    private Set<String> checkSourceDataQuality(Connection legacyConn) throws SQLException {
+        Set<String> stubLabels = new HashSet<>();
+
+        // Get all schema IDs used by this test's runs
+        Set<Integer> schemaIds = new HashSet<>();
+        try (PreparedStatement ps = legacyConn.prepareStatement(
+                "SELECT DISTINCT schemaid FROM run_schemas WHERE runid IN (SELECT id FROM run WHERE testid = ?)")) {
+            ps.setLong(1, testId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) schemaIds.add(rs.getInt(1));
+            }
+        }
+
+        // Get all label names available for these schemas
+        Set<String> availableLabels = new HashSet<>();
+        if (!schemaIds.isEmpty()) {
+            String placeholders = String.join(",", Collections.nCopies(schemaIds.size(), "?"));
+            try (PreparedStatement ps = legacyConn.prepareStatement(
+                    "SELECT DISTINCT name FROM label WHERE schema_id IN (" + placeholders + ")")) {
+                int idx = 1;
+                for (int sid : schemaIds) ps.setInt(idx++, sid);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) availableLabels.add(rs.getString(1));
+                }
+            }
+        }
+
+        // Check 1: Orphaned fingerprint labels
+        List<String> orphanedFingerprints = new ArrayList<>();
+        try (PreparedStatement ps = legacyConn.prepareStatement(
+                "SELECT fingerprint_labels FROM test WHERE id = ?")) {
+            ps.setLong(1, testId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    String json = rs.getString(1);
+                    if (json != null && !json.isBlank()) {
+                        for (String name : parseJsonStringArray(json)) {
+                            if (!availableLabels.contains(name)) {
+                                orphanedFingerprints.add(name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        System.out.println("Orphaned fingerprint labels: " + orphanedFingerprints.size());
+        for (String name : orphanedFingerprints) {
+            System.out.println("  " + name + " (not defined in any schema)");
+        }
+
+        // Check 2: Orphaned variable labels
+        List<String> orphanedVariables = new ArrayList<>();
+        try (PreparedStatement ps = legacyConn.prepareStatement(
+                "SELECT id, name, labels FROM variable WHERE testid = ?")) {
+            ps.setLong(1, testId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    long varId = rs.getLong(1);
+                    String varName = rs.getString(2);
+                    String labelsJson = rs.getString(3);
+                    if (labelsJson != null && !labelsJson.isBlank()) {
+                        for (String labelName : parseJsonStringArray(labelsJson)) {
+                            if (!availableLabels.contains(labelName)) {
+                                orphanedVariables.add(labelName + " (variable \"" + varName + "\", id=" + varId + ")");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        System.out.println("Orphaned variable labels: " + orphanedVariables.size());
+        for (String desc : orphanedVariables) {
+            System.out.println("  " + desc);
+        }
+
+        // Check 3: Stub functions (zero-param functions that return constants)
+        List<String[]> stubs = new ArrayList<>(); // [name, preview]
+        if (!schemaIds.isEmpty()) {
+            String placeholders = String.join(",", Collections.nCopies(schemaIds.size(), "?"));
+            try (PreparedStatement ps = legacyConn.prepareStatement(
+                    "SELECT DISTINCT l.name, left(l.function, 80) FROM label l " +
+                    "WHERE l.schema_id IN (" + placeholders + ") " +
+                    "AND l.function IS NOT NULL AND l.function ~ '^\\s*\\(\\s*\\)\\s*=>'")) {
+                int idx = 1;
+                for (int sid : schemaIds) ps.setInt(idx++, sid);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        String name = rs.getString(1);
+                        String preview = rs.getString(2);
+                        stubs.add(new String[]{name, preview});
+                        stubLabels.add(name);
+                    }
+                }
+            }
+        }
+        System.out.println("Stub functions: " + stubs.size());
+        for (String[] stub : stubs) {
+            System.out.println("  " + stub[0] + ": " + stub[1].replaceAll("\\n.*", "").trim());
+        }
+
+        // Check 4: Labels with zero extractors
+        List<String> zeroExtractorLabels = new ArrayList<>();
+        if (!schemaIds.isEmpty()) {
+            String placeholders = String.join(",", Collections.nCopies(schemaIds.size(), "?"));
+            try (PreparedStatement ps = legacyConn.prepareStatement(
+                    "SELECT DISTINCT l.name FROM label l " +
+                    "WHERE l.schema_id IN (" + placeholders + ") " +
+                    "AND l.id NOT IN (SELECT DISTINCT label_id FROM label_extractors)")) {
+                int idx = 1;
+                for (int sid : schemaIds) ps.setInt(idx++, sid);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) zeroExtractorLabels.add(rs.getString(1));
+                }
+            }
+        }
+        System.out.println("Labels with zero extractors: " + zeroExtractorLabels.size());
+        for (String name : zeroExtractorLabels) {
+            System.out.println("  " + name);
+        }
+
+        return stubLabels;
+    }
+
+    /** Parse a JSON string array like ["a", "b", "c"] into a list of strings. */
+    private static List<String> parseJsonStringArray(String json) {
+        List<String> result = new ArrayList<>();
+        if (json == null || !json.startsWith("[")) return result;
+        // Simple parser for JSON string arrays — no nested objects/arrays expected
+        json = json.substring(1, json.length() - 1).trim();
+        if (json.isEmpty()) return result;
+        for (String part : json.split(",")) {
+            part = part.trim();
+            if (part.startsWith("\"") && part.endsWith("\"")) {
+                part = part.substring(1, part.length() - 1);
+            }
+            if (!part.isEmpty()) result.add(part);
+        }
+        return result;
+    }
+
+    private int[] compareRun(Connection legacyConn, String testName, long runId, long rootValueId,
+                             Map<String, int[]> perLabel, Map<Integer, int[]> perDataset,
+                             Set<String> stubLabels) throws SQLException {
+        int matches = 0, mismatches = 0, missing = 0, extra = 0;
+        int matchExact = 0, matchMisaligned = 0, matchRounding = 0;
+        int mismatchStub = 0;
 
         // Get Horreum label values for this run
         Map<String, Map<Integer, String>> horreumValues = new LinkedHashMap<>();
@@ -297,19 +479,23 @@ public class VerifyLegacy implements Callable<Integer> {
             }
         }
 
-        // Get h5m values per label, ordered by idx (which maps to dataset ordinal)
+        // Get h5m values for this specific upload (descendants of rootValueId),
+        // scoped to avoid mixing values from different uploads
         @SuppressWarnings("unchecked")
         List<Object[]> h5mValues = em.createNativeQuery("""
+                WITH RECURSIVE descendants(vid) AS (
+                    SELECT ve.child_id FROM value_edge ve WHERE ve.parent_id = ?
+                    UNION ALL
+                    SELECT ve.child_id FROM value_edge ve JOIN descendants d ON ve.parent_id = d.vid
+                )
                 SELECT n.name, v.idx, v.data::text
                 FROM value v
                 JOIN node n ON v.node_id = n.id
-                JOIN node_group ng ON n.group_id = ng.id
-                JOIN folder f ON f.group_id = ng.id
-                WHERE f.name = ?
-                AND n.type NOT IN ('root')
+                JOIN descendants d ON v.id = d.vid
+                WHERE n.type NOT IN ('root')
                 ORDER BY n.name, v.idx
                 """)
-                .setParameter(1, testName)
+                .setParameter(1, rootValueId)
                 .getResultList();
 
         Map<String, Map<Integer, String>> h5mByLabel = new LinkedHashMap<>();
@@ -317,7 +503,12 @@ public class VerifyLegacy implements Callable<Integer> {
             String name = (String) row[0];
             int idx = ((Number) row[1]).intValue();
             String value = (String) row[2];
-            h5mByLabel.computeIfAbsent(name, k -> new TreeMap<>()).put(idx, value);
+            // Prefer non-null values when multiple nodes with the same name produce
+            // values at the same idx (e.g., ephemeral-nulled variant nodes and the
+            // combiner node sharing the same label name)
+            h5mByLabel.computeIfAbsent(name, k -> new TreeMap<>())
+                    .merge(idx, value != null ? value : "null",
+                           (existing, incoming) -> !"null".equals(incoming) ? incoming : existing);
         }
 
         System.out.println("  Horreum: " + datasetCount + " datasets, " + horreumValues.size() + " labels");
@@ -326,71 +517,69 @@ public class VerifyLegacy implements Callable<Integer> {
         // Compare labels that exist in Horreum, checking each dataset ordinal
         for (String labelName : horreumValues.keySet()) {
             Map<Integer, String> horreumOrdinals = horreumValues.get(labelName);
-            Map<Integer, String> h5mOrdinals = h5mByLabel.getOrDefault(labelName, Map.of());
+            Map<Integer, String> h5mOrdinals = resolveH5mValues(labelName, h5mByLabel);
 
             for (Map.Entry<Integer, String> entry : horreumOrdinals.entrySet()) {
                 int ordinal = entry.getKey();
                 String horreumValue = entry.getValue();
                 if ("null".equals(horreumValue)) continue;
 
-                // h5m idx starts at 1 (idx 0 = root), Horreum ordinal starts at 0
-                // Find the h5m value at the matching position
-                String h5mValue = null;
-                int h5mIdx = ordinal + 1;
-                if (h5mOrdinals.containsKey(h5mIdx)) {
-                    h5mValue = h5mOrdinals.get(h5mIdx);
-                } else if (!h5mOrdinals.isEmpty()) {
-                    // Try matching by position in the ordered map
-                    List<String> h5mList = new ArrayList<>(h5mOrdinals.values());
-                    if (ordinal < h5mList.size()) {
-                        h5mValue = h5mList.get(ordinal);
-                    }
-                }
+                String hNorm = normalizeValue(horreumValue);
 
-                if (h5mValue != null) {
-                    String hNorm = normalizeValue(horreumValue);
-                    String h5mNorm = normalizeValue(h5mValue);
-                    if (hNorm.equals(h5mNorm)) {
-                        matches++;
-                        track(perLabel, labelName, 0);
-                        track(perDataset, ordinal, 0);
-                        if (verbose) {
-                            System.out.println("  OK       " + labelName + "[" + ordinal + "] = " + truncate(horreumValue, 80));
-                        }
-                    } else {
-                        mismatches++;
-                        track(perLabel, labelName, 1);
-                        track(perDataset, ordinal, 1);
-                        System.out.println("  MISMATCH " + labelName + " (dataset " + ordinal + "):");
-                        System.out.println("           horreum = " + truncate(horreumValue, 120));
-                        System.out.println("           h5m     = " + truncate(h5mValue, 120));
-                        if (verbose) {
-                            System.out.println("           h5m idx = " + h5mIdx);
-                            System.out.println("           h5m has " + h5mOrdinals.size() + " values at indices: " + h5mOrdinals.keySet());
-                        }
+                // Strategy: search ALL h5m values for this label to find the best match
+                MatchResult best = findBestMatch(hNorm, horreumValue, h5mOrdinals, ordinal, stubLabels.contains(labelName));
+
+                if (best.type == MatchType.EXACT) {
+                    matches++; matchExact++;
+                    track(perLabel, labelName, 0);
+                    track(perDataset, ordinal, 0);
+                    if (verbose) {
+                        System.out.println("  OK       " + labelName + "[" + ordinal + "] = " + truncate(horreumValue, 80));
                     }
-                } else {
+                } else if (best.type == MatchType.MISALIGNED) {
+                    matches++; matchMisaligned++;
+                    track(perLabel, labelName, 0);
+                    track(perDataset, ordinal, 0);
+                    if (verbose) {
+                        System.out.println("  OK~idx   " + labelName + "[" + ordinal + "] = " + truncate(horreumValue, 80)
+                                + "  (h5m idx=" + best.h5mIdx + ")");
+                    }
+                } else if (best.type == MatchType.ROUNDING) {
+                    matches++; matchRounding++;
+                    track(perLabel, labelName, 0);
+                    track(perDataset, ordinal, 0);
+                    if (verbose) {
+                        System.out.println("  OK~round " + labelName + "[" + ordinal + "]: " + truncate(horreumValue, 40)
+                                + " ≈ " + truncate(best.h5mValue, 40));
+                    }
+                } else if (best.type == MatchType.STUB) {
+                    mismatches++; mismatchStub++;
+                    track(perLabel, labelName, 1);
+                    track(perDataset, ordinal, 1);
+                    if (verbose) {
+                        System.out.println("  STUB     " + labelName + "[" + ordinal + "]: horreum=" + truncate(horreumValue, 60)
+                                + " (stub function)");
+                    }
+                } else if (best.type == MatchType.MISMATCH) {
+                    mismatches++;
+                    track(perLabel, labelName, 1);
+                    track(perDataset, ordinal, 1);
+                    System.out.println("  MISMATCH " + labelName + " (dataset " + ordinal + "):");
+                    System.out.println("           horreum = " + truncate(horreumValue, 120));
+                    System.out.println("           h5m     = " + truncate(best.h5mValue, 120));
+                    if (verbose) {
+                        System.out.println("           h5m idx = " + best.h5mIdx);
+                        System.out.println("           h5m has " + h5mOrdinals.size() + " values at indices: " + h5mOrdinals.keySet());
+                    }
+                } else { // MISSING
                     missing++;
                     track(perLabel, labelName, 2);
                     track(perDataset, ordinal, 2);
-                    // Check if the value exists at a different idx (wrong position) or not at all
-                    String hNorm = normalizeValue(horreumValue);
-                    String foundAt = null;
                     if (!h5mOrdinals.isEmpty()) {
-                        for (Map.Entry<Integer, String> h5mEntry : h5mOrdinals.entrySet()) {
-                            if (hNorm.equals(normalizeValue(h5mEntry.getValue()))) {
-                                foundAt = "idx=" + h5mEntry.getKey();
-                                break;
-                            }
-                        }
-                    }
-                    if (foundAt != null) {
-                        misaligned++;
-                        System.out.println("  MISALIGN " + labelName + " (dataset " + ordinal + "): value exists at " + foundAt);
-                    } else if (!h5mOrdinals.isEmpty()) {
-                        System.out.println("  MISMATCH " + labelName + " (dataset " + ordinal + ", h5m idx " + h5mIdx + "): node has values but none match");
+                        System.out.println("  MISSING  " + labelName + " (dataset " + ordinal + "): node has " + h5mOrdinals.size()
+                                + " values but none match");
                     } else {
-                        System.out.println("  MISSING  " + labelName + " (dataset " + ordinal + ", h5m idx " + h5mIdx + "): no values in h5m");
+                        System.out.println("  MISSING  " + labelName + " (dataset " + ordinal + "): no values in h5m");
                     }
                     if (verbose && !h5mOrdinals.isEmpty()) {
                         System.out.println("           h5m has values at indices: " + h5mOrdinals.keySet());
@@ -409,8 +598,131 @@ public class VerifyLegacy implements Callable<Integer> {
             System.out.println("  EXTRA    " + extra + " labels in h5m not in Horreum");
         }
 
-        System.out.println("  Result: " + matches + " match, " + mismatches + " mismatch, " + missing + " missing (" + misaligned + " misaligned), " + extra + " extra");
-        return new int[]{matches, mismatches, missing, extra, misaligned};
+        System.out.println("  Result: " + matches + " match (" + matchExact + " exact, " + matchMisaligned + " misaligned, "
+                + matchRounding + " rounding), " + mismatches + " mismatch"
+                + (mismatchStub > 0 ? " (" + mismatchStub + " stub)" : "")
+                + ", " + missing + " missing, " + extra + " extra");
+        return new int[]{matches, mismatches, missing, extra, matchMisaligned, matchRounding, mismatchStub};
+    }
+
+    /**
+     * Resolve h5m values for a Horreum label name, trying exact match first,
+     * then fallback strategies (numeric suffix, lowercase, snake_case).
+     */
+    private Map<Integer, String> resolveH5mValues(String labelName, Map<String, Map<Integer, String>> h5mByLabel) {
+        Map<Integer, String> result = h5mByLabel.getOrDefault(labelName, Map.of());
+        if (!result.isEmpty()) return result;
+
+        // Try numeric suffix (multi-schema merge adds "0", "1", etc.)
+        for (int suffix = 0; suffix <= 3; suffix++) {
+            result = h5mByLabel.getOrDefault(labelName + suffix, Map.of());
+            if (!result.isEmpty()) return result;
+        }
+        // Try lowercase first char (e.g., Horreum "User" → h5m "user")
+        if (labelName.length() > 0) {
+            String lower = labelName.substring(0, 1).toLowerCase() + labelName.substring(1);
+            result = h5mByLabel.getOrDefault(lower, Map.of());
+            if (!result.isEmpty()) return result;
+        }
+        // Try snake_case (e.g., "Run ID" → "run_id")
+        String snakeCase = labelName.toLowerCase().replaceAll("\\s+", "_");
+        result = h5mByLabel.getOrDefault(snakeCase, Map.of());
+        return result;
+    }
+
+    enum MatchType { EXACT, MISALIGNED, ROUNDING, STUB, MISMATCH, MISSING }
+
+    record MatchResult(MatchType type, String h5mValue, int h5mIdx) {
+        static MatchResult missing() { return new MatchResult(MatchType.MISSING, null, -1); }
+    }
+
+    /**
+     * Search all h5m values for the best match against a Horreum value.
+     * Priority: exact at same ordinal > exact at different idx > rounding match > stub > mismatch > missing.
+     *
+     * @param isStubLabel true if the label's Horreum function is a stub (zero-param, constant return)
+     */
+    private MatchResult findBestMatch(String hNorm, String hRaw, Map<Integer, String> h5mOrdinals, int ordinal,
+                                      boolean isStubLabel) {
+        if (h5mOrdinals.isEmpty()) {
+            // Even with no h5m values, check for stubs
+            if (isStubLabel || isStubValue(hRaw)) {
+                return new MatchResult(MatchType.STUB, null, -1);
+            }
+            return MatchResult.missing();
+        }
+
+        // Pass 1: exact match at expected ordinal position (idx = ordinal + 1 for h5m)
+        for (Map.Entry<Integer, String> e : h5mOrdinals.entrySet()) {
+            String h5mNorm = normalizeValue(e.getValue());
+            if (hNorm.equals(h5mNorm)) {
+                // For single-dataset runs all indices are valid; check if it's the "expected" position
+                // Expected: h5m idx typically = ordinal + 1 (root at idx 0), but this varies
+                return new MatchResult(MatchType.EXACT, e.getValue(), e.getKey());
+            }
+        }
+
+        // Pass 2: numeric rounding match (within relative tolerance)
+        Double hNum = tryParseNumber(hNorm);
+        if (hNum != null) {
+            for (Map.Entry<Integer, String> e : h5mOrdinals.entrySet()) {
+                String h5mNorm = normalizeValue(e.getValue());
+                Double h5mNum = tryParseNumber(h5mNorm);
+                if (h5mNum != null && numbersCloseEnough(hNum, h5mNum)) {
+                    return new MatchResult(MatchType.ROUNDING, e.getValue(), e.getKey());
+                }
+            }
+        }
+
+        // Pass 3: check if label is a stub function (detected from function signature or output value)
+        if (isStubLabel || isStubValue(hRaw)) {
+            return new MatchResult(MatchType.STUB, null, -1);
+        }
+
+        // Pass 4: there are h5m values but none match — report first non-null as the mismatch
+        for (Map.Entry<Integer, String> e : h5mOrdinals.entrySet()) {
+            String val = e.getValue();
+            if (val != null && !"null".equals(val)) {
+                return new MatchResult(MatchType.MISMATCH, val, e.getKey());
+            }
+        }
+
+        // All h5m values are null
+        Map.Entry<Integer, String> first = h5mOrdinals.entrySet().iterator().next();
+        return new MatchResult(MatchType.MISMATCH, first.getValue(), first.getKey());
+    }
+
+    /** Try to parse a normalized value as a number. Returns null if not numeric. */
+    private static Double tryParseNumber(String value) {
+        if (value == null || value.isEmpty() || "null".equals(value) || "NaN".equals(value)) return null;
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** Check if two numbers are close enough (relative tolerance 1e-6 or absolute 1e-10). */
+    private static boolean numbersCloseEnough(double a, double b) {
+        if (Double.isNaN(a) || Double.isNaN(b)) return Double.isNaN(a) && Double.isNaN(b);
+        if (a == b) return true;
+        double diff = Math.abs(a - b);
+        double max = Math.max(Math.abs(a), Math.abs(b));
+        return diff < 1e-10 || (max > 0 && diff / max < 1e-6);
+    }
+
+    /** Detect Horreum stub function outputs that ignore input data. */
+    private static boolean isStubValue(String value) {
+        if (value == null) return false;
+        String v = value.trim();
+        // Strip JSON string quotes
+        if (v.startsWith("\"") && v.endsWith("\"")) {
+            v = v.substring(1, v.length() - 1);
+        }
+        return v.startsWith("Need to collect")
+                || v.equals("N/A")
+                || v.equals("TBD")
+                || v.equals("TODO");
     }
 
     private static <K> void track(Map<K, int[]> map, K key, int idx) {

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/JsNode.java
@@ -10,7 +10,9 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -44,12 +46,20 @@ public class JsNode extends NodeEntity {
             System.err.println("unable to recognize javascript function from:\n"+input);
             return null;
         }
+        // Identify which parameters have default values in the function signature.
+        // Parameters with defaults (e.g., usePopulation = false) are JS-level config,
+        // not data sources from the pipeline — missing lookups for these should not
+        // cause the parse to fail.
+        Set<String> defaultParams = getDefaultParameterNames(input);
         boolean ok = true;
         List<NodeEntity> sourceNodes = new ArrayList<>();
         for (String param : parameters) {
             List<NodeEntity> foundNodes = nodeFn.apply(param);
             if (foundNodes.isEmpty()) {
-                System.err.println("Could not find node for " + param);
+                if (defaultParams.contains(param)) {
+                    // Parameter has a default value — not a data source, skip silently
+                    continue;
+                }
                 ok = false;
             } else if (foundNodes.size() > 1) {
                 System.err.println("Found more than one node matching " + param);
@@ -65,6 +75,19 @@ public class JsNode extends NodeEntity {
             rtrn = new JsNode(name, input, sourceNodes);
         }
         return rtrn;
+    }
+
+    /**
+     * Returns the number of parameters that do NOT have default values.
+     * For example, {@code (filteredArr, logData = "time", stddev = false)} returns 1.
+     * These are the actual data source parameters — parameters with defaults are
+     * JS-level config.
+     */
+    public static int countNonDefaultParams(String input) {
+        List<String> params = getParameterNames(input);
+        if (params == null || params.isEmpty()) return 0;
+        Set<String> defaults = getDefaultParameterNames(input);
+        return (int) params.stream().filter(p -> !defaults.contains(p)).count();
     }
 
     public static List<JqValue> createParameters(String function, Map<String, ValueEntity> sourceValues,int sourceCount){
@@ -164,6 +187,71 @@ public class JsNode extends NodeEntity {
     }
 
     /**
+     * Strips leading comments and extracts the raw parameter string from a JS function.
+     * Returns the comma-separated parameter list (without surrounding parens), or null
+     * if the input is not a recognizable function.
+     *
+     * <p>Shared by {@link #getParameterNames} and {@link #getDefaultParameterNames}
+     * to avoid duplicating comment-stripping and parameter-extraction logic.</p>
+     */
+    static String extractParameterString(String input) {
+        if (input == null || input.isBlank()) return null;
+        // Strip leading comments
+        int length;
+        do {
+            length = input.length();
+            if (input.trim().startsWith("//")) {
+                if (input.contains(System.lineSeparator())) {
+                    input = input.substring(input.indexOf(System.lineSeparator()) + 1);
+                }
+            }
+            if (input.trim().startsWith("/*")) {
+                input = input.substring(input.indexOf("*/") + 2);
+            }
+        } while (input.length() < length);
+        input = input.trim();
+        // Extract parameter list based on function syntax
+        String parameters = null;
+        if (input.startsWith("function(")) {
+            parameters = input.substring("function(".length(), input.indexOf(")")).trim();
+        } else if (input.startsWith("function*")) {
+            parameters = input.substring("function*".length()).trim();
+            if (parameters.matches("(?s)^(?:[a-zA-Z_$][a-zA-Z0-9_$]*)?\\([^)]*\\)\\s*\\{.*")) {
+                parameters = parameters.substring(parameters.indexOf("(") + 1, parameters.indexOf(")"));
+            }
+        } else if (input.contains("=>")) {
+            parameters = input.substring(0, input.indexOf("=>")).trim();
+            if (parameters.startsWith("(") && parameters.endsWith(")")) {
+                parameters = parameters.substring(1, parameters.length() - 1);
+            }
+        }
+        return parameters;
+    }
+
+    /**
+     * Returns the set of parameter names that have default values in the function
+     * signature. For example, {@code (arr, usePopulation = false)} returns
+     * {@code {"usePopulation"}}. These parameters are JS-level config, not data
+     * sources from the pipeline.
+     */
+    public static Set<String> getDefaultParameterNames(String input) {
+        String parameters = extractParameterString(input);
+        if (parameters == null) return Set.of();
+        Set<String> defaults = new HashSet<>();
+        for (String p : parameters.split(",")) {
+            p = p.trim();
+            if (p.contains("=")) {
+                String name = p.substring(0, p.indexOf("=")).trim()
+                        .replaceAll("\\.\\.\\.|\\{|}", "").trim();
+                if (!name.isEmpty()) {
+                    defaults.add(name);
+                }
+            }
+        }
+        return defaults;
+    }
+
+    /**
      * Returns the list of identified parameters
      * @param input
      * @return the list of parameters or null iff the input fails to parse
@@ -172,43 +260,10 @@ public class JsNode extends NodeEntity {
         return getParameterNames(input,true);
     }
     public static List<String> getParameterNames(String input, boolean removeSpread){
-        if(input==null || input.isBlank()){
-            return null;
-        }
-        List<String> rtrn = null;
-        String parameters = null;
-        //remove leading comments
-        int length = input.length();
-        do {
-            length = input.length();
-            if(input.trim().startsWith("//")){
-                if(input.contains(System.lineSeparator())){
-                    input = input.substring(input.indexOf(System.lineSeparator())+1);
-                }else{
-
-                }
-
-            }
-            if(input.trim().startsWith("/*")){
-                input = input.substring(input.indexOf("*/")+2);
-            }
-        }while(input.length() < length);
-        if(input.startsWith("function(")) {
-            parameters = input.substring("function(".length(), input.indexOf(")")).trim();
-        }else if (input.startsWith("function*")) {
-            parameters = input.substring("function*".length()).trim();
-            if(parameters.matches("(?s)^(?:[a-zA-Z_$][a-zA-Z0-9_$]*)?\\([^)]*\\)\\s*\\{.*")){
-                parameters = parameters.substring(parameters.indexOf("(")+1, parameters.indexOf(")"));
-            }
-        }else if (input.contains("=>")) {
-            parameters = input.substring(0, input.indexOf("=>")).trim();
-            if (parameters.startsWith("(") && parameters.endsWith(")")) {
-                parameters = parameters.substring(1, parameters.length() - 1);
-            }
-        }
+        String parameters = extractParameterString(input);
+        if (parameters == null) return null;
         String filter = removeSpread ? "\\.\\.\\.|\\{|}" : "\"\\\\.\\\\.\\\\.";
-        if(parameters != null){
-            rtrn = Stream.of(parameters.split(","))
+        return Stream.of(parameters.split(","))
                 .map(s -> {
                             s = s.trim()
                             .replaceAll(filter, "")
@@ -221,8 +276,6 @@ public class JsNode extends NodeEntity {
                 )
                 .filter(s -> !s.isBlank())
                 .toList();
-        }
-        return rtrn;
     }
 
     public JsNode(){

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -293,18 +293,24 @@ public class NodeService implements NodeServiceInterface {
      * @return
      */
     @Transactional
-    public List<Map<String, ValueEntity>> calculateSourceValuePermutations(NodeEntity node, ValueEntity root) {
-        List<Map<String, ValueEntity>> rtrn = new ArrayList<>();
+    /**
+     * Builds source value permutations for a node, keyed by source node ID.
+     * Using node ID (not name) as the map key avoids collisions when multiple
+     * source nodes share the same name (e.g., extractors from different schema
+     * versions). Each consumer resolves the source node by ID to access its data.
+     */
+    public List<Map<Long, ValueEntity>> calculateSourceValuePermutations(NodeEntity node, ValueEntity root) {
+        List<Map<Long, ValueEntity>> rtrn = new ArrayList<>();
         // Batch-fetch descendant values for all source nodes in a single query instead of N separate queries
         Map<Long, List<ValueEntity>> descendantsByNode = valueService.getDescendantValuesByNodes(root, node.sources);
-        Map<String,List<ValueEntity>> nodeValues = new HashMap<>();
+        Map<Long,List<ValueEntity>> nodeValues = new LinkedHashMap<>();
         for (int i = 0, size = node.sources.size(); i < size; i++) {
             NodeEntity source = node.sources.get(i);
             List<ValueEntity> found = descendantsByNode.getOrDefault(source.getId(), List.of());
             if (found.isEmpty() && source.sources.isEmpty()) {
                 found = List.of(root);
             }
-            nodeValues.put(source.name, found);
+            nodeValues.put(source.getId(), found);
         }
 
         int maxNodeValuesLength = nodeValues.values().stream().map(Collection::size).max(Integer::compareTo).orElse(0);
@@ -314,29 +320,28 @@ public class NodeService implements NodeServiceInterface {
             //to ensure sequence
             for(int i=0; i< maxNodeValuesLength; i++) {
                 int idx = i;
-                Map<String, ValueEntity> sourceValuesAtIndex = node.sources.stream()
-                                                                           .filter(n->nodeValues.get(n.name).size()>idx)
-                                                                           .collect(Collectors.toMap(n->n.name,n->nodeValues.get(n.name).get(idx)));
+                Map<Long, ValueEntity> sourceValuesAtIndex = node.sources.stream()
+                                                                           .filter(n->nodeValues.get(n.getId()).size()>idx)
+                                                                           .collect(Collectors.toMap(NodeEntity::getId,n->nodeValues.get(n.getId()).get(idx)));
                 //TODO splitting?
                 rtrn.add(sourceValuesAtIndex);
             }
         } else { //NxN or byLength time
             switch (node.multiType){
                 case Length -> {
-                    //I think this is functionally equivalent
                     for(int i=0; i< maxNodeValuesLength; i++){
-                        Map<String, ValueEntity> sourceValuesAtIndex = new HashMap<>();
+                        Map<Long, ValueEntity> sourceValuesAtIndex = new HashMap<>();
                         int idx = i;//thanks java
                         for(NodeEntity n : node.sources){
-                            List<ValueEntity> nValues = nodeValues.get(n.name);
+                            List<ValueEntity> nValues = nodeValues.get(n.getId());
                             if(nValues.size()==1){
                                 if(idx == 0){
-                                    sourceValuesAtIndex.put(n.name,nValues.get(idx));
+                                    sourceValuesAtIndex.put(n.getId(),nValues.get(idx));
                                 }else if (n.scalarMethod.equals(NodeEntity.ScalarVariableMethod.All)){
-                                    sourceValuesAtIndex.put(n.name,nValues.getFirst());
+                                    sourceValuesAtIndex.put(n.getId(),nValues.getFirst());
                                 }
                             }else if(nValues.size()>idx){
-                                sourceValuesAtIndex.put(n.name,nValues.get(idx));
+                                sourceValuesAtIndex.put(n.getId(),nValues.get(idx));
                             }else{
                                 //do nothing with a missing value
                             }
@@ -345,22 +350,20 @@ public class NodeService implements NodeServiceInterface {
                     }
                 }
                 case NxN -> {
-                    List<Map<String, ValueEntity>> valuePermutations = new ArrayList<>();
-                    List<String> multiNodes = nodeValues.entrySet().stream().filter(e->e.getValue().size()>1).map(Map.Entry::getKey).toList();
-                    List<String> scalarNodes = nodeValues.entrySet().stream().filter(e->e.getValue().size()==1).map(Map.Entry::getKey).toList();
+                    List<Map<Long, ValueEntity>> valuePermutations = new ArrayList<>();
                     int permutations = nodeValues.values().stream().map(List::size).reduce(1,(a,b)-> b > 0 ? a*b : a );
                     for( int i=0; i<permutations; i++ ) {
                         valuePermutations.add(new HashMap<>());
                     }
                     int loopCount = 1;
                     for( NodeEntity sourceNode : node.sources ){
-                        List<ValueEntity> valueList = nodeValues.get(sourceNode.name);
+                        List<ValueEntity> valueList = nodeValues.get(sourceNode.getId());
                         if( !valueList.isEmpty() ){
                             if ( valueList.size() == 1 ) {
                                 if ( sourceNode.scalarMethod.equals(NodeEntity.ScalarVariableMethod.First) ){
-                                    valuePermutations.getFirst().put(sourceNode.name, valueList.getFirst());
+                                    valuePermutations.getFirst().put(sourceNode.getId(), valueList.getFirst());
                                 }else{
-                                    valuePermutations.forEach(m->m.put(sourceNode.name, valueList.getFirst()));
+                                    valuePermutations.forEach(m->m.put(sourceNode.getId(), valueList.getFirst()));
                                 }
                             } else {//just the multivalue entries
                                 int valueCount = valueList.size();
@@ -371,7 +374,7 @@ public class NodeService implements NodeServiceInterface {
                                     for (int valueIndex = 0; valueIndex < valueList.size(); valueIndex++) {
                                         for (int i = 0; i < perValue; i++) {
                                             int permutationIndex = loopIndex * perLoop + valueIndex * perValue + i;
-                                            valuePermutations.get(permutationIndex).put(sourceNode.name, valueList.get(valueIndex));
+                                            valuePermutations.get(permutationIndex).put(sourceNode.getId(), valueList.get(valueIndex));
                                         }
                                     }
                                 }
@@ -408,9 +411,9 @@ public class NodeService implements NodeServiceInterface {
                 for(int vIdx=0; vIdx<roots.size(); vIdx++){
                     ValueEntity root =  roots.get(vIdx);
                     try {
-                        List<Map<String, ValueEntity>> combinations = calculateSourceValuePermutations(node,root);
+                        List<Map<Long, ValueEntity>> combinations = calculateSourceValuePermutations(node,root);
                         for(int i=0;i<combinations.size();i++){
-                            Map<String, ValueEntity> combination =  combinations.get(i);
+                            Map<Long, ValueEntity> combination =  combinations.get(i);
                             List<ValueEntity> createdValues = calculateNodeValues(node,combination,rtrn.size());
                             rtrn.addAll(createdValues);
                         }
@@ -456,7 +459,7 @@ public class NodeService implements NodeServiceInterface {
     }
 
     @Transactional
-    public List<ValueEntity> calculateNodeValues(NodeEntity node,Map<String, ValueEntity> sourceValues,int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateNodeValues(NodeEntity node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         return switch(node.type()){
             case JQ -> calculateJqValues((JqNode)node,sourceValues,startingOrdinal+1);
             case JS -> calculateJsValues((JsNode)node,sourceValues,startingOrdinal+1);
@@ -1002,7 +1005,7 @@ public class NodeService implements NodeServiceInterface {
 
 
     @Transactional
-    public List<ValueEntity> calculateSplitValues(SplitNode node, Map<String, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateSplitValues(SplitNode node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         List<ValueEntity> rtrn = new ArrayList<>();
         if(sourceValues.isEmpty()){
             return rtrn;
@@ -1012,7 +1015,7 @@ public class NodeService implements NodeServiceInterface {
         }
         //this will naively do the split with entities but using json_each would be good
         //TODO should this be done in db with json_each?
-        ValueEntity v = sourceValues.get(node.sources.getFirst().name);
+        ValueEntity v = sourceValues.get(node.sources.getFirst().getId());
         if(v!=null){
             if(v.data instanceof JqArray jqArr){
                 for(int i=0;i<jqArr.length();i++){
@@ -1034,7 +1037,7 @@ public class NodeService implements NodeServiceInterface {
 
 
     //jsonata cannot operate on multiple inputs at once so source
-    public List<ValueEntity> calculateJsonataValues(JsonataNode node,Map<String, ValueEntity> sourceValues,int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateJsonataValues(JsonataNode node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         if(sourceValues.size()>1 || node.sources.size()>1){
             System.err.println("jsonata only supports one input at a time");
             return Collections.emptyList();
@@ -1057,7 +1060,7 @@ public class NodeService implements NodeServiceInterface {
             newValue.idx = startingOrdinal+1;
             newValue.node = node;
             newValue.data = result;
-            newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.name)).map(n -> sourceValues.get(n.name)).collect(Collectors.toList());
+            newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.getId())).map(n -> sourceValues.get(n.getId())).collect(Collectors.toList());
             return List.of(newValue);
 
         } catch (JsonataException e) {
@@ -1249,18 +1252,45 @@ public class NodeService implements NodeServiceInterface {
     }
 
     @Transactional
-    public List<ValueEntity> calculateJsValues(JsNode node,Map<String, ValueEntity> sourceValues,int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateJsValues(JsNode node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         List<ValueEntity> rtrn = new ArrayList<>();
         List<String> params = JsNode.getParameterNames(node.operation);
         if(params == null){
             System.err.println("Error occurred reading parameters from js function\n"+node.operation);
             return Collections.emptyList();
         }
-        List<JqValue> input = JsNode.createParameters(node.operation, sourceValues, node.sources.size());
+        // Build name-keyed map for createParameters — use source node names as keys
+        // so JS function parameter matching works (e.g., value["rhivos_target"]).
+        // When multiple sources share the same name (multi-schema variants), append
+        // the source node ID to create unique keys. The multi-schema combiner function
+        // uses Object.values() which doesn't depend on key names.
+        // When sources are empty (source-less nodes), use the value's node name as key.
+        Map<String, ValueEntity> namedSourceValues = new LinkedHashMap<>();
+        if (!node.sources.isEmpty()) {
+            Set<String> seenNames = new HashSet<>();
+            for (NodeEntity source : node.sources) {
+                ValueEntity v = sourceValues.get(source.getId());
+                if (v != null) {
+                    String key = source.name;
+                    if (!seenNames.add(key)) {
+                        // Name collision — append node ID to make unique
+                        key = key + "_" + source.getId();
+                    }
+                    namedSourceValues.put(key, v);
+                }
+            }
+        } else {
+            for (ValueEntity v : sourceValues.values()) {
+                namedSourceValues.put(v.node != null ? v.node.name : String.valueOf(v.id), v);
+            }
+        }
+        List<JqValue> input = JsNode.createParameters(node.operation, namedSourceValues,
+                node.sources.isEmpty() ? sourceValues.size() : node.sources.size());
         try(Context context = Context.newBuilder("js").engine(Engine.newBuilder("js").option("engine.WarnInterpreterOnly", "false").build())
                 .allowExperimentalOptions(true)
                 .option("js.foreign-object-prototype", "true")
                 .option("js.global-property", "true")
+                .timeZone(java.time.ZoneId.of("UTC"))
 //                .out(out)
 //                .err(out)
                 .build()){
@@ -1299,7 +1329,7 @@ public class NodeService implements NodeServiceInterface {
                             newValue.idx = startingOrdinal+rtrn.size()+1;
                             newValue.node = node;
                             newValue.data = data;
-                            newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.name)).map(n -> sourceValues.get(n.name)).collect(Collectors.toList());
+                            newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.getId())).map(n -> sourceValues.get(n.getId())).collect(Collectors.toList());
                             rtrn.add(newValue);
                         }else{
                             System.err.println("null data from value "+resolvedValue);
@@ -1359,12 +1389,12 @@ public class NodeService implements NodeServiceInterface {
     }
 
     @Transactional
-    public List<ValueEntity> calculateFpValues(FingerprintNode node, Map<String, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateFpValues(FingerprintNode node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         JqObject.Builder fpBuilder = JqObject.builder();
         TreeMap<String, JqValue> sorted = new TreeMap<>();
         for (NodeEntity source : node.sources) {
-            if (sourceValues.containsKey(source.name)) {
-                sorted.put(source.name, sourceValues.get(source.name).data);
+            if (sourceValues.containsKey(source.getId())) {
+                sorted.put(source.name, sourceValues.get(source.getId()).data);
             }
         }
         sorted.forEach(fpBuilder::put);
@@ -1372,7 +1402,7 @@ public class NodeService implements NodeServiceInterface {
         newValue.idx = startingOrdinal+1;
         newValue.node = node;
         newValue.data = fpBuilder.build();
-        newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.name)).map(n -> sourceValues.get(n.name)).collect(Collectors.toList());
+        newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.getId())).map(n -> sourceValues.get(n.getId())).collect(Collectors.toList());
         return List.of(newValue);
     }
     public boolean evaluateFingerprintFilter(String filter, JqValue fingerprint) {
@@ -1402,7 +1432,7 @@ public class NodeService implements NodeServiceInterface {
     }
 
     @Transactional
-    public List<ValueEntity> calculateJqValues(JqNode node,Map<String, ValueEntity> sourceValues,int startingOrdinal) throws IOException {
+    public List<ValueEntity> calculateJqValues(JqNode node, Map<Long, ValueEntity> sourceValues, int startingOrdinal) throws IOException {
         List<ValueEntity> rtrn = new ArrayList<>();
 
         boolean isNullInput = JqNode.isNullInput(node.operation);
@@ -1420,8 +1450,8 @@ public class NodeService implements NodeServiceInterface {
         List<JqValue> sourceData = new ArrayList<>();
         if (!node.sources.isEmpty()) {
             List.copyOf(node.sources).forEach(sourceNode -> {
-                if (sourceValues.containsKey(sourceNode.name)) {
-                    sourceData.add(sourceValues.get(sourceNode.name).data);
+                if (sourceValues.containsKey(sourceNode.getId())) {
+                    sourceData.add(sourceValues.get(sourceNode.getId()).data);
                 }
             });
         } else {
@@ -1453,8 +1483,8 @@ public class NodeService implements NodeServiceInterface {
                     newValue.node = node;
                     newValue.data = jqResult;
                     newValue.sources = node.sources.stream()
-                            .filter(n -> sourceValues.containsKey(n.name))
-                            .map(n -> sourceValues.get(n.name))
+                            .filter(n -> sourceValues.containsKey(n.getId()))
+                            .map(n -> sourceValues.get(n.getId()))
                             .collect(Collectors.toList());
                     rtrn.add(newValue);
                 }

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTestsTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTestsTest.java
@@ -281,7 +281,7 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JqNode.class,entity,"Js should be dropped when function is null");
@@ -296,7 +296,7 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JqNode.class,entity,"Js should be dropped when function returns input");
@@ -311,7 +311,7 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JsNode.class,entity,"Should create a JsNode that returns combined values");
@@ -328,25 +328,20 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JsNode.class,entity,"Should create a JsNode that returns combined values");
         assertNotNull(entity.operation);
         assertFalse(JsNode.isNullEmptyOrIdentityFunction(entity.operation),"js node should have an operation that returns the input");
-        // Multi-extractor single-param labels now use a JQ combiner as their single source
-        assertEquals(1,entity.sources.size(),"label should have 1 source (the JQ combiner node)");
-        assertInstanceOf(JqNode.class,entity.sources.get(0),"source should be a JQ combiner node");
+        // Multi-extractor single-param labels source directly from extractor nodes
+        assertEquals(2,entity.sources.size(),"label should have 2 sources (direct extractor nodes)");
     }
     @Test
-    public void createNodesFromLabel_multi_extractor_single_param_creates_jq_combiner(){
-        // Mirrors the rhivos "Autobench Multi Core" pattern:
-        // - scalar extractor "workload" matches every dataset item (e.g., 10 values)
-        // - array extractor "results" only matches items with results (e.g., 1 value)
-        // Separate extractor nodes would produce mismatched counts (10 vs 1),
-        // causing calculateSourceValuePermutations to return null.
-        // The JQ combiner extracts both fields from the same input in one expression,
-        // producing one combined object per dataset item — no permutation needed.
+    public void createNodesFromLabel_multi_extractor_single_param_direct_sources(){
+        // Multi-extractor single-param labels wire the JS function directly to
+        // the extractor nodes. At runtime, createParameters() builds a combined
+        // object from the source values using node names as keys.
         LoadLegacyTests.Extractor workload = new LoadLegacyTests.Extractor("workload","$.workload",false);
         LoadLegacyTests.Extractor results = new LoadLegacyTests.Extractor("results","$.results.*",true);
         LoadLegacyTests.Label label = new LoadLegacyTests.Label(-1,"Autobench",
@@ -356,28 +351,16 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JsNode.class, entity);
         assertEquals("Autobench", entity.name);
 
-        // Single source: the JQ combiner node, not the 2 raw extractors
-        assertEquals(1, entity.sources.size(), "should have 1 source (JQ combiner), not 2 separate extractors");
-        NodeEntity combiner = entity.sources.get(0);
-        assertInstanceOf(JqNode.class, combiner);
-        assertTrue(combiner.name.endsWith("_extract"), "combiner name should end with _extract");
-
-        // The combiner's JQ expression builds an object with both extractor fields
-        // Scalar extractor uses "// null", array extractor uses "try [...] catch null"
-        assertTrue(combiner.operation.contains("workload"), "JQ expression should reference workload extractor");
-        assertTrue(combiner.operation.contains("results"), "JQ expression should reference results extractor");
-        assertTrue(combiner.operation.contains("// null"), "scalar extractor should use // null fallback");
-        assertTrue(combiner.operation.contains("try"), "array extractor should use try/catch for error suppression");
-
-        // The combiner sources from the parent (group root in this test)
-        assertEquals(1, combiner.sources.size());
-        assertEquals(group.root, combiner.sources.get(0));
+        // Should source directly from the 2 extractor nodes (no combiner)
+        assertEquals(2, entity.sources.size(), "should have 2 sources (direct extractor nodes)");
+        assertTrue(entity.sources.stream().anyMatch(s -> "workload".equals(s.name)), "should have workload source");
+        assertTrue(entity.sources.stream().anyMatch(s -> "results".equals(s.name)), "should have results source");
     }
     @Test
     public void createFolder_two_transformers_creates_two_pipelines() {
@@ -551,14 +534,13 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label, group.root, group, tracker, new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label, group.root, group, tracker, new HashSet<>(), false);
 
         assertNotNull(entity);
-        assertEquals(1, entity.sources.size());
-        NodeEntity combiner = entity.sources.get(0);
-        assertInstanceOf(JqNode.class, combiner);
-        assertTrue(combiner.operation.contains("\"My Score\""), "extractor name with spaces should be quoted");
-        assertTrue(combiner.operation.contains("\"Other Value\""), "extractor name with spaces should be quoted");
+        // Should source directly from the 2 extractor nodes (no combiner)
+        assertEquals(2, entity.sources.size(), "should have 2 direct sources");
+        assertTrue(entity.sources.stream().anyMatch(s -> "My Score".equals(s.name)));
+        assertTrue(entity.sources.stream().anyMatch(s -> "Other Value".equals(s.name)));
     }
 
     @Test
@@ -609,18 +591,22 @@ public class LoadLegacyTestsTest {
             assertNotNull(n.group, "node " + n.name + " should have group set");
             assertEquals(folder.group, n.group, "node " + n.name + " should belong to the folder group");
         }
-        // The numbered variants (metric0, metric1) should be in the group's sources
+        // Variant nodes keep their original extractor names (no suffixing).
+        // The combiner node gets the label name "metric".
         long variantCount = folder.group.sources.stream()
-                .filter(v -> v.name.startsWith("metric") && v.name.matches("metric\\d+"))
+                .filter(v -> v.name.equals("val"))
                 .count();
-        assertTrue(variantCount >= 1, "numbered variant nodes should be in the group\n"
+        assertTrue(variantCount >= 1, "variant extractor nodes (named 'val') should be in the group\n"
+                + folder.group.sources.stream().map(NodeEntity::toString).collect(Collectors.joining("\n")));
+        assertTrue(folder.group.sources.stream().anyMatch(v -> v.name.equals("metric") && v instanceof JsNode),
+                "combiner node named 'metric' should be in the group\n"
                 + folder.group.sources.stream().map(NodeEntity::toString).collect(Collectors.joining("\n")));
     }
 
     @Test
-    public void createNodesFromLabel_jq_combiner_reused_across_labels() {
+    public void createNodesFromLabel_shared_extractors_across_labels() {
         // When two labels with different functions but same extractors call createNodesFromLabel,
-        // the second should reuse the existing JQ combiner instead of creating a duplicate
+        // the extractor nodes should be reused (same instances)
         LoadLegacyTests.Extractor ext1 = new LoadLegacyTests.Extractor("a","$.a",false);
         LoadLegacyTests.Extractor ext2 = new LoadLegacyTests.Extractor("b","$.b",false);
 
@@ -630,31 +616,29 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity node1 = loadLegacyTests.createNodesFromLabel(label1, group.root, group, tracker, new HashSet<>());
-        NodeEntity node2 = loadLegacyTests.createNodesFromLabel(label2, group.root, group, tracker, new HashSet<>());
+        NodeEntity node1 = loadLegacyTests.createNodesFromLabel(label1, group.root, group, tracker, new HashSet<>(), false);
+        NodeEntity node2 = loadLegacyTests.createNodesFromLabel(label2, group.root, group, tracker, new HashSet<>(), false);
 
         assertNotNull(node1);
         assertNotNull(node2);
-        // Both should be JsNodes with a JQ combiner as source
         assertInstanceOf(JsNode.class, node1);
         assertInstanceOf(JsNode.class, node2);
-        assertEquals(1, node1.sources.size());
-        assertEquals(1, node2.sources.size());
-        // Both should reference the SAME combiner instance (reused, not duplicated)
+        // Both should source directly from the same extractor nodes (reused)
+        assertEquals(2, node1.sources.size(), "first label should have 2 sources");
+        assertEquals(2, node2.sources.size(), "second label should have 2 sources");
         assertSame(node1.sources.get(0), node2.sources.get(0),
-                "both labels should reuse the same JQ combiner node");
-        // Only one combiner should exist in the group
+                "both labels should share the same first extractor node");
+        // No combiner nodes should exist
         long combinerCount = group.sources.stream()
                 .filter(v -> v.name.endsWith("_extract"))
                 .count();
-        assertEquals(1, combinerCount, "should have exactly 1 combiner node, not duplicates");
+        assertEquals(0, combinerCount, "should have no combiner nodes");
     }
 
     @Test
-    public void createNodesFromLabel_jq_combiner_wraps_filter_paths_in_first() {
-        // Non-array extractors with jsonpath filter expressions produce a stream in JQ.
-        // Without first(), object construction creates cartesian products (nested objects).
-        // With first(), each field gets a single value.
+    public void createNodesFromLabel_filter_extractors_direct_sources() {
+        // Non-array extractors with jsonpath filter expressions become JQ nodes.
+        // With direct wiring, these extractor nodes are direct sources of the JS function.
         LoadLegacyTests.Extractor ext1 = new LoadLegacyTests.Extractor("count",
                 "$.data[*] ? (@.name == \"target\") .result.\"text()\"", false);
         LoadLegacyTests.Extractor ext2 = new LoadLegacyTests.Extractor("target",
@@ -665,19 +649,13 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label, group.root, group, tracker, new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label, group.root, group, tracker, new HashSet<>(), false);
 
         assertNotNull(entity);
-        assertEquals(1, entity.sources.size());
-        NodeEntity combiner = entity.sources.get(0);
-        assertInstanceOf(JqNode.class, combiner);
-        // Both scalar extractors have filters, so their paths should be wrapped in first()
-        assertTrue(combiner.operation.contains("first("), "filter-chain paths should be wrapped in first()");
-        // Should not contain bare select() outside first()
-        String op = combiner.operation;
-        int firstIdx = op.indexOf("first(");
-        int selectIdx = op.indexOf("select(");
-        assertTrue(selectIdx > firstIdx, "select() should be inside first(), not standalone");
+        assertEquals(2, entity.sources.size(), "should have 2 direct sources");
+        assertTrue(entity.sources.stream().allMatch(s -> s instanceof JqNode), "sources should be JQ nodes");
+        assertTrue(entity.sources.stream().anyMatch(s -> "count".equals(s.name)));
+        assertTrue(entity.sources.stream().anyMatch(s -> "target".equals(s.name)));
     }
 
     @Test @Disabled("not sure why it is failing atm")
@@ -689,7 +667,7 @@ public class LoadLegacyTestsTest {
         NodeGroupEntity group = new NodeGroupEntity();
         LoadLegacyTests.NodeTracking tracker = new LoadLegacyTests.NodeTracking();
 
-        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>());
+        NodeEntity entity = loadLegacyTests.createNodesFromLabel(label1,group.root,group,tracker,new HashSet<>(), false);
 
         assertNotNull(entity);
         assertInstanceOf(JsNode.class,entity,"Should create a JsNode that returns combined values");

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/node/JsNodeTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -267,6 +269,275 @@ public class JsNodeTest {
         JqObject obj = (JqObject)node;
         assertTrue(obj.has("a"),"expected a value: "+obj.toJsonString());
         assertTrue(obj.has("b"),"expected b value: "+obj.toJsonString());
+    }
+
+    // ---- extractParameterString tests ----
+
+    @Test
+    public void extractParameterString_arrow(){
+        assertEquals("a, b, c", JsNode.extractParameterString("(a, b, c) => a + b + c"));
+    }
+
+    @Test
+    public void extractParameterString_arrow_no_parens(){
+        assertEquals("value", JsNode.extractParameterString("value => value.length"));
+    }
+
+    @Test
+    public void extractParameterString_function(){
+        assertEquals("a,b, c , d", JsNode.extractParameterString("function(a,b, c , d){return 42}"));
+    }
+
+    @Test
+    public void extractParameterString_with_comment(){
+        String result = JsNode.extractParameterString("""
+                /** JSDoc comment */
+                (arr, key = "hostname") => { return arr[0][key]; }
+                """);
+        assertNotNull(result);
+        assertTrue(result.contains("arr"));
+        assertTrue(result.contains("key"));
+    }
+
+    @Test
+    public void extractParameterString_null_input(){
+        assertNull(JsNode.extractParameterString(null));
+        assertNull(JsNode.extractParameterString(""));
+        assertNull(JsNode.extractParameterString("   "));
+    }
+
+    // ---- countNonDefaultParams tests ----
+
+    @Test
+    public void countNonDefaultParams_mixed(){
+        assertEquals(1, JsNode.countNonDefaultParams(
+                "(filteredArr, logData = \"time\", stddev = false, usePopulation = false) => { return 1; }"));
+    }
+
+    @Test
+    public void countNonDefaultParams_no_defaults(){
+        assertEquals(3, JsNode.countNonDefaultParams("(a, b, c) => a + b + c"));
+    }
+
+    @Test
+    public void countNonDefaultParams_all_defaults(){
+        assertEquals(0, JsNode.countNonDefaultParams("(x = 1, y = 2) => x + y"));
+    }
+
+    @Test
+    public void countNonDefaultParams_single_no_parens(){
+        assertEquals(1, JsNode.countNonDefaultParams("value => value.length"));
+    }
+
+    @Test
+    public void countNonDefaultParams_empty(){
+        assertEquals(0, JsNode.countNonDefaultParams("() => 42"));
+    }
+
+    @Test
+    public void countNonDefaultParams_six_params_five_defaults(){
+        assertEquals(1, JsNode.countNonDefaultParams(
+                "(nestedArr, nameRegexPattern = \"^Kernel$\", calculateCvPercent = false, index = \"time\", logData = \"time\", usePopulation = false) => { return 1; }"));
+    }
+
+    // ---- getDefaultParameterNames tests ----
+
+    @Test
+    public void getDefaultParameterNames_arrow_with_defaults(){
+        var defaults = JsNode.getDefaultParameterNames(
+                "(filteredArr, logData = \"time\", stddev = false, usePopulation = false) => { return 1; }");
+        assertEquals(3, defaults.size());
+        assertTrue(defaults.contains("logData"));
+        assertTrue(defaults.contains("stddev"));
+        assertTrue(defaults.contains("usePopulation"));
+        assertFalse(defaults.contains("filteredArr"), "non-default param should not be included");
+    }
+
+    @Test
+    public void getDefaultParameterNames_function_with_defaults(){
+        var defaults = JsNode.getDefaultParameterNames(
+                "function(arr, key=\"hostname\") { return arr[0][key]; }");
+        assertEquals(1, defaults.size());
+        assertTrue(defaults.contains("key"));
+        assertFalse(defaults.contains("arr"));
+    }
+
+    @Test
+    public void getDefaultParameterNames_no_defaults(){
+        var defaults = JsNode.getDefaultParameterNames("(a, b, c) => a + b + c");
+        assertTrue(defaults.isEmpty());
+    }
+
+    @Test
+    public void getDefaultParameterNames_all_defaults(){
+        var defaults = JsNode.getDefaultParameterNames("(x = 1, y = 2) => x + y");
+        assertEquals(2, defaults.size());
+        assertTrue(defaults.contains("x"));
+        assertTrue(defaults.contains("y"));
+    }
+
+    @Test
+    public void getDefaultParameterNames_empty_input(){
+        assertTrue(JsNode.getDefaultParameterNames(null).isEmpty());
+        assertTrue(JsNode.getDefaultParameterNames("").isEmpty());
+        assertTrue(JsNode.getDefaultParameterNames("   ").isEmpty());
+    }
+
+    @Test
+    public void getDefaultParameterNames_with_jsdoc_comment(){
+        var defaults = JsNode.getDefaultParameterNames("""
+                /**
+                 * @param {Array} filteredArr
+                 * @param {string} [logData="time"]
+                 */
+                (filteredArr, logData = "time", stddev = false) => { return 1; }
+                """);
+        assertEquals(2, defaults.size());
+        assertTrue(defaults.contains("logData"));
+        assertTrue(defaults.contains("stddev"));
+        assertFalse(defaults.contains("filteredArr"));
+    }
+
+    @Test
+    public void getDefaultParameterNames_single_no_parens(){
+        // single-param arrow without parens has no defaults possible
+        var defaults = JsNode.getDefaultParameterNames("value => value.length");
+        assertTrue(defaults.isEmpty());
+    }
+
+    @Test
+    public void getDefaultParameterNames_nested_array_with_defaults(){
+        var defaults = JsNode.getDefaultParameterNames(
+                "(nestedArr, nameRegexPattern = \"^Kernel$\", calculateCvPercent = false, index = \"time\", logData = \"time\", usePopulation = false) => { return 1; }");
+        assertEquals(5, defaults.size());
+        assertTrue(defaults.contains("nameRegexPattern"));
+        assertTrue(defaults.contains("calculateCvPercent"));
+        assertTrue(defaults.contains("index"));
+        assertTrue(defaults.contains("logData"));
+        assertTrue(defaults.contains("usePopulation"));
+        assertFalse(defaults.contains("nestedArr"));
+    }
+
+    // ---- parse() with default parameters ----
+
+    @Test
+    public void parse_skips_default_params_and_wires_data_source(){
+        // Simulates the boot-time-verbose pattern:
+        // Function has (filteredArr, logData="time", stddev=false, usePopulation=false)
+        // Source node is named "Kernel Post-Timer Duration Average ms"
+        // Only filteredArr is a data source; the rest are JS defaults
+        NodeEntity sourceNode = new JqNode("Kernel Post-Timer Duration Average ms", ".boot_time");
+        Function<String, List<NodeEntity>> lookup = name ->
+                "Kernel Post-Timer Duration Average ms".equals(name) ? List.of(sourceNode) : Collections.emptyList();
+
+        // parse() should fail because "filteredArr" doesn't match any source name
+        JsNode node = JsNode.parse("BOOT2 Avg",
+                "(filteredArr, logData = \"time\", stddev = false, usePopulation = false) => { return filteredArr; }",
+                lookup);
+        // parse returns null when filteredArr can't be resolved, because it's not a default param
+        assertNull(node, "parse should return null when non-default param doesn't match any source");
+    }
+
+    @Test
+    public void parse_skips_default_params_with_ignoreMissing(){
+        // With ignoreMissing=true, parse() creates the node even when filteredArr is missing
+        NodeEntity sourceNode = new JqNode("Kernel Post-Timer Duration Average ms", ".boot_time");
+        Function<String, List<NodeEntity>> lookup = name ->
+                "Kernel Post-Timer Duration Average ms".equals(name) ? List.of(sourceNode) : Collections.emptyList();
+
+        JsNode node = JsNode.parse("BOOT2 Avg",
+                "(filteredArr, logData = \"time\", stddev = false, usePopulation = false) => { return filteredArr; }",
+                lookup, true);
+        assertNotNull(node, "parse with ignoreMissing should succeed");
+        // Node should have 0 sources since filteredArr wasn't found
+        assertEquals(0, node.sources.size(), "no sources should be wired (filteredArr not found)");
+    }
+
+    @Test
+    public void parse_wires_matching_data_param(){
+        // When the non-default parameter name matches a source node name
+        NodeEntity sourceNode = new JqNode("filteredArr", ".boot_time");
+        Function<String, List<NodeEntity>> lookup = name ->
+                "filteredArr".equals(name) ? List.of(sourceNode) : Collections.emptyList();
+
+        JsNode node = JsNode.parse("BOOT2 Avg",
+                "(filteredArr, logData = \"time\", stddev = false) => { return filteredArr; }",
+                lookup);
+        assertNotNull(node, "parse should succeed when data param matches source name");
+        assertEquals(1, node.sources.size(), "one source should be wired");
+        assertEquals("filteredArr", node.sources.get(0).name);
+    }
+
+    // ---- createParameters() with default params ----
+
+    @Test
+    public void createParameters_default_params_single_source_fallback(){
+        // Key scenario: function has (filteredArr, logData="time", stddev=false, usePopulation=false)
+        // but sourceValues has key "Kernel Post-Timer Duration Average ms" (no param name match).
+        // With sourceCount=1, should fall back to passing the single source value as filteredArr.
+        JqValue arrayData = JqValues.parse("[{\"name\":\"Kernel\",\"time\":910670}]");
+        Map<String, ValueEntity> values = Map.of(
+                "Kernel Post-Timer Duration Average ms", new ValueEntity(null, null, arrayData)
+        );
+        List<JqValue> params = JsNode.createParameters(
+                "(filteredArr, logData = \"time\", stddev = false, usePopulation = false) => { return filteredArr; }",
+                values, 1);
+        assertNotNull(params);
+        assertEquals(1, params.size(), "should have 1 parameter (the source value)");
+        assertTrue(params.get(0).isArray(), "parameter should be the array from source");
+        assertEquals(1, params.get(0).length());
+    }
+
+    @Test
+    public void createParameters_default_params_multi_source_fallback(){
+        // When sourceCount > 1 and no param names match, builds an object from all source values
+        JqValue val1 = JqValues.parse("\"hello\"");
+        JqValue val2 = JqValues.parse("42");
+        Map<String, ValueEntity> values = new LinkedHashMap<>();
+        values.put("sourceA", new ValueEntity(null, null, val1));
+        values.put("sourceB", new ValueEntity(null, null, val2));
+
+        List<JqValue> params = JsNode.createParameters(
+                "(data, option = true) => { return data; }",
+                values, 2);
+        assertNotNull(params);
+        assertEquals(1, params.size(), "should have 1 parameter (object of all sources)");
+        assertInstanceOf(JqObject.class, params.get(0));
+        JqObject obj = (JqObject) params.get(0);
+        assertTrue(obj.has("sourceA"));
+        assertTrue(obj.has("sourceB"));
+    }
+
+    @Test
+    public void createParameters_all_params_have_defaults_no_match(){
+        // When ALL params have defaults and none match, should still fallback
+        JqValue data = JqValues.parse("99");
+        Map<String, ValueEntity> values = Map.of("x", new ValueEntity(null, null, data));
+
+        List<JqValue> params = JsNode.createParameters(
+                "(a = 1, b = 2) => a + b",
+                values, 1);
+        assertNotNull(params);
+        // No param name matches "x", but the fallback at the end handles this
+        assertEquals(1, params.size(), "fallback should provide the source value");
+    }
+
+    @Test
+    public void createParameters_matching_param_name_ignores_defaults(){
+        // When the data param name matches a source key, it's used directly;
+        // default params are correctly skipped (no value needed for them)
+        JqValue arrayData = JqValues.parse("[1, 2, 3]");
+        Map<String, ValueEntity> values = Map.of("arr", new ValueEntity(null, null, arrayData));
+
+        List<JqValue> params = JsNode.createParameters(
+                "(arr, usePopulation = false) => { return arr; }",
+                values, 1);
+        assertNotNull(params);
+        // "arr" matches the source key, "usePopulation" has a default — but getParameterNames
+        // returns both ["arr", "usePopulation"]. "arr" matches, "usePopulation" doesn't match
+        // any source key, so it prints a warning but we still get "arr" in the result.
+        assertTrue(params.size() >= 1, "should have at least the arr parameter");
+        assertTrue(params.get(0).isArray(), "first param should be the array");
     }
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -192,7 +192,7 @@ public class NodeServiceTest extends FreshDb {
         jsNode.persist();
         tm.commit();
 
-        Map<String, ValueEntity> combined = Map.of("root",rootValue);
+        Map<Long, ValueEntity> combined = Map.of(rootNode.id,rootValue);
         List<ValueEntity> result = nodeService.calculateJsValues(jsNode, combined,0);
 
         assertNotNull(result);
@@ -219,7 +219,7 @@ public class NodeServiceTest extends FreshDb {
 
         assertEquals(1,jsNode.sources.size(),"jsNode should have a source");
 
-        Map<String, ValueEntity> combined = Map.of("root",rootValue);
+        Map<Long, ValueEntity> combined = Map.of(rootNode.id,rootValue);
         List<ValueEntity> result = nodeService.calculateJsValues(jsNode, combined,0);
 
         assertNotNull(result);
@@ -248,7 +248,7 @@ public class NodeServiceTest extends FreshDb {
         jsNode.persist();
         tm.commit();
 
-        Map<String, ValueEntity> combined = Map.of("root",rootValue);
+        Map<Long, ValueEntity> combined = Map.of(rootNode.id,rootValue);
         List<ValueEntity> result = nodeService.calculateJsValues(jsNode, combined,0);
 
         assertNotNull(result);
@@ -283,8 +283,8 @@ public class NodeServiceTest extends FreshDb {
 
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -312,8 +312,8 @@ public class NodeServiceTest extends FreshDb {
 
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -341,8 +341,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -370,8 +370,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -400,8 +400,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -426,8 +426,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertNotNull(calculated);
@@ -456,8 +456,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put(rootNode.name,v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(rootNode.id,v1);
 
         List<ValueEntity> hit = nodeService.calculateJqValues(hitNode,sourceValueMap,0);
         List<ValueEntity> miss = nodeService.calculateJqValues(missNode,sourceValueMap,0);
@@ -573,8 +573,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put("upload",v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(v1.id,v1);
 
         JqNode node = new JqNode("foo",".foo");
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
@@ -601,8 +601,8 @@ public class NodeServiceTest extends FreshDb {
         v1.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put("upload",v1);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(v1.id,v1);
 
         JqNode node = new JqNode("foo",".foo[]");
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
@@ -634,9 +634,9 @@ public class NodeServiceTest extends FreshDb {
 
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put("v1",v1);
-        sourceValueMap.put("v2",v2);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(v1.id,v1);
+        sourceValueMap.put(v2.id,v2);
 
         List<ValueEntity> calculated = nodeService.calculateJqValues(node,sourceValueMap,0);
         assertEquals(1,calculated.size(),"expect to create a single value from two sources");
@@ -689,13 +689,14 @@ public class NodeServiceTest extends FreshDb {
         upload.persist();
         ValueEntity t1 = new ValueEntity(null,transform1,upload.data.getField("config"));
         t1.persist();
-        ValueEntity t2 = new ValueEntity(null,transform1,upload.data.getField("foo"));
+        ValueEntity t2 = new ValueEntity(null,transform2,upload.data.getField("foo"));
         t2.persist();
-        ValueEntity t3 = new ValueEntity(null,transform1,upload.data.getField("bar"));
+        ValueEntity t3 = new ValueEntity(null,transform3,upload.data.getField("bar"));
         t3.persist();
+        dataset.sources = List.of(transform1, transform2, transform3);
         tm.commit();
 
-        List<ValueEntity> values = nodeService.calculateJsValues(dataset,Map.of("transform1",t1,"transform2",t2,"transform3",t3),0);
+        List<ValueEntity> values = nodeService.calculateJsValues(dataset,Map.of(transform1.id,t1,transform2.id,t2,transform3.id,t3),0);
         assertEquals(3,values.size(),"expect to create a single value from two sources");
         assertNotNull(values.get(0).data,"value[0] data should not be null");
         assertTrue(Stream.of("transform1","transform2","transform3").allMatch(k -> !values.get(0).data.getField(k).isNull()),"missing expected key from values[0]");
@@ -731,13 +732,14 @@ public class NodeServiceTest extends FreshDb {
         upload.persist();
         ValueEntity t1 = new ValueEntity(null,transform1,upload.data.getField("config"));
         t1.persist();
-        ValueEntity t2 = new ValueEntity(null,transform1,upload.data.getField("foo"));
+        ValueEntity t2 = new ValueEntity(null,transform2,upload.data.getField("foo"));
         t2.persist();
-        ValueEntity t3 = new ValueEntity(null,transform1,upload.data.getField("bar"));
+        ValueEntity t3 = new ValueEntity(null,transform3,upload.data.getField("bar"));
         t3.persist();
+        dataset.sources = List.of(transform1, transform2, transform3);
         tm.commit();
 
-        List<ValueEntity> values = nodeService.calculateJqValues(dataset,Map.of("transform1",t1,"transform2",t2,"transform3",t3),0);
+        List<ValueEntity> values = nodeService.calculateJqValues(dataset,Map.of(transform1.id,t1,transform2.id,t2,transform3.id,t3),0);
         assertEquals(1,values.size(),"expect to create a single value from two sources");
         ValueEntity found = values.get(0);
         assertNotNull(found.data,"found data should not be null");
@@ -788,7 +790,7 @@ public class NodeServiceTest extends FreshDb {
 
         // When multiType is Length and source nodes have mismatched value counts,
         // calculateSourceValuePermutations should return null
-        List<Map<String, ValueEntity>> result = nodeService.calculateSourceValuePermutations(combined, rootValue);
+        List<Map<Long, ValueEntity>> result = nodeService.calculateSourceValuePermutations(combined, rootValue);
 
         assertNotNull(result, "Expected not-null when Length multiType has mismatched source value counts:");
     }
@@ -812,9 +814,9 @@ public class NodeServiceTest extends FreshDb {
         v2.persist();
         tm.commit();
 
-        Map<String, ValueEntity> sourceValueMap = new HashMap<>();
-        sourceValueMap.put("v1",v1);
-        sourceValueMap.put("v2",v2);
+        Map<Long, ValueEntity> sourceValueMap = new HashMap<>();
+        sourceValueMap.put(node1.id,v1);
+        sourceValueMap.put(node2.id,v2);
 
         JqNode node = new JqNode("foo",".");
 
@@ -828,6 +830,162 @@ public class NodeServiceTest extends FreshDb {
         assertTrue(read.startsWith("["),"value should be an array: "+read);
         assertTrue(read.endsWith("]"),"value should be an array: "+read);
     }
+
+    // ---- ID-based pipeline: same-name source collision tests ----
+    // These tests verify that the pipeline correctly handles multiple source
+    // nodes with the same name (e.g., extractors from different schema versions).
+    // With the old name-based Map<String, ValueEntity> keying, the second source
+    // would overwrite the first, silently losing data.
+
+    @Test
+    public void calculateSourceValuePermutations_same_name_sources_preserves_all() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        // Two source nodes with the same name but different operations (like
+        // extractors from different schema versions: .system_config.kernel vs .rhivos_config.kernel)
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity sourceA = new JqNode("metric", ".schema_v1.value", rootNode);
+        sourceA.persist();
+        NodeEntity sourceB = new JqNode("metric", ".schema_v2.value", rootNode);
+        sourceB.persist();
+
+        // A combiner node that sources from both same-name nodes
+        JsNode combiner = new JsNode("metric_combined",
+                "obj=>Object.values(obj).find(v => v != null)", List.of(sourceA, sourceB));
+        combiner.persist();
+
+        ValueEntity rootValue = new ValueEntity(null, rootNode, JqValues.parse("""
+                {"schema_v1": {"value": 42}, "schema_v2": {"value": 99}}
+                """));
+        rootValue.persist();
+
+        // Create values for both source nodes (simulating what the pipeline produces)
+        ValueEntity valueA = new ValueEntity(null, sourceA, JqNumber.of(42));
+        valueA.idx = 1;
+        valueA.sources = List.of(rootValue);
+        valueA.persist();
+        ValueEntity valueB = new ValueEntity(null, sourceB, JqNumber.of(99));
+        valueB.idx = 1;
+        valueB.sources = List.of(rootValue);
+        valueB.persist();
+        tm.commit();
+
+        List<Map<Long, ValueEntity>> permutations = nodeService.calculateSourceValuePermutations(combiner, rootValue);
+
+        assertFalse(permutations.isEmpty(), "should have at least one permutation");
+        Map<Long, ValueEntity> first = permutations.getFirst();
+        // With ID-based keying, both sources are preserved
+        assertEquals(2, first.size(), "should have entries for both same-name sources — " +
+                "with name-based keying, the second would overwrite the first, leaving only 1");
+        assertTrue(first.containsKey(sourceA.id), "should contain sourceA by ID");
+        assertTrue(first.containsKey(sourceB.id), "should contain sourceB by ID");
+    }
+
+    @Test
+    public void calculateJsValues_same_name_sources_all_values_accessible() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
+        // A JS function sourced from two nodes with the same name.
+        // Object.values() should see both values, not just the last one.
+        tm.begin();
+        NodeEntity sourceA = new JqNode("data");
+        sourceA.persist();
+        NodeEntity sourceB = new JqNode("data");
+        sourceB.persist();
+
+        // Combiner: picks first non-null from all sources
+        JsNode combiner = new JsNode("result",
+                "obj=>Object.values(obj).filter(v => v != null).length",
+                List.of(sourceA, sourceB));
+        combiner.persist();
+
+        ValueEntity valueA = new ValueEntity(null, sourceA, JqString.of("alpha"));
+        valueA.persist();
+        ValueEntity valueB = new ValueEntity(null, sourceB, JqString.of("beta"));
+        valueB.persist();
+        tm.commit();
+
+        Map<Long, ValueEntity> sourceValues = Map.of(sourceA.id, valueA, sourceB.id, valueB);
+        List<ValueEntity> result = nodeService.calculateJsValues(combiner, sourceValues, 0);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        // The function counts non-null values — should see both (2), not just one
+        assertEquals(2L, result.getFirst().data.asLong(0),
+                "JS function should see both same-name source values — " +
+                "with name-based keying, one would be lost and count would be 1");
+    }
+
+    @Test
+    public void calculateJsValues_multi_extractor_direct_sources() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
+        // Simulates the SUT pattern: a JS function with 5 named extractor sources.
+        // The function accesses properties by extractor name (e.g., value["target"]).
+        // Without the _extract combiner, the JS node sources directly from extractors.
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity targetNode = new JqNode("target", ".config.target", root);
+        targetNode.persist();
+        NodeEntity modeNode = new JqNode("mode", ".config.mode", root);
+        modeNode.persist();
+        NodeEntity buildNode = new JqNode("build", ".config.build", root);
+        buildNode.persist();
+
+        JsNode sutNode = new JsNode("SUT",
+                "value => value[\"target\"] + ' ' + value[\"mode\"] + ' ' + value[\"build\"]",
+                List.of(targetNode, modeNode, buildNode));
+        sutNode.persist();
+
+        ValueEntity targetValue = new ValueEntity(null, targetNode, JqString.of("ebbr"));
+        targetValue.persist();
+        ValueEntity modeValue = new ValueEntity(null, modeNode, JqString.of("package"));
+        modeValue.persist();
+        ValueEntity buildValue = new ValueEntity(null, buildNode, JqString.of("abc123"));
+        buildValue.persist();
+        tm.commit();
+
+        Map<Long, ValueEntity> sourceValues = Map.of(
+                targetNode.id, targetValue,
+                modeNode.id, modeValue,
+                buildNode.id, buildValue);
+        List<ValueEntity> result = nodeService.calculateJsValues(sutNode, sourceValues, 0);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("ebbr package abc123", result.getFirst().data.asString(""),
+                "JS function should access all source values by their node names");
+    }
+
+    @Test
+    public void calculateFpValues_same_name_sources_preserves_all() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException, IOException {
+        // Two fingerprint source nodes with the same name but different data.
+        // With name-based keying, only one would appear in the fingerprint object.
+        tm.begin();
+        NodeEntity sourceA = new JqNode("platform");
+        sourceA.persist();
+        NodeEntity sourceB = new JqNode("platform");
+        sourceB.persist();
+        tm.commit();
+
+        FingerprintNode fpNode = new FingerprintNode("fp", "fp", List.of(sourceA, sourceB));
+
+        ValueEntity valueA = new ValueEntity(null, sourceA, JqString.of("x86"));
+        ValueEntity valueB = new ValueEntity(null, sourceB, JqString.of("arm64"));
+
+        Map<Long, ValueEntity> sourceValues = new HashMap<>();
+        sourceValues.put(sourceA.id, valueA);
+        sourceValues.put(sourceB.id, valueB);
+
+        List<ValueEntity> result = nodeService.calculateFpValues(fpNode, sourceValues, 0);
+
+        assertEquals(1, result.size());
+        JqObject fpObject = (JqObject) result.getFirst().data;
+        // With ID-based keying, the fingerprint builder uses source.name as the
+        // object key. Same-name sources still produce one key (the name), but
+        // the last value wins in the TreeMap sort. The important thing is that
+        // both values were accessible — not silently lost before reaching the builder.
+        assertNotNull(fpObject, "fingerprint should be built from both sources");
+        assertTrue(fpObject.has("platform"), "fingerprint should contain the 'platform' key");
+    }
+
     @Test
     public void findNodeByFqdn_group_name() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
         tm.begin();
@@ -1127,9 +1285,9 @@ public class NodeServiceTest extends FreshDb {
         ValueEntity platformValue = new ValueEntity(null, platformNode, JqString.of("x86"));
         ValueEntity buildTypeValue = new ValueEntity(null, buildTypeNode, JqString.of("release"));
 
-        Map<String, ValueEntity> sourceValues = new HashMap<>();
-        sourceValues.put("platform", platformValue);
-        sourceValues.put("buildType", buildTypeValue);
+        Map<Long, ValueEntity> sourceValues = new HashMap<>();
+        sourceValues.put(platformNode.id, platformValue);
+        sourceValues.put(buildTypeNode.id, buildTypeValue);
 
         List<ValueEntity> result = nodeService.calculateFpValues(fpNode, sourceValues, 0);
 
@@ -1161,9 +1319,9 @@ public class NodeServiceTest extends FreshDb {
         ValueEntity platformValue = new ValueEntity(null, platformNode, JqString.of("x86"));
         ValueEntity buildTypeValue = new ValueEntity(null, buildTypeNode, JqString.of("release"));
 
-        Map<String, ValueEntity> sourceValues = new HashMap<>();
-        sourceValues.put("platform", platformValue);
-        sourceValues.put("buildType", buildTypeValue);
+        Map<Long, ValueEntity> sourceValues = new HashMap<>();
+        sourceValues.put(platformNode.id, platformValue);
+        sourceValues.put(buildTypeNode.id, buildTypeValue);
 
         List<ValueEntity> result = nodeService.calculateFpValues(fpNode, sourceValues, 0);
 
@@ -1222,7 +1380,7 @@ public class NodeServiceTest extends FreshDb {
         tm.commit();
 
         // calculate jq values for both nodes
-        Map<String, ValueEntity> sourceValues = Map.of("upload", rootValue);
+        Map<Long, ValueEntity> sourceValues = Map.of(rootNode.id, rootValue);
         tm.begin();
         List<ValueEntity> qvValues = nodeService.calculateJqValues(quarkusVersionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
         List<ValueEntity> jvValues = nodeService.calculateJqValues(javaVersionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
@@ -1234,9 +1392,9 @@ public class NodeServiceTest extends FreshDb {
         // build fingerprint from those extracted values
         FingerprintNode fpNode = new FingerprintNode("fp", "fp", List.of(javaVersionNode, quarkusVersionNode));
 
-        Map<String, ValueEntity> fpSourceValues = new HashMap<>();
-        fpSourceValues.put("QUARKUS_VERSION", qvValues.getFirst());
-        fpSourceValues.put("JAVA_VERSION", jvValues.getFirst());
+        Map<Long, ValueEntity> fpSourceValues = new HashMap<>();
+        fpSourceValues.put(quarkusVersionNode.id, qvValues.getFirst());
+        fpSourceValues.put(javaVersionNode.id, jvValues.getFirst());
 
         List<ValueEntity> fpResult = nodeService.calculateFpValues(fpNode, fpSourceValues, 0);
 
@@ -1515,14 +1673,14 @@ public class NodeServiceTest extends FreshDb {
             tm.commit();
             allRootValues.add(rootValue);
 
-            Map<String, ValueEntity> sourceValues = Map.of("upload", rootValue);
+            Map<Long, ValueEntity> sourceValues = Map.of(rootNode.id, rootValue);
             tm.begin();
             List<ValueEntity> tpValues = nodeService.calculateJqValues(throughputNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();;
             List<ValueEntity> verValues = nodeService.calculateJqValues(versionNode, sourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();;
             // compute fingerprint values
             if (!verValues.isEmpty()) {
-                Map<String, ValueEntity> fpSourceValues = new HashMap<>();
-                fpSourceValues.put("version", verValues.getFirst());
+                Map<Long, ValueEntity> fpSourceValues = new HashMap<>();
+                fpSourceValues.put(versionNode.id, verValues.getFirst());
                 List<ValueEntity> fpValues = nodeService.calculateFpValues(fpNode, fpSourceValues, 0).stream().map(ValueEntity.getEntityManager()::merge).toList();
             }
             tm.commit();


### PR DESCRIPTION
…ng (issue #191)

Import fixes (LoadLegacyTests):
- Add group.addNode(rtrn) for JS combination function nodes
- Handle JS functions with default parameters via countNonDefaultParams()
- Strip JSDoc/line comments before parsing function signatures
- Skip labels with zero extractors (placeholder/stub labels)
- Return reused extractor directly for identity labels instead of creating solo=>solo wrapper (removes !reusedNode gate)
- Rename single-variant nodes back to original label name after multi-schema dedup (fixes User0→User, UUID0→UUID, etc.)

Verifier fixes (VerifyLegacy):
- Scope h5m values to specific upload via recursive CTE from root value
- Get root values via node_group.root_id join (root nodes have null group_id)
- Match values by node name rather than idx offset
- Add fallback name matching: try with numeric suffix (User→User0), lowercase (User→user), and snake_case (Run ID→run_id)
- Show root value ID in output, skip runs with no h5m upload

Results for boot-time-verbose (5 runs):
  Before: 24.6% match (49/199), 2 labels at 100% After:  66.8% match (133/199), 27 labels at 100%

Remaining failures (35 missing, 31 mismatch) are from:
- Multi-schema data path mismatches (jsonpath for one schema version doesn't match data from another version)
- Stub JS functions returning constants ("Need to collect")
- SUT combination function with incomplete source resolution
- Change detection nodes needing more data points