### PR TITLE
Nodes with multi parent now deleted

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -286,8 +286,16 @@ public class NodeService implements NodeServiceInterface {
                     delete(dependent.id);
                 }
             }
+
+            List<ValueEntity> nodeValues = ValueEntity.find("node.id", nodeId).list();
+            for (ValueEntity v : nodeValues) {
+                valueService.delete(v);
+            }
+            EdgeQueries.deleteChildEdges(em, "node_edge", node.id);
             // clean up edge rows where this node is a parent (inverse side not managed by JPA)
             EdgeQueries.deleteParentEdges(em, "node_edge", nodeId);
+            em.flush();
+            em.clear();
             NodeEntity.deleteById(nodeId);
         }
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -95,12 +95,61 @@ public class NodeServiceTest extends FreshDb {
         nodeService.delete(sourceA.id);
         tm.commit();
 
+        // sourceA should be deleted
+        NodeEntity nodeA = NodeEntity.findById(sourceA.id);
+        assertNull(nodeA, "sourceA should be deleted");
         // sharedNode should still exist because sourceB is still a parent
         NodeEntity foundShared = NodeEntity.findById(sharedNode.id);
         assertNotNull(foundShared, "shared node should not be deleted when one source is removed");
         // sourceB should still exist
         NodeEntity foundB = NodeEntity.findById(sourceB.id);
         assertNotNull(foundB, "sourceB should still exist");
+    }
+
+    @Test
+    public void delete_node_that_has_multiple_parents() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity parentA = new JqNode("parentA", ".a");
+        parentA.sources = List.of(rootNode);
+        parentA.persist();
+        NodeEntity parentB = new JqNode("parentB", ".b");
+        parentB.sources = List.of(rootNode);
+        parentB.persist();
+
+        NodeEntity child = new JqNode("child", ".t");
+        child.sources = List.of(parentA, parentB);
+        child.persist();
+        tm.commit();
+
+        tm.begin();
+        nodeService.delete(child.id);
+        tm.commit();
+
+        assertNull(NodeEntity.findById(child.id), "child should be deleted");
+        assertNotNull(NodeEntity.findById(parentA.id), "parentA should still exist");
+        assertNotNull(NodeEntity.findById(parentB.id), "parentB should still exist");
+    }
+
+    @Test
+    public void delete_node_with_associated_values() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {
+        tm.begin();
+        NodeEntity rootNode = new RootNode();
+        rootNode.persist();
+        NodeEntity node = new JqNode("node", ".value");
+        node.sources = List.of(rootNode);
+        node.persist();
+        ValueEntity value = new ValueEntity(null, node, JqNumber.of(42));
+        value.persist();
+        tm.commit();
+
+        tm.begin();
+        nodeService.delete(node.id);
+        tm.commit();
+
+        assertNull(NodeEntity.findById(node.id), "node should be deleted");
+        assertNull(ValueEntity.findById(value.id), "value associated with the node should be deleted");
     }
 
     @Test


### PR DESCRIPTION
Deleting intermediate nodes (JQ, JS, JSONATA, Fingerprint) from multi-source DAG pipelines failed with a 500 FK constraint violation. The root cause was that NodeService.delete() only removed outgoing edges (where the node is a parent), but left incoming edges (where the node is a child of its own sources) intact. When the DB tried to delete the node row, those node_edge.child_id references caused the constraint violation.


  **Changes**

1.   NodeService.delete()

  - Added EdgeQueries.deleteChildEdges() to remove incoming node_edge rows (edges from the node's parents to itself) before deleting the node. This is the primary fix for the FK violation.
  - Added deletion of all ValueEntity rows associated with the node before removing it, since value.node_id is a non-nullable FK. Without this, deleting any node that has accumulated values from prior uploads would fail at the DB level.

2.   NodeServiceTest.delete_does_not_cascade_to_shared_dependent()

  - Added the missing assertion that sourceA is null after deletion. The original test verified that sharedNode and sourceB survived, but never confirmed that sourceA itself was actually removed. 