### PR TITLE
Folder CRUD - Add folder CRUD operations to Dashboard UI

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -29,6 +29,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.WebApplicationException;
 import org.hibernate.query.NativeQuery;
 
 import java.io.IOException;
@@ -72,6 +73,9 @@ public class FolderService implements FolderServiceInterface {
     @Override
     @Transactional
     public long create(String name){
+        if(FolderEntity.find("name",name).firstResult() !=null){
+            throw new WebApplicationException("Folder already exists:" + name, 409);
+        }
         FolderEntity entity = new FolderEntity();
         entity.name = name;
         entity.group = new NodeGroupEntity(name); //TODO do we auto-create a nodeGroup?

--- a/src/main/webui/src/app/components/CreateFolderModal.tsx
+++ b/src/main/webui/src/app/components/CreateFolderModal.tsx
@@ -1,0 +1,80 @@
+import {
+  Button,
+  ComposedModal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from '@carbon/react';
+import { createFolderMutation } from '@client/@tanstack/react-query.gen.ts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { AxiosError } from 'axios';
+
+interface CreateFolderModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export const CreateFolderModal = ({ open, onClose }: CreateFolderModalProps) => {
+  const [folderName, setFolderName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const createFolder = useMutation({
+    ...createFolderMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+      setFolderName('');
+      setError(null);
+      onClose();
+    },
+    onError: (e: AxiosError<Error>) => {
+      if (e.response?.status === 409) {
+        setError('A folder with same name already exists');
+      } else {
+        setError(e.message ?? 'Failed to create folder');
+      }
+    },
+  });
+
+  const handleSave = () => {
+    if (folderName.trim() === '') {
+      setError('Folder name cannot be empty');
+      return;
+    }
+    createFolder.mutate({ path: { name: folderName.trim() } });
+  };
+
+  return (
+    <ComposedModal open={open} onClose={() => { setFolderName(''); setError(null); onClose(); }}>
+      <ModalHeader title="Create Folder" />
+      <ModalBody>
+        <TextInput
+          id="folder-name"
+          labelText="Folder name"
+          placeholder="e.g. benchmarks"
+          value={folderName}
+          onChange={(e) => setFolderName(e.target.value)}
+        />
+        {error && (
+          <p style={{ color: 'var(--cds-support-error)', marginTop: '0.5rem' }}>
+            {error}
+          </p>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={() => { setFolderName(''); setError(null); onClose(); }}>
+          Cancel
+        </Button>
+        <Button
+          kind="primary"
+          onClick={handleSave}
+          disabled={createFolder.isPending}
+        >
+          {createFolder.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};

--- a/src/main/webui/src/app/pages/DashboardPage.css
+++ b/src/main/webui/src/app/pages/DashboardPage.css
@@ -1,0 +1,9 @@
+ .create-folder-btn {
+    border-radius: 2rem !important;
+    background-color: var(--cds-layer) !important;
+  }
+
+  .cds--btn.create-folder-btn:hover {
+     background-color: var(--cds-layer-hover) !important;
+   }
+

--- a/src/main/webui/src/app/pages/DashboardPage.tsx
+++ b/src/main/webui/src/app/pages/DashboardPage.tsx
@@ -1,10 +1,12 @@
 import type { FolderSummary } from '@client/types.gen.ts';
 
 import {
+  Button,
   Column,
   ErrorBoundary,
   Grid,
   InlineLoading,
+  Modal,
   SkeletonText,
   StructuredListBody,
   StructuredListCell,
@@ -14,10 +16,14 @@ import {
   Tag,
   Tile,
 } from '@carbon/react';
-import { getDashboardSummariesOptions } from '@client/@tanstack/react-query.gen.ts';
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { Suspense } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { FolderAdd, TrashCan } from '@carbon/icons-react';
+import { getDashboardSummariesOptions,deleteFolderMutation } from '@client/@tanstack/react-query.gen.ts';
+import { CreateFolderModal } from '@app/components/CreateFolderModal';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useState,Suspense } from 'react';
+import {useNavigate } from 'react-router-dom';
+import '@app/pages/DashboardPage.css';
+import { AxiosError } from 'axios';
 
 function formatDate(date?: string | null): string {
   if (!date) return '—';
@@ -40,10 +46,13 @@ function folderStatus(summary: FolderSummary): { label: string; type: 'green' | 
   return { label: 'No uploads', type: 'gray' };
 }
 
+
+
 const SummaryCards = ({ summaries }: { summaries: FolderSummary[] }) => {
   const totalUploads = summaries.reduce((sum, s) => sum + (s.uploadCount ?? 0), 0);
   const totalChanges = summaries.reduce((sum, s) => sum + (s.changeCount ?? 0), 0);
   const foldersWithChanges = summaries.filter((s) => (s.changeCount ?? 0) > 0).length;
+
 
   return (
     <Grid condensed style={{ marginBottom: 'var(--cds-spacing-05)' }}>
@@ -81,8 +90,27 @@ const SummaryCards = ({ summaries }: { summaries: FolderSummary[] }) => {
 
 const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [confirmFolder, setConfirmFolder] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const deleteFolder = useMutation({
+    ...deleteFolderMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+      setConfirmFolder(null);
+    },
+    onError: (e: AxiosError<Error>) => {
+      if (e.response?.status === 500) {
+              setDeleteError('This folder contains nodes or uploaded data and cannot be deleted. Please remove all nodes and data first.');
+            } else {
+              setDeleteError(e.message ?? 'Failed to delete folder');
+            }
+    },
+  });
 
   return (
+    <>
     <StructuredListWrapper selection>
       <StructuredListHead>
         <StructuredListRow head>
@@ -93,6 +121,7 @@ const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
           <StructuredListCell head>Changes</StructuredListCell>
           <StructuredListCell head>Last Upload</StructuredListCell>
           <StructuredListCell head>Last Change</StructuredListCell>
+          <StructuredListCell head>Actions</StructuredListCell>
         </StructuredListRow>
       </StructuredListHead>
       <StructuredListBody>
@@ -123,29 +152,73 @@ const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
               </StructuredListCell>
               <StructuredListCell>{formatDate(summary.lastUpload as unknown as string)}</StructuredListCell>
               <StructuredListCell>{formatDate(summary.lastChange as unknown as string)}</StructuredListCell>
+              <StructuredListCell>
+                <Button
+                  kind="danger--ghost"
+                  size="sm"
+                  hasIconOnly
+                  renderIcon={TrashCan}
+                  iconDescription="Delete folder"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setConfirmFolder(summary.name ?? '');
+                  }}
+                />
+              </StructuredListCell>
             </StructuredListRow>
           );
         })}
       </StructuredListBody>
     </StructuredListWrapper>
+
+    <Modal
+      open={confirmFolder !== null}
+      danger
+      modalHeading={`Delete "${confirmFolder ?? ''}"`}
+      primaryButtonText="Delete"
+      secondaryButtonText="Cancel"
+      onRequestClose={() => { setConfirmFolder(null); setDeleteError(null); }}
+      onSecondarySubmit={() => { setConfirmFolder(null); setDeleteError(null); }}
+      onRequestSubmit={() => {
+        deleteFolder.mutate({ path: { name: confirmFolder ?? '' } });
+      }}
+    >
+      <p>Are you sure you want to delete this folder? This action cannot be undone.</p>
+      {deleteError && (
+        <p style={{ color: 'var(--cds-support-error)', marginTop: '0.5rem' }}>
+          {deleteError}
+        </p>
+      )}
+    </Modal>
+    </>
   );
 };
 
 const DashboardContent = () => {
   const { data: summaries } = useSuspenseQuery(getDashboardSummariesOptions());
-
-  if (summaries.length === 0) {
-    return (
-      <Tile>
-        <p>No folders configured yet. Create a folder and upload data to get started.</p>
-      </Tile>
-    );
-  }
-
+  const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <SummaryCards summaries={summaries} />
-      <FolderTable summaries={summaries} />
+      <Button
+        kind="primary"
+        size="md"
+        renderIcon={FolderAdd}
+        onClick={() => setIsOpen(true)}
+        className="create-folder-btn"
+        style={{ margin: 'var(--cds-spacing-05)' }}>
+        Create Folder
+      </Button>
+      {summaries.length === 0 ? (
+        <Tile>
+          <p>No folders configured yet. Create a folder and upload data to get started.</p>
+        </Tile>
+      ) : (
+        <>
+          <SummaryCards summaries={summaries} />
+          <FolderTable summaries={summaries} />
+        </>
+      )}
+      <CreateFolderModal open={isOpen} onClose={()=>setIsOpen(false)} />
     </>
   );
 };


### PR DESCRIPTION
Summary:
  - Added a Create Folder button on the Dashboard page that opens a modal allowing users to enter a folder name and save it to the database via POST /api/folder/{name}
  - Added a Delete button on each folder row that prompts for confirmation before calling DELETE /api/folder/{name}
  - Both operations refresh the dashboard table automatically on success without a full page reload
  - Duplicate folder name error is handled with a user-friendly message instead of a raw 500 error
  
To Test:
Enter into dev mode - mvn quarkus:dev - open http://localhost:8080/
  - Create a new folder from the UI and verify it appears in the table and the database
  - Try creating a folder with the same name and verify the friendly error message appears
  - Delete a folder and verify it disappears from the table and the database
  - Verify clicking Cancel on both modals closes them without making any changes