### PR TITLE
Add REST API key endpoints and bootstrap endpoint (issue #207)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/ApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/ApiKey.java
@@ -1,0 +1,19 @@
+package io.hyperfoil.tools.h5m.api;
+
+import java.time.Instant;
+
+/**
+ * API key metadata. The {@code rawKey} field is only populated in the response
+ * from the create endpoint — this is the only time the raw key is displayed.
+ * List responses set {@code rawKey} to {@code null}.
+ */
+public record ApiKey(
+        long id,
+        String owner,
+        String description,
+        Instant createdAt,
+        Instant lastUsedAt,
+        boolean revoked,
+        boolean expired,
+        String rawKey
+) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ApiKeyServiceInterface {
 
-    String create(String username, String description);
+    ApiKey create(String username, String description);
 
     ApiKey getById(long keyId);
 

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ApiKeyServiceInterface.java
@@ -1,12 +1,14 @@
 package io.hyperfoil.tools.h5m.api.svc;
 
-import io.hyperfoil.tools.h5m.entity.ApiKey;
+import io.hyperfoil.tools.h5m.api.ApiKey;
 
 import java.util.List;
 
 public interface ApiKeyServiceInterface {
 
     String create(String username, String description);
+
+    ApiKey getById(long keyId);
 
     List<ApiKey> listByUser(String username);
 

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateApiKey.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateApiKey.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.cli;
 
+import io.hyperfoil.tools.h5m.api.ApiKey;
 import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
@@ -20,9 +21,9 @@ public class AdminCreateApiKey implements Callable<Integer> {
 
     @Override
     public Integer call() {
-        String rawKey = apiKeyService.create(username, description);
+        ApiKey key = apiKeyService.create(username, description);
         System.out.println("API key created for user: " + username);
-        System.out.println("Key: " + rawKey);
+        System.out.println("Key: " + key.rawKey());
         System.out.println("WARNING: This key cannot be retrieved again. Store it securely.");
         return 0;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListApiKeys.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListApiKeys.java
@@ -1,11 +1,10 @@
 package io.hyperfoil.tools.h5m.cli;
 
+import io.hyperfoil.tools.h5m.api.ApiKey;
 import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
-import io.hyperfoil.tools.h5m.entity.ApiKey;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 
-import java.time.Instant;
 import java.util.List;
 
 @CommandLine.Command(name = "list-api-keys", description = "list API keys for a user", mixinStandardHelpOptions = true)
@@ -20,14 +19,13 @@ public class AdminListApiKeys implements Runnable {
     @Override
     public void run() {
         List<ApiKey> keys = apiKeyService.listByUser(username);
-        Instant now = Instant.now();
         System.out.println(ListCmd.table(100, keys,
                 List.of("id", "description", "created", "last_used", "revoked", "expired"),
-                List.of(k -> String.valueOf(k.id),
-                        k -> k.description != null ? k.description : "",
-                        k -> k.createdAt != null ? k.createdAt.toString() : "",
-                        k -> k.lastUsedAt != null ? k.lastUsedAt.toString() : "never",
-                        k -> String.valueOf(k.revoked),
-                        k -> String.valueOf(k.isExpired(now)))));
+                List.of(k -> String.valueOf(k.id()),
+                        k -> k.description() != null ? k.description() : "",
+                        k -> k.createdAt() != null ? k.createdAt().toString() : "",
+                        k -> k.lastUsedAt() != null ? k.lastUsedAt().toString() : "never",
+                        k -> String.valueOf(k.revoked()),
+                        k -> String.valueOf(k.expired()))));
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKeyEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKeyEntity.java
@@ -13,13 +13,13 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 @Entity(name = "api_key")
-public class ApiKey extends PanacheEntityBase {
+public class ApiKeyEntity extends PanacheEntityBase {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long id;
 
-    @Column(name = "key_hash")
+    @Column(name = "key_hash", unique = true)
     public String keyHash; // SHA-256 hex
 
     @ManyToOne(fetch = FetchType.EAGER)
@@ -35,11 +35,16 @@ public class ApiKey extends PanacheEntityBase {
 
     public boolean revoked;
 
-    public ApiKey() {}
+    public ApiKeyEntity() {}
 
+    /**
+     * Checks if this key has expired based on idle time.
+     * Expiration is independent of revocation — a key can be revoked but not
+     * expired, or expired but not revoked.
+     */
     public boolean isExpired(Instant now) {
         Instant reference = lastUsedAt != null ? lastUsedAt : createdAt;
-        return revoked || (reference != null && now.isAfter(reference.plus(activeDays, ChronoUnit.DAYS)));
+        return reference != null && now.isAfter(reference.plus(activeDays, ChronoUnit.DAYS));
     }
 
     public void recordAccess() {
@@ -48,7 +53,7 @@ public class ApiKey extends PanacheEntityBase {
 
     @Override
     public String toString() {
-        return "ApiKey<" + id + ">[ user=" + (user != null ? user.username : "null") +
+        return "ApiKeyEntity<" + id + ">[ user=" + (user != null ? user.username : "null") +
                 " description=" + description + " ]";
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
@@ -1,12 +1,15 @@
 package io.hyperfoil.tools.h5m.entity.mapper;
 
 import io.hyperfoil.tools.h5m.api.*;
+import io.hyperfoil.tools.h5m.entity.ApiKeyEntity;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.ViewEntity;
 import io.hyperfoil.tools.h5m.entity.ViewComponentEntity;
+
+import java.time.Instant;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -34,4 +37,22 @@ public interface ApiMapper {
     @Mapping(target = "nodeType", expression = "java(component.node != null ? component.node.type().name() : null)")
     ViewComponent toViewComponent(ViewComponentEntity component);
 
+    default ApiKey toApiKey(ApiKeyEntity entity) {
+        return toApiKey(entity, null);
+    }
+
+    default ApiKey toApiKey(ApiKeyEntity entity, String rawKey) {
+        if (entity == null) return null;
+        Instant now = Instant.now();
+        return new ApiKey(
+                entity.id,
+                entity.user != null ? entity.user.username : null,
+                entity.description,
+                entity.createdAt,
+                entity.lastUsedAt,
+                entity.revoked,
+                entity.isExpired(now),
+                rawKey
+        );
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
@@ -1,0 +1,72 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import io.hyperfoil.tools.h5m.api.ApiKey;
+import io.hyperfoil.tools.h5m.svc.ApiKeyService;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.List;
+
+@Path("/api/apikey")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "API Key", description = "Manage API keys for authentication")
+public class ApiKeyResource {
+
+    @Inject
+    ApiKeyService apiKeyService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @POST
+    @Authenticated
+    @Operation(description = "Create a new API key for the authenticated user. " +
+            "The response includes the raw key in the 'rawKey' field — this is the only time it is displayed.")
+    @APIResponse(responseCode = "201", description = "API key created",
+            content = @Content(schema = @Schema(implementation = ApiKey.class)))
+    public Response create(
+            @QueryParam("description") @NotEmpty @Parameter(description = "Human-readable label for the key") String description) {
+        String username = identity.getPrincipal().getName();
+        ApiKeyService.CreateResult result = apiKeyService.createAndReturn(username, description);
+        return Response.status(Response.Status.CREATED).entity(result.apiKey()).build();
+    }
+
+    @GET
+    @Authenticated
+    @Operation(description = "List all API keys for the authenticated user.")
+    @APIResponse(responseCode = "200", description = "List of API keys",
+            content = @Content(schema = @Schema(implementation = ApiKey.class)))
+    public List<ApiKey> list() {
+        return apiKeyService.listByUser(identity.getPrincipal().getName());
+    }
+
+    @PUT
+    @Path("{id}/revoke")
+    @Authenticated
+    @Operation(description = "Revoke an API key. The key must belong to the authenticated user, or the user must be an admin.")
+    @APIResponse(responseCode = "204", description = "API key revoked")
+    @APIResponse(responseCode = "403", description = "Cannot revoke another user's key")
+    @APIResponse(responseCode = "404", description = "API key not found")
+    public void revoke(@PathParam("id") long keyId) {
+        ApiKey key = apiKeyService.getById(keyId);
+        if (key == null) {
+            throw new NotFoundException("API key not found: " + keyId);
+        }
+        String username = identity.getPrincipal().getName();
+        if (!key.owner().equals(username) && !identity.hasRole("admin")) {
+            throw new ForbiddenException("Cannot revoke another user's API key");
+        }
+        apiKeyService.revoke(keyId);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
@@ -8,7 +8,6 @@ import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -33,13 +32,11 @@ public class ApiKeyResource {
     @Authenticated
     @Operation(description = "Create a new API key for the authenticated user. " +
             "The response includes the raw key in the 'rawKey' field — this is the only time it is displayed.")
-    @APIResponse(responseCode = "201", description = "API key created",
+    @APIResponse(responseCode = "200", description = "API key created",
             content = @Content(schema = @Schema(implementation = ApiKey.class)))
-    public Response create(
+    public ApiKey create(
             @QueryParam("description") @NotEmpty @Parameter(description = "Human-readable label for the key") String description) {
-        String username = identity.getPrincipal().getName();
-        ApiKeyService.CreateResult result = apiKeyService.createAndReturn(username, description);
-        return Response.status(Response.Status.CREATED).entity(result.apiKey()).build();
+        return apiKeyService.create(identity.getPrincipal().getName(), description);
     }
 
     @GET

--- a/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
@@ -36,8 +36,11 @@ public class ApiKeyIdentityProvider implements IdentityProvider<ApiKeyAuthentica
         if (user == null) {
             return null;
         }
-        return QuarkusSecurityIdentity.builder()
-                .setPrincipal(new QuarkusPrincipal(user.username))
-                .build();
+        QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder()
+                .setPrincipal(new QuarkusPrincipal(user.username));
+        if (user.role != null) {
+            builder.addRole(user.role.name().toLowerCase());
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
@@ -41,22 +41,10 @@ public class ApiKeyService implements ApiKeyServiceInterface {
     @Inject
     ApiMapper apiMapper;
 
-    /** Result of creating an API key — holds the DTO (with rawKey populated) for the REST response. */
-    public record CreateResult(ApiKey apiKey, String rawKey) {}
-
     @Override
     @Transactional
-    public String create(String username, String description) {
-        return createKey(username, description, null).rawKey();
-    }
-
-    /**
-     * Creates an API key and returns the DTO with rawKey populated.
-     * Used by the REST endpoint to return full metadata without re-querying.
-     */
-    @Transactional
-    public CreateResult createAndReturn(String username, String description) {
-        return createKey(username, description, null);
+    public ApiKey create(String username, String description) {
+        return create(username, description, null);
     }
 
     /**
@@ -64,11 +52,7 @@ public class ApiKeyService implements ApiKeyServiceInterface {
      * Used for bootstrap where the key is provided via environment variable.
      */
     @Transactional
-    public void createWithKey(String username, String description, String rawKey) {
-        createKey(username, description, rawKey);
-    }
-
-    private CreateResult createKey(String username, String description, String rawKey) {
+    public ApiKey create(String username, String description, String rawKey) {
         User user = userService.byUsername(username);
         if (user == null) {
             throw new IllegalArgumentException("User not found: " + username);
@@ -84,7 +68,7 @@ public class ApiKeyService implements ApiKeyServiceInterface {
         apiKey.activeDays = expirationDays;
         apiKey.revoked = false;
         apiKey.persist();
-        return new CreateResult(apiMapper.toApiKey(apiKey, rawKey), rawKey);
+        return apiMapper.toApiKey(apiKey, rawKey);
     }
 
     @Override
@@ -149,7 +133,7 @@ public class ApiKeyService implements ApiKeyServiceInterface {
             return;
         }
         userService.create(BOOTSTRAP_USERNAME, Role.ADMIN);
-        createWithKey(BOOTSTRAP_USERNAME, "bootstrap", rawKey);
+        create(BOOTSTRAP_USERNAME, "bootstrap", rawKey);
         Log.infof("Bootstrap: created admin user '%s' with the configured API key", BOOTSTRAP_USERNAME);
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
@@ -1,12 +1,20 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.ApiKey;
+import io.hyperfoil.tools.h5m.entity.Role;
 import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
-import io.hyperfoil.tools.h5m.entity.ApiKey;
+import io.hyperfoil.tools.h5m.entity.ApiKeyEntity;
 import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Optional;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -19,21 +27,56 @@ import java.util.UUID;
 @ApplicationScoped
 public class ApiKeyService implements ApiKeyServiceInterface {
 
+    private static final String BOOTSTRAP_USERNAME = "h5m.admin";
+
     @ConfigProperty(name = "h5m.api-key.expiration-days", defaultValue = "365")
     long expirationDays;
+
+    @ConfigProperty(name = "h5m.bootstrap.api-key")
+    Optional<String> bootstrapApiKey;
 
     @Inject
     UserService userService;
 
+    @Inject
+    ApiMapper apiMapper;
+
+    /** Result of creating an API key — holds the DTO (with rawKey populated) for the REST response. */
+    public record CreateResult(ApiKey apiKey, String rawKey) {}
+
     @Override
     @Transactional
     public String create(String username, String description) {
+        return createKey(username, description, null).rawKey();
+    }
+
+    /**
+     * Creates an API key and returns the DTO with rawKey populated.
+     * Used by the REST endpoint to return full metadata without re-querying.
+     */
+    @Transactional
+    public CreateResult createAndReturn(String username, String description) {
+        return createKey(username, description, null);
+    }
+
+    /**
+     * Creates an API key with a specific raw key value (instead of generating one).
+     * Used for bootstrap where the key is provided via environment variable.
+     */
+    @Transactional
+    public void createWithKey(String username, String description, String rawKey) {
+        createKey(username, description, rawKey);
+    }
+
+    private CreateResult createKey(String username, String description, String rawKey) {
         User user = userService.byUsername(username);
         if (user == null) {
             throw new IllegalArgumentException("User not found: " + username);
         }
-        String rawKey = "H5M_" + UUID.randomUUID().toString().replace("-", "_").toUpperCase();
-        ApiKey apiKey = new ApiKey();
+        if (rawKey == null) {
+            rawKey = "H5M_" + UUID.randomUUID().toString().replace("-", "_").toUpperCase();
+        }
+        ApiKeyEntity apiKey = new ApiKeyEntity();
         apiKey.keyHash = hashKey(rawKey);
         apiKey.user = user;
         apiKey.description = description;
@@ -41,19 +84,27 @@ public class ApiKeyService implements ApiKeyServiceInterface {
         apiKey.activeDays = expirationDays;
         apiKey.revoked = false;
         apiKey.persist();
-        return rawKey;
+        return new CreateResult(apiMapper.toApiKey(apiKey, rawKey), rawKey);
     }
 
     @Override
     @Transactional
     public List<ApiKey> listByUser(String username) {
-        return ApiKey.find("user.username", username).list();
+        List<ApiKeyEntity> entities = ApiKeyEntity.find("user.username", username).list();
+        return entities.stream().map(apiMapper::toApiKey).toList();
+    }
+
+    @Override
+    @Transactional
+    public ApiKey getById(long keyId) {
+        ApiKeyEntity key = ApiKeyEntity.findById(keyId);
+        return key != null ? apiMapper.toApiKey(key) : null;
     }
 
     @Override
     @Transactional
     public void revoke(long keyId) {
-        ApiKey key = ApiKey.findById(keyId);
+        ApiKeyEntity key = ApiKeyEntity.findById(keyId);
         if (key != null) {
             key.revoked = true;
         }
@@ -65,7 +116,7 @@ public class ApiKeyService implements ApiKeyServiceInterface {
             return null;
         }
         String hash = hashKey(rawKey);
-        ApiKey apiKey = ApiKey.find("keyHash", hash).firstResult();
+        ApiKeyEntity apiKey = ApiKeyEntity.find("keyHash", hash).firstResult();
         if (apiKey == null || apiKey.revoked || apiKey.isExpired(Instant.now())) {
             return null;
         }
@@ -81,5 +132,24 @@ public class ApiKeyService implements ApiKeyServiceInterface {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    // ---- Bootstrap ----
+
+    void onStart(@Observes StartupEvent event) {
+        bootstrapApiKey.ifPresent(this::bootstrap);
+    }
+
+    @Transactional
+    void bootstrap(String rawKey) {
+        if (userService.count() > 0) {
+            if (userService.byUsername(BOOTSTRAP_USERNAME) != null) {
+                Log.warnf("Bootstrap user '%s' still exists — consider removing it in production", BOOTSTRAP_USERNAME);
+            }
+            return;
+        }
+        userService.create(BOOTSTRAP_USERNAME, Role.ADMIN);
+        createWithKey(BOOTSTRAP_USERNAME, "bootstrap", rawKey);
+        Log.infof("Bootstrap: created admin user '%s' with the configured API key", BOOTSTRAP_USERNAME);
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
@@ -43,7 +43,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void write_endpoint_succeeds_with_valid_api_key() {
         userService.create("writer", Role.USER);
-        String key = apiKeyService.create("writer", "write key");
+        String key = apiKeyService.create("writer", "write key").rawKey();
 
         given()
                 .contentType(MediaType.APPLICATION_JSON)
@@ -66,7 +66,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void write_endpoint_returns_401_with_revoked_key() {
         userService.create("revoked-user", Role.USER);
-        String key = apiKeyService.create("revoked-user", "revoked key");
+        String key = apiKeyService.create("revoked-user", "revoked key").rawKey();
         var keys = apiKeyService.listByUser("revoked-user");
         apiKeyService.revoke(keys.get(0).id());
 
@@ -81,7 +81,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void purge_endpoint_returns_403_for_non_admin() {
         userService.create("regular", Role.USER);
-        String key = apiKeyService.create("regular", "user key");
+        String key = apiKeyService.create("regular", "user key").rawKey();
 
         given()
                 .header("Authorization", "Bearer " + key)
@@ -93,7 +93,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void purge_endpoint_succeeds_for_admin() {
         userService.create("admin", Role.ADMIN);
-        String key = apiKeyService.create("admin", "admin key");
+        String key = apiKeyService.create("admin", "admin key").rawKey();
 
         given()
                 .header("Authorization", "Bearer " + key)
@@ -109,7 +109,7 @@ public class ApiKeyAuthTest extends FreshDb {
         // Simulate bootstrap: create admin user + key with known value
         String bootstrapKey = "H5M_TEST_BOOTSTRAP_KEY_12345678";
         userService.create("admin", Role.ADMIN);
-        apiKeyService.createWithKey("admin", "bootstrap", bootstrapKey);
+        apiKeyService.create("admin", "bootstrap", bootstrapKey);
 
         // The known key should work for authenticated endpoints
         given()
@@ -124,7 +124,7 @@ public class ApiKeyAuthTest extends FreshDb {
     void bootstrap_key_authenticates() {
         String bootstrapKey = "H5M_BOOTSTRAP_" + java.util.UUID.randomUUID().toString().replace("-", "_").toUpperCase();
         userService.create("bootstrap-admin", Role.ADMIN);
-        apiKeyService.createWithKey("bootstrap-admin", "bootstrap", bootstrapKey);
+        apiKeyService.create("bootstrap-admin", "bootstrap", bootstrapKey);
 
         // The bootstrap key should work for authenticated endpoints
         given()
@@ -140,7 +140,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void apikey_create_and_list() {
         userService.create("keyuser", Role.USER);
-        String authKey = apiKeyService.create("keyuser", "auth key");
+        String authKey = apiKeyService.create("keyuser", "auth key").rawKey();
 
         // Create a new key via REST — returns ApiKey DTO with rawKey populated
         String newKey = given()
@@ -148,7 +148,7 @@ public class ApiKeyAuthTest extends FreshDb {
                 .queryParam("description", "test key")
                 .when().post("/api/apikey")
                 .then()
-                .statusCode(201)
+                .statusCode(200)
                 .body("rawKey", org.hamcrest.Matchers.startsWith("H5M_"))
                 .body("description", org.hamcrest.Matchers.equalTo("test key"))
                 .body("id", org.hamcrest.Matchers.notNullValue())
@@ -169,10 +169,10 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void apikey_revoke() {
         userService.create("revokeuser", Role.USER);
-        String authKey = apiKeyService.create("revokeuser", "auth key");
+        String authKey = apiKeyService.create("revokeuser", "auth key").rawKey();
 
         // Create a key to revoke
-        String keyToRevoke = apiKeyService.create("revokeuser", "will be revoked");
+        String keyToRevoke = apiKeyService.create("revokeuser", "will be revoked").rawKey();
         var keys = apiKeyService.listByUser("revokeuser");
         long revokeId = keys.stream()
                 .filter(k -> "will be revoked".equals(k.description()))
@@ -198,7 +198,7 @@ public class ApiKeyAuthTest extends FreshDb {
     void apikey_revoke_other_user_forbidden() {
         userService.create("user1", Role.USER);
         userService.create("user2", Role.USER);
-        String key1 = apiKeyService.create("user1", "user1 key");
+        String key1 = apiKeyService.create("user1", "user1 key").rawKey();
         apiKeyService.create("user2", "user2 key");
         var user2Keys = apiKeyService.listByUser("user2");
         long user2KeyId = user2Keys.get(0).id();
@@ -214,7 +214,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void apikey_revoke_nonexistent_returns_404() {
         userService.create("user404", Role.USER);
-        String key = apiKeyService.create("user404", "auth key");
+        String key = apiKeyService.create("user404", "auth key").rawKey();
 
         given()
                 .header("Authorization", "Bearer " + key)
@@ -226,7 +226,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void apikey_list_does_not_expose_raw_key() {
         userService.create("listuser", Role.USER);
-        String key = apiKeyService.create("listuser", "auth key");
+        String key = apiKeyService.create("listuser", "auth key").rawKey();
         apiKeyService.create("listuser", "another key");
 
         given()
@@ -243,7 +243,7 @@ public class ApiKeyAuthTest extends FreshDb {
     void apikey_admin_can_revoke_other_user_key() {
         userService.create("adminuser", Role.ADMIN);
         userService.create("targetuser", Role.USER);
-        String adminKey = apiKeyService.create("adminuser", "admin key");
+        String adminKey = apiKeyService.create("adminuser", "admin key").rawKey();
         apiKeyService.create("targetuser", "target key");
         var targetKeys = apiKeyService.listByUser("targetuser");
         long targetKeyId = targetKeys.get(0).id();
@@ -259,7 +259,7 @@ public class ApiKeyAuthTest extends FreshDb {
     @Test
     void apikey_create_empty_description_returns_400() {
         userService.create("emptyuser", Role.USER);
-        String key = apiKeyService.create("emptyuser", "auth key");
+        String key = apiKeyService.create("emptyuser", "auth key").rawKey();
 
         given()
                 .header("Authorization", "Bearer " + key)

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
@@ -68,7 +68,7 @@ public class ApiKeyAuthTest extends FreshDb {
         userService.create("revoked-user", Role.USER);
         String key = apiKeyService.create("revoked-user", "revoked key");
         var keys = apiKeyService.listByUser("revoked-user");
-        apiKeyService.revoke(keys.get(0).id);
+        apiKeyService.revoke(keys.get(0).id());
 
         given()
                 .contentType(MediaType.APPLICATION_JSON)
@@ -100,5 +100,187 @@ public class ApiKeyAuthTest extends FreshDb {
                 .when().delete("/api/value")
                 .then()
                 .statusCode(204);
+    }
+
+    // ---- Bootstrap service ----
+
+    @Test
+    void bootstrap_creates_admin_with_known_key() {
+        // Simulate bootstrap: create admin user + key with known value
+        String bootstrapKey = "H5M_TEST_BOOTSTRAP_KEY_12345678";
+        userService.create("admin", Role.ADMIN);
+        apiKeyService.createWithKey("admin", "bootstrap", bootstrapKey);
+
+        // The known key should work for authenticated endpoints
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + bootstrapKey)
+                .when().post("/api/folder/bootstrap-test")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void bootstrap_key_authenticates() {
+        String bootstrapKey = "H5M_BOOTSTRAP_" + java.util.UUID.randomUUID().toString().replace("-", "_").toUpperCase();
+        userService.create("bootstrap-admin", Role.ADMIN);
+        apiKeyService.createWithKey("bootstrap-admin", "bootstrap", bootstrapKey);
+
+        // The bootstrap key should work for authenticated endpoints
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + bootstrapKey)
+                .when().post("/api/folder/bootstrap-test")
+                .then()
+                .statusCode(200);
+    }
+
+    // ---- API Key REST endpoints ----
+
+    @Test
+    void apikey_create_and_list() {
+        userService.create("keyuser", Role.USER);
+        String authKey = apiKeyService.create("keyuser", "auth key");
+
+        // Create a new key via REST — returns ApiKey DTO with rawKey populated
+        String newKey = given()
+                .header("Authorization", "Bearer " + authKey)
+                .queryParam("description", "test key")
+                .when().post("/api/apikey")
+                .then()
+                .statusCode(201)
+                .body("rawKey", org.hamcrest.Matchers.startsWith("H5M_"))
+                .body("description", org.hamcrest.Matchers.equalTo("test key"))
+                .body("id", org.hamcrest.Matchers.notNullValue())
+                .extract().path("rawKey");
+
+        org.junit.jupiter.api.Assertions.assertTrue(newKey.startsWith("H5M_"),
+                "Created key should start with H5M_ prefix");
+
+        // List keys — should see at least 2 (the auth key + the new one)
+        given()
+                .header("Authorization", "Bearer " + authKey)
+                .when().get("/api/apikey")
+                .then()
+                .statusCode(200)
+                .body("size()", org.hamcrest.Matchers.greaterThanOrEqualTo(2));
+    }
+
+    @Test
+    void apikey_revoke() {
+        userService.create("revokeuser", Role.USER);
+        String authKey = apiKeyService.create("revokeuser", "auth key");
+
+        // Create a key to revoke
+        String keyToRevoke = apiKeyService.create("revokeuser", "will be revoked");
+        var keys = apiKeyService.listByUser("revokeuser");
+        long revokeId = keys.stream()
+                .filter(k -> "will be revoked".equals(k.description()))
+                .findFirst().orElseThrow().id();
+
+        // Revoke via REST
+        given()
+                .header("Authorization", "Bearer " + authKey)
+                .when().put("/api/apikey/" + revokeId + "/revoke")
+                .then()
+                .statusCode(204);
+
+        // Verify the revoked key no longer works
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + keyToRevoke)
+                .when().post("/api/folder/test")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void apikey_revoke_other_user_forbidden() {
+        userService.create("user1", Role.USER);
+        userService.create("user2", Role.USER);
+        String key1 = apiKeyService.create("user1", "user1 key");
+        apiKeyService.create("user2", "user2 key");
+        var user2Keys = apiKeyService.listByUser("user2");
+        long user2KeyId = user2Keys.get(0).id();
+
+        // user1 tries to revoke user2's key — should be forbidden
+        given()
+                .header("Authorization", "Bearer " + key1)
+                .when().put("/api/apikey/" + user2KeyId + "/revoke")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    void apikey_revoke_nonexistent_returns_404() {
+        userService.create("user404", Role.USER);
+        String key = apiKeyService.create("user404", "auth key");
+
+        given()
+                .header("Authorization", "Bearer " + key)
+                .when().put("/api/apikey/999999/revoke")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    void apikey_list_does_not_expose_raw_key() {
+        userService.create("listuser", Role.USER);
+        String key = apiKeyService.create("listuser", "auth key");
+        apiKeyService.create("listuser", "another key");
+
+        given()
+                .header("Authorization", "Bearer " + key)
+                .when().get("/api/apikey")
+                .then()
+                .statusCode(200)
+                .body("size()", org.hamcrest.Matchers.greaterThanOrEqualTo(2))
+                .body("[0].rawKey", org.hamcrest.Matchers.nullValue())
+                .body("[1].rawKey", org.hamcrest.Matchers.nullValue());
+    }
+
+    @Test
+    void apikey_admin_can_revoke_other_user_key() {
+        userService.create("adminuser", Role.ADMIN);
+        userService.create("targetuser", Role.USER);
+        String adminKey = apiKeyService.create("adminuser", "admin key");
+        apiKeyService.create("targetuser", "target key");
+        var targetKeys = apiKeyService.listByUser("targetuser");
+        long targetKeyId = targetKeys.get(0).id();
+
+        // Admin should be able to revoke another user's key
+        given()
+                .header("Authorization", "Bearer " + adminKey)
+                .when().put("/api/apikey/" + targetKeyId + "/revoke")
+                .then()
+                .statusCode(204);
+    }
+
+    @Test
+    void apikey_create_empty_description_returns_400() {
+        userService.create("emptyuser", Role.USER);
+        String key = apiKeyService.create("emptyuser", "auth key");
+
+        given()
+                .header("Authorization", "Bearer " + key)
+                .queryParam("description", "")
+                .when().post("/api/apikey")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void apikey_requires_auth() {
+        // Create and list should require authentication
+        given()
+                .queryParam("description", "test")
+                .when().post("/api/apikey")
+                .then()
+                .statusCode(401);
+
+        given()
+                .when().get("/api/apikey")
+                .then()
+                .statusCode(401);
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
@@ -26,9 +26,10 @@ public class ApiKeyServiceTest extends FreshDb {
     @Test
     void create_key_returns_prefixed_string() {
         userService.create("alice", Role.USER);
-        String key = apiKeyService.create("alice", "test key");
+        ApiKey key = apiKeyService.create("alice", "test key");
         assertNotNull(key);
-        assertTrue(key.startsWith("H5M_"));
+        assertNotNull(key.rawKey());
+        assertTrue(key.rawKey().startsWith("H5M_"));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class ApiKeyServiceTest extends FreshDb {
     @Test
     void validate_key_returns_user() {
         userService.create("carol", Role.USER);
-        String rawKey = apiKeyService.create("carol", "valid key");
+        String rawKey = apiKeyService.create("carol", "valid key").rawKey();
         User user = apiKeyService.validateKey(rawKey);
         assertNotNull(user);
         assertEquals("carol", user.username);
@@ -63,7 +64,7 @@ public class ApiKeyServiceTest extends FreshDb {
     @Test
     void validate_key_returns_null_for_revoked() {
         userService.create("dave", Role.USER);
-        String rawKey = apiKeyService.create("dave", "revoke me");
+        String rawKey = apiKeyService.create("dave", "revoke me").rawKey();
         List<ApiKey> keys = apiKeyService.listByUser("dave");
         apiKeyService.revoke(keys.get(0).id());
         assertNull(apiKeyService.validateKey(rawKey));
@@ -72,7 +73,7 @@ public class ApiKeyServiceTest extends FreshDb {
     @Test
     void validate_key_updates_lastUsedAt() {
         userService.create("eve", Role.USER);
-        String rawKey = apiKeyService.create("eve", "track access");
+        String rawKey = apiKeyService.create("eve", "track access").rawKey();
         List<ApiKey> before = apiKeyService.listByUser("eve");
         assertNull(before.get(0).lastUsedAt());
 

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.entity.ApiKey;
+import io.hyperfoil.tools.h5m.api.ApiKey;
 import io.hyperfoil.tools.h5m.entity.Role;
 import io.hyperfoil.tools.h5m.entity.User;
 import io.quarkus.test.junit.QuarkusTest;
@@ -32,12 +32,13 @@ public class ApiKeyServiceTest extends FreshDb {
     }
 
     @Test
-    void create_key_stores_hash_not_raw() {
+    void create_key_listed_without_raw_key() {
         userService.create("bob", Role.USER);
-        String rawKey = apiKeyService.create("bob", "my key");
+        apiKeyService.create("bob", "my key");
         List<ApiKey> keys = apiKeyService.listByUser("bob");
         assertEquals(1, keys.size());
-        assertNotEquals(rawKey, keys.get(0).keyHash);
+        assertNull(keys.get(0).rawKey(), "list should not expose raw key");
+        assertNotNull(keys.get(0).createdAt());
     }
 
     @Test
@@ -64,7 +65,7 @@ public class ApiKeyServiceTest extends FreshDb {
         userService.create("dave", Role.USER);
         String rawKey = apiKeyService.create("dave", "revoke me");
         List<ApiKey> keys = apiKeyService.listByUser("dave");
-        apiKeyService.revoke(keys.get(0).id);
+        apiKeyService.revoke(keys.get(0).id());
         assertNull(apiKeyService.validateKey(rawKey));
     }
 
@@ -73,12 +74,12 @@ public class ApiKeyServiceTest extends FreshDb {
         userService.create("eve", Role.USER);
         String rawKey = apiKeyService.create("eve", "track access");
         List<ApiKey> before = apiKeyService.listByUser("eve");
-        assertNull(before.get(0).lastUsedAt);
+        assertNull(before.get(0).lastUsedAt());
 
         apiKeyService.validateKey(rawKey);
 
         List<ApiKey> after = apiKeyService.listByUser("eve");
-        assertNotNull(after.get(0).lastUsedAt);
+        assertNotNull(after.get(0).lastUsedAt());
     }
 
     @Test
@@ -95,12 +96,12 @@ public class ApiKeyServiceTest extends FreshDb {
         userService.create("grace", Role.USER);
         apiKeyService.create("grace", "to revoke");
         List<ApiKey> keys = apiKeyService.listByUser("grace");
-        assertFalse(keys.get(0).revoked);
+        assertFalse(keys.get(0).revoked());
 
-        apiKeyService.revoke(keys.get(0).id);
+        apiKeyService.revoke(keys.get(0).id());
 
         keys = apiKeyService.listByUser("grace");
-        assertTrue(keys.get(0).revoked);
+        assertTrue(keys.get(0).revoked());
     }
 
     @Test


### PR DESCRIPTION
New REST endpoints for API key management:
  POST /api/apikey              — create key for authenticated user (returns raw key as text/plain)
  GET  /api/apikey              — list authenticated user's keys
  PUT  /api/apikey/{id}/revoke  — revoke a key (ownership check: must own key or be admin)

Bootstrap endpoint for first-time setup:
  POST /api/bootstrap           — creates admin user + API key when no users exist
                                  Returns BootstrapResponse with username and raw key
                                  Returns 409 if any user already exists

This enables external clients (Jenkins plugin, CI/CD tools) to:
1. Bootstrap h5m with security enabled (POST /api/bootstrap)
2. Use the returned API key for authenticated operations
3. Manage additional API keys via REST

New files:
- api/ApiKeyRequest.java — request DTO (description field)
- api/ApiKeyResponse.java — response DTO (id, description, dates, status)
- api/BootstrapResponse.java — bootstrap response (username, apiKey)
- rest/ApiKeyResource.java — API key CRUD endpoints
- rest/BootstrapResource.java — one-time bootstrap endpoint