### PR TITLE
fix Work recalculate concurrency with cascade and fix rd work

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/NodeType.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/NodeType.java
@@ -2,29 +2,34 @@ package io.hyperfoil.tools.h5m.api;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 @Schema(description = "The type of transformation a node performs")
 public enum NodeType {
-    EDIVISIVE("ed"),
-    FINGERPRINT("fp"),
-    FIXED_THRESHOLD("ft"),
-    JQ("jq"),
-    JS("js"),
-    JSONATA("nata"),
-    RELATIVE_DIFFERENCE("rd"),
-    ROOT("root"),
-    STDDEV_ANOMALY("sd"),
-    SPLIT("split"),
-    USER_INPUT("user");
+    EDIVISIVE("ed",true),
+    FINGERPRINT("fp",true),
+    FIXED_THRESHOLD("ft",true),
+    JQ("jq",false),
+    JS("js",false),
+    JSONATA("nata",false),
+    RELATIVE_DIFFERENCE("rd",true),
+    ROOT("root",false),
+    STDDEV_ANOMALY("sd",true),
+    SPLIT("split",false),
+    USER_INPUT("user",false);
 
     private final String display;
+    private final boolean analysis;
 
-    NodeType(String display) {
-        this.display = display;
+    NodeType(String display,boolean analysis) {
+        this.display = display;this.analysis = analysis;
     }
 
     public String display() {
         return display;
     }
+    public boolean isAnalysis(){return analysis;}
 
     /**
      * Returns true if this node type is a change detection node.

--- a/src/main/java/io/hyperfoil/tools/h5m/api/ProcessingType.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/ProcessingType.java
@@ -6,8 +6,6 @@ package io.hyperfoil.tools.h5m.api;
 public enum ProcessingType {
     /** An upload of new data being processed through the pipeline */
     UPLOAD,
-    /** A full folder recalculation (all nodes, all root values) */
-    RECALCULATE,
     /** A selective node recalculation (specific node and its dependents) */
     RECALCULATE_NODE
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
@@ -68,15 +68,6 @@ public interface FolderServiceInterface {
     Upload upload(String name, String path, JqValue data);
 
     /**
-     * Recalculates all values in the folder by reprocessing each root value
-     * through the node graph. Returns a status tracker with progress information.
-     *
-     * @param name The name of the folder to recalculate.
-     * @return tracker with progress and completion future
-     */
-    RecalculationTracker recalculate(String name);
-
-    /**
      * Selectively recalculates values for a specific node and its dependents.
      *
      * @param nodeId The ID of the node to recalculate.

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
@@ -75,16 +75,6 @@ public class H5m implements QuarkusApplication {
         }
         return 0;
     }
-    @CommandLine.Command(name="recalculate",description = "recalculate values for all entries in folder")
-    public int recalculate(String folderName){
-        try {
-            folderService.recalculate(folderName);
-        } catch (NoResultException e) {
-            System.err.println("could not find folder "+folderName);
-            return 1;
-        }
-        return 0;
-    }
     @CommandLine.Command(name="upload",description = "")
     public int upload(
             @CommandLine.Parameters(index="0")

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -185,7 +185,7 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
     @Override
     public int hashCode(){
         if(id != null){
-            return Objects.hash(id, name, operation);
+            return Objects.hash(id);//, name, operation);
         }
         // hash source ids one level deep to avoid recursion on deep graphs
         int sourcesHash = 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -15,19 +15,29 @@ import java.util.stream.Collectors;
 //custom post nodegroup actions could have sourceNodes without activeNode
 public class Work implements Runnable, Comparable<Work>{
 
-    public List<Long> sourceValueIds;//IDs of source values — full entities are loaded in WorkService.execute()
+    private List<Long> sourceValueIds;//IDs of source values — full entities are loaded in WorkService.execute()
 
-    public List<NodeEntity> sourceNodes; //what is going to use a list of sources that are not already listed for the activeNode?
+    private List<NodeEntity> sourceNodes; //what is going to use a list of sources that are not already listed for the activeNode?
 
-    public int retryCount;
+    private int retryCount;
 
-    public Set<NodeEntity> activeNodes;
+    private Set<NodeEntity> activeNodes;
 
-    public boolean cumulative = false;
+    /*
+     * If the work should be performed after work for any dependent Nodes regardless of Values
+     */
+    private boolean cumulative = false;
 
-    /** Whether external notifications should be dispatched for detection results.
-     *  Set to false for recalculations and bulk imports. */
-    public boolean dispatch = true;
+    /*
+     * Whether external notifications should be dispatched for detection results.
+     * Set to false for recalculations and bulk imports.
+     */
+    private boolean dispatch = true;
+
+    /*
+     * If the work should queue activeNode child values if it creates new values
+     */
+    private boolean cascade = true;
 
     public Work(){
         retryCount = 0;
@@ -38,8 +48,7 @@ public class Work implements Runnable, Comparable<Work>{
     public Work(Set<NodeEntity> activeNodes,List<NodeEntity> sourceNodes,List<Long> sourceValueIds){
         this();
         this.activeNodes = new HashSet<>(activeNodes); //so that it will be mutable
-        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
-                || node instanceof StdDevAnomaly || node instanceof EDivisive)){
+        if(activeNodes.stream().anyMatch(node -> node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }
         this.sourceValueIds = sourceValueIds == null ? Collections.emptyList() : new ArrayList<>(sourceValueIds);
@@ -52,13 +61,13 @@ public class Work implements Runnable, Comparable<Work>{
 
     public void setActiveNodes(Set<NodeEntity> activeNodes) {
         this.activeNodes = activeNodes;
-        if(activeNodes.stream().anyMatch(node -> node instanceof RelativeDifference
-                || node instanceof StdDevAnomaly || node instanceof EDivisive)){
+        if(activeNodes.stream().anyMatch(node -> node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }else{
             this.cumulative = false;
         }
     }
+    public List<Long> getSourceValueIds(){return sourceValueIds;}
 
     //work A depends on work B if A.activeNode depends on B.activeNode
     public boolean dependsOn(Work work){
@@ -186,4 +195,17 @@ public class Work implements Runnable, Comparable<Work>{
                 " retry="+retryCount+
                 " hashCode="+hashCode()+" >";
     }
+
+    public boolean isCascade() { return cascade; }
+    public void setCascade(boolean cascade) { this.cascade = cascade; }
+
+    public boolean isDispatch() { return dispatch; }
+    public void setDispatch(boolean dispatch) { this.dispatch = dispatch; }
+
+    public boolean isCumulative() { return cumulative; }
+    public void setCumulative(boolean cumulative) { this.cumulative = cumulative; }
+
+
+    public int getRetryCount() { return retryCount; }
+    public void incrementRetryCount(){ this.retryCount++; }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -97,14 +97,6 @@ public class FolderResource {
         return folderService.upload(name, path, data).uploadId;
     }
 
-    @POST
-    @Path("{name}/recalculate")
-    @Authenticated
-    @Operation(description = "Start recalculation of all values in a folder. Returns immediately with a status for progress polling.")
-    public RecalculationStatus recalculate(@PathParam("name") String name) {
-        return folderService.recalculate(name).toStatus();
-    }
-
     @GET
     @Path("/recalculation/{id}")
     @Authenticated

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -247,11 +247,6 @@ public class FolderService implements FolderServiceInterface {
 
 
     @Override
-    public RecalculationTracker recalculate(String name) {
-        return processingService.recalculate(name);
-    }
-
-    @Override
     public RecalculationTracker recalculateNode(long nodeId) {
         return processingService.recalculateNode(nodeId);
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class NodeService implements NodeServiceInterface {
 
+    private static final String ANALYSIS_NODES = "("+Arrays.stream(NodeType.values()).filter(NodeType::isAnalysis).map(t->"'"+t.display()+"'").collect(Collectors.joining(","))+")";
+
     private static final ConcurrentHashMap<String, JqProgram> JQ_CACHE = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, JqProgram> JSONATA_CACHE = new ConcurrentHashMap<>();
 
@@ -253,6 +255,47 @@ public class NodeService implements NodeServiceInterface {
             em.flush();
         }
         return node.id;
+    }
+
+    /**
+     * returns this list of Ephemeral nodes that must be recalculated to be able to recalculate the input node
+     * @param node
+     * @return
+     */
+    @Transactional
+    public Set<NodeEntity> getEphemeralSources(NodeEntity node){
+        Set<NodeEntity> rtrn = new HashSet<>();
+        Set<NodeEntity> seen = new HashSet<>();
+        Queue<NodeEntity> queue = new LinkedList<>(node.sources);
+
+        while(!queue.isEmpty()){
+            NodeEntity n = queue.poll();
+            if (isEphemeral(n) && !seen.contains(n)) {
+                seen.add(n);
+                rtrn.add(n);
+                queue.addAll(n.sources);
+            }
+        }
+        return rtrn;
+    }
+
+    @Transactional
+    public boolean isEphemeral(NodeEntity node){
+        Boolean result = (Boolean) em.createNativeQuery("""
+            select exists(
+                select 1
+                    from node n
+                    where n.id = :node_id and n.type != 'root' and n.type NOT IN ANALYSIS_NODES and (n.ephemeral = 'DISCARD' OR (
+                        n.ephemeral = 'AUTO' and
+                        EXISTS (
+                            select 1
+                            from node_edge ne JOIN node child ON child.id = ne.child_id
+                            where ne.parent_id = n.id AND child.type NOT IN ANALYSIS_NODES
+                        )
+                    ))
+             )
+            """.replaceAll("ANALYSIS_NODES",ANALYSIS_NODES),Boolean.class).setParameter("node_id",node.id).getSingleResult();
+        return result !=null && result;
     }
 
     @Transactional

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
@@ -21,6 +21,7 @@ import jakarta.transaction.Transactional;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 /**
  * Handles pipeline processing lifecycle: recalculation, selective node
@@ -48,6 +49,8 @@ public class ProcessingService {
     WorkService workService;
     @Inject
     RecalculationService recalculationService;
+    @Inject
+    NodeService nodeService;
 
     // --- Recovery ---
 
@@ -68,7 +71,6 @@ public class ProcessingService {
                 for (ProcessingTrackerEntity tracking : incomplete) {
                     switch (tracking.type) {
                         case UPLOAD -> recoverUpload(tracking);
-                        case RECALCULATE -> recoverRecalculate(tracking);
                         case RECALCULATE_NODE -> recoverRecalculateNode(tracking);
                     }
                 }
@@ -104,7 +106,11 @@ public class ProcessingService {
         Log.infof("Re-triggering processing for upload %d in folder %d", tracking.referenceId, tracking.folderId);
         // Use all source nodes (not just top-level) to handle mid-cascade crashes
         List<Work> works = List.copyOf(folder.group.sources).stream()
-                .map(node -> new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id)))
+                .map(node -> {
+                    Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id));
+                    w.setCascade(false);
+                    return w;
+                })
                 .toList();
         if (!works.isEmpty()) {
             CompletableFuture<Void> future = workService.createTracked(works, Set.of(rootValue.id));
@@ -123,18 +129,6 @@ public class ProcessingService {
         } else {
             tracking.completed = true;
         }
-    }
-
-    private void recoverRecalculate(ProcessingTrackerEntity tracking) {
-        FolderEntity folder = findFolderById(tracking.folderId);
-        if (folder == null) {
-            Log.warnf("Folder %d not found for incomplete recalculation, removing tracking record", tracking.folderId);
-            tracking.delete();
-            return;
-        }
-        Log.infof("Re-triggering full recalculation for folder '%s' (id=%d)", folder.name, tracking.folderId);
-        tracking.completed = true;
-        recalculate(folder.name);
     }
 
     private void recoverRecalculateNode(ProcessingTrackerEntity tracking) {
@@ -172,7 +166,7 @@ public class ProcessingService {
         // Create a new tracker for this recovery work — if recovery itself crashes,
         // the new tracker ensures it's re-triggered on next startup.
         ProcessingTrackerEntity recoveryTracker = new ProcessingTrackerEntity(
-                ProcessingType.RECALCULATE, tracking.folderId, -1);
+                ProcessingType.RECALCULATE_NODE, tracking.folderId, tracking.referenceId);
         recoveryTracker.persist();
         tracking.completed = true;
 
@@ -184,7 +178,8 @@ public class ProcessingService {
             rootValueIds.add(rootValue.id);
             for (NodeEntity sourceNode : List.copyOf(folder.group.sources)) {
                 Work w = new Work(sourceNode, new ArrayList<>(sourceNode.sources), List.of(rootValue.id));
-                w.dispatch = false;
+                w.setDispatch(false);
+                w.setCascade(false);
                 works.add(w);
             }
         }
@@ -231,144 +226,105 @@ public class ProcessingService {
     // --- Recalculation ---
 
     /**
-     * Recalculates all values in the folder by reprocessing each root value
-     * through the node graph. Queues top-level nodes for each root value and
-     * relies on cascade in {@code WorkService.execute()} for downstream nodes.
-     *
-     * @param name the folder name to recalculate
-     * @return recalculation status with progress tracking
-     * @throws IllegalStateException if uploads are in progress for this folder
-     */
-    public RecalculationTracker recalculate(String name) {
-        return QuarkusTransaction.requiringNew().call(() -> {
-            FolderEntity folder = findFolderByName(name);
-            List<NodeEntity> topLevelNodes = folder.group.getTopLevelNodes();
-            return doRecalculate(folder, -1, ProcessingType.RECALCULATE, topLevelNodes);
-        });
-    }
-
-    /**
      * Selectively recalculates values for a specific node and its dependents.
-     * Walks up the source chain to find the highest ancestor nodes whose
-     * source data is available (not ephemeral-nullified). Queues Work from
-     * those ancestors — cascade in WorkService.execute() recomputes the
-     * intermediate nodes before reaching the target.
+     * Walks up the source chain to find ephemeral ancestor.
+     * Queues Work from those ancestors along with Work for target node
      *
-     * Use case: user changes a JQ expression or detection config for a node.
+     * Use cases:
+     * * A user adds a new Node to the NodeGroup
+     * * A user changes a Node's operation or sources
      *
      * @param nodeId the node to recalculate
      * @return recalculation status with progress tracking
      * @throws IllegalStateException if uploads are in progress for this folder
      * @throws IllegalArgumentException if the node is not found or has no group
      */
-    public RecalculationTracker recalculateNode(long nodeId) {
+    public RecalculationTracker recalculateNode(long nodeId){
         return QuarkusTransaction.requiringNew().call(() -> {
             NodeEntity targetNode = NodeEntity.findById(nodeId);
-            if (targetNode == null) {
+            if(targetNode == null){
                 throw new IllegalArgumentException("Node not found: " + nodeId);
             }
             if (targetNode.group == null) {
                 throw new IllegalArgumentException("Node " + nodeId + " has no group");
             }
             FolderEntity folder = findFolderByGroupId(targetNode.group.id);
-            List<NodeEntity> allGroupNodes = List.copyOf(folder.group.sources);
-            Set<NodeEntity> startNodes = findRecomputationStartNodes(targetNode, folder.group.root, allGroupNodes);
-            return doRecalculate(folder, nodeId, ProcessingType.RECALCULATE_NODE, startNodes);
-        });
-    }
-
-    /**
-     * Shared recalculation logic for both full-folder and selective-node recalculation.
-     * Rejects if uploads are in progress, builds Work items for each root value × node,
-     * creates a crash-recovery tracker, wires progress callbacks, and schedules
-     * ephemeral data nullification on completion.
-     *
-     * @param folder the folder to recalculate (must be fetched with group, sources, root)
-     * @param nodeId the target node ID, or -1 for full folder recalculation
-     * @param trackingType RECALCULATE or RECALCULATE_NODE
-     * @param nodesToQueue the nodes to create Work items for
-     * @return recalculation status with progress tracking
-     */
-    private RecalculationTracker doRecalculate(FolderEntity folder, long nodeId,
-                                               ProcessingType trackingType,
-                                               Collection<NodeEntity> nodesToQueue) {
-        // Reject if uploads are in progress to avoid conflicting Work items
-        // with different dispatch flags (upload=true vs recalculate=false)
-        long inFlight = ProcessingTrackerEntity.count(
-                "type = ?1 and folderId = ?2 and completed = false", ProcessingType.UPLOAD, folder.id);
-        if (inFlight > 0) {
-            throw new IllegalStateException(
-                    "Cannot recalculate while " + inFlight + " upload(s) are in progress for folder " + folder.name);
-        }
-
-        List<ValueEntity> rootValues = valueService.getValues(folder.group.root);
-        rootValues.forEach(ValueEntity::getPath); // initialize lazy proxies
-
-        if (rootValues.isEmpty()) {
-            return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
-        }
-
-        List<Work> works = new ArrayList<>();
-        Set<Long> rootValueIds = new HashSet<>();
-        for (ValueEntity rootValue : rootValues) {
-            rootValueIds.add(rootValue.id);
-            for (NodeEntity node : nodesToQueue) {
-                Work w = new Work(node, new ArrayList<>(node.sources), List.of(rootValue.id));
-                w.dispatch = false; // suppress external notifications during recalculation
-                works.add(w);
+            List<ValueEntity> rootValues = valueService.getValues(targetNode.group.root);
+            if (rootValues.isEmpty()) {
+                return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
             }
-        }
+            rootValues.forEach(ValueEntity::getPath); // initialize lazy proxies
 
-        if (works.isEmpty()) {
-            return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
-        }
+            Set<Long> rootValueIds = new HashSet<>(rootValues.size());
+            Set<NodeEntity> ephemeralSources = nodeService.getEphemeralSources(targetNode);
+            List<Work> todo = new  ArrayList<>();
 
-        // Track for crash recovery
-        ProcessingTrackerEntity tracking = new ProcessingTrackerEntity(trackingType, folder.id, nodeId);
-        tracking.persist();
-
-        CompletableFuture<Void> future = workService.createTracked(works, rootValueIds);
-
-        // Create status tracker with per-root progress callbacks.
-        // This wiring is safe from races: createTracked() defers work queue insertion
-        // to afterCompletion (transaction commit), so no work has started yet.
-        RecalculationTracker status = recalculationService.create(folder.name, nodeId, rootValues.size(), future);
-        for (Long rootId : rootValueIds) {
-            workService.getTracker(rootId).ifPresent(tracker ->
-                tracker.getFuture().whenComplete((v, t) -> status.incrementCompleted())
-            );
-        }
-
-        // Mark completed and null out ephemeral data after recalculation finishes
-        long trackingId = tracking.id;
-        future.whenComplete((v, t) -> {
-            if (t != null) {
-                Log.errorf(t, "Recalculation failed for folder '%s' (nodeId=%d)", folder.name, nodeId);
-            }
-            // Mark tracker completed even on failure to prevent infinite retry on restart.
-            // On success, also nullify ephemeral data and evict the 2LC.
-            QuarkusTransaction.requiringNew().run(() -> {
-                ProcessingTrackerEntity entity = ProcessingTrackerEntity.findById(trackingId);
-                if (entity != null) {
-                    entity.completed = true;
-                }
-                if (t == null) {
-                    for (ValueEntity rootValue : rootValues) {
-                        int nullified = valueService.nullifyEphemeralData(rootValue.id);
-                        if (nullified > 0) {
-                            Log.debugf("Nullified data for %d ephemeral values (root %d)", nullified, rootValue.id);
-                        }
+            for(ValueEntity rootValue : rootValues){
+                rootValueIds.add(rootValue.id);
+                if(!ephemeralSources.isEmpty()){
+                    for(NodeEntity ephemeralSource : ephemeralSources){
+                        Work ephemeralWork = new Work(ephemeralSource,new ArrayList<>(ephemeralSource.sources),List.of(rootValue.id));
+                        ephemeralWork.setCascade(false);
+                        ephemeralWork.setDispatch(false);
+                        todo.add(ephemeralWork);
                     }
-                    // Evict cached ValueEntity instances since data was nullified via native SQL
-                    em.getEntityManagerFactory().getCache().evict(ValueEntity.class);
                 }
+                Work nodeWork = new Work(targetNode, new ArrayList<>(targetNode.sources), List.of(rootValue.id));
+                nodeWork.setDispatch(false);
+                todo.add(nodeWork);
+            }
+
+            if(todo.isEmpty()){
+                return recalculationService.create(folder.name, nodeId, 0, COMPLETED);
+            }
+
+            // Track for crash recovery
+            ProcessingTrackerEntity tracking = new ProcessingTrackerEntity(ProcessingType.RECALCULATE_NODE, folder.id, nodeId);
+            tracking.persist();
+
+            CompletableFuture<Void> future = workService.createTracked(todo, rootValueIds);
+
+            // Create status tracker with per-root progress callbacks.
+            // This wiring is safe from races: createTracked() defers work queue insertion
+            // to afterCompletion (transaction commit), so no work has started yet.
+            RecalculationTracker status = recalculationService.create(folder.name, nodeId, rootValues.size(), future);
+            for (Long rootId : rootValueIds) {
+                workService.getTracker(rootId).ifPresent(tracker ->
+                        tracker.getFuture().whenComplete((v, t) -> status.incrementCompleted())
+                );
+            }
+
+            // Mark completed and null out ephemeral data after recalculation finishes
+            long trackingId = tracking.id;
+            future.whenComplete((v, t) -> {
+                if (t != null) {
+                    Log.errorf(t, "Recalculation failed for folder '%s' (nodeId=%d)", folder.name, nodeId);
+                }
+                // Mark tracker completed even on failure to prevent infinite retry on restart.
+                // On success, also nullify ephemeral data and evict the 2LC.
+                QuarkusTransaction.requiringNew().run(() -> {
+                    ProcessingTrackerEntity entity = ProcessingTrackerEntity.findById(trackingId);
+                    if (entity != null) {
+                        entity.completed = true;
+                    }
+                    if (t == null) {
+                        for (ValueEntity rootValue : rootValues) {
+                            int nullified = valueService.nullifyEphemeralData(rootValue.id);
+                            if (nullified > 0) {
+                                Log.debugf("Nullified data for %d ephemeral values (root %d)", nullified, rootValue.id);
+                            }
+                        }
+                        // Evict cached ValueEntity instances since data was nullified via native SQL
+                        em.getEntityManagerFactory().getCache().evict(ValueEntity.class);
+                    }
+                });
             });
+            return status;
+
         });
-        return status;
     }
 
     // --- Ephemeral chain walking ---
-
     /**
      * Walks up the source chain from the target node to find the nodes where
      * recomputation should start. Ephemeral nodes (DISCARD, or AUTO with

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -78,11 +78,11 @@ public class WorkService implements WorkServiceInterface {
      * This derives the association from sourceValues rather than duplicating state on Work.
      */
     private List<UploadTracker> findTrackers(Work work) {
-        if (work.sourceValueIds == null || trackers.isEmpty()) {
+        if (work.getSourceValueIds() == null || trackers.isEmpty()) {
             return List.of();
         }
         List<UploadTracker> found = new ArrayList<>();
-        for (Long valueId : work.sourceValueIds) {
+        for (Long valueId : work.getSourceValueIds()) {
             if (valueId != null) {
                 UploadTracker tracker = trackers.get(valueId);
                 if (tracker != null) {
@@ -142,6 +142,7 @@ public class WorkService implements WorkServiceInterface {
             }
             newWorks.add(work);
         }
+
         if (!newWorks.isEmpty()) {
             List<Work> toQueue = List.copyOf(newWorks);
             for (Work work : toQueue) {
@@ -149,7 +150,7 @@ public class WorkService implements WorkServiceInterface {
                 // WorkQueue.sort() → dependsOn() which runs in afterCompletion
                 // outside the session. Without this, dependsOn() would try to
                 // lazily traverse NodeEntity.sources and fail.
-                if (work.activeNodes != null) {
+                if (work.getActiveNodes() != null) {
                     work.dependsOn(work);
                 }
                 // Increment trackers for each work item (before afterCompletion decrement)
@@ -223,6 +224,8 @@ public class WorkService implements WorkServiceInterface {
         return Optional.ofNullable(trackers.get(rootValueId));
     }
 
+    public WorkQueue getQueue(){return workExecutor.getWorkQueue();}
+
     @Override
     public boolean isIdle() {
         return workExecutor.getWorkQueue().isIdle();
@@ -243,7 +246,7 @@ public class WorkService implements WorkServiceInterface {
             // Work only carries value IDs — full entities are loaded here in
             // the transaction that needs them.
             List<ValueEntity> sourceValues = new ArrayList<>();
-            for (Long valueId : w.sourceValueIds) {
+            for (Long valueId : w.getSourceValueIds()) {
                 ValueEntity managed = em.find(ValueEntity.class, valueId);
                 if (managed != null) {
                     Hibernate.initialize(managed.data);
@@ -254,7 +257,7 @@ public class WorkService implements WorkServiceInterface {
             // Reload active nodes in this transaction's persistence context —
             // calculateValues() accesses node.sources which is lazy
             Set<NodeEntity> activeNodes = new HashSet<>();
-            for (NodeEntity an : w.activeNodes) {
+            for (NodeEntity an : w.getActiveNodes()) {
                 NodeEntity managed = em.find(NodeEntity.class, an.id);
                 if (managed != null) {
                     activeNodes.add(managed);
@@ -332,19 +335,22 @@ public class WorkService implements WorkServiceInterface {
                                 .map(v -> v.folder.id)
                                 .findFirst()
                                 .orElse(-1L);
-                        changeDetectedEvent.fire(new ChangeDetectedEvent(folderId, node.getId(), node.name, valueIds, w.dispatch));
+                        changeDetectedEvent.fire(new ChangeDetectedEvent(folderId, node.getId(), node.name, valueIds, w.isDispatch()));
                     }
                     // Cascade work inherits source value IDs and dispatch flag, so
                     // tracker association is derived automatically via findTrackers()
-                    List<Long> sourceValueIds = sourceValues.stream().map(ValueEntity::getId).toList();
-                    List<Work> cascadeWork = nodeService.getDependentNodes(node).stream()
-                            .map(n -> {
-                                Work cascaded = new Work(n, n.sources, sourceValueIds);
-                                cascaded.dispatch = w.dispatch;
-                                return cascaded;
-                            })
-                            .toList();
-                    create(cascadeWork);
+                    if(w.isCascade()) {
+                        List<Long> sourceValueIds = sourceValues.stream().map(ValueEntity::getId).toList();
+                        List<Work> cascadeWork = nodeService.getDependentNodes(node).stream()
+                                .map(n -> {
+                                    Work cascaded = new Work(n, n.sources, sourceValueIds);
+                                    cascaded.setDispatch(w.isDispatch());
+                                    return cascaded;
+                                })
+                                .toList();
+
+                        create(cascadeWork);
+                    }
                 }
             }
 
@@ -358,7 +364,7 @@ public class WorkService implements WorkServiceInterface {
 
             // Defer decrement until after this transaction commits so that
             // isIdle() cannot return true while the DB commit is still in flight.
-            if(w.activeNodes != null && !w.activeNodes.isEmpty()){
+            if(w.getActiveNodes() != null && !w.getActiveNodes().isEmpty()){
                 decrementDeferred = true;
                 tm.getTransaction().registerSynchronization(new Synchronization() {
                     @Override public void beforeCompletion() {}
@@ -370,8 +376,8 @@ public class WorkService implements WorkServiceInterface {
             }
         }catch( Exception e){
             Log.errorf(e, "WorkRunner caught: %s\n work=%s", e.getMessage(), w);
-            w.retryCount++;
-            if(w.retryCount > RETRY_LIMIT){
+            w.incrementRetryCount();
+            if(w.getRetryCount() > RETRY_LIMIT){
                 Log.error("Work exceeded retry limit");
                 // Fail trackers so CompletableFutures complete exceptionally
                 failTrackers(w, e);
@@ -383,7 +389,7 @@ public class WorkService implements WorkServiceInterface {
                 decrementDeferred = true;
             }
         } finally {
-            if(!decrementDeferred && w.activeNodes != null && !w.activeNodes.isEmpty()){
+            if(!decrementDeferred && w.getActiveNodes() != null && !w.getActiveNodes().isEmpty()){
                 workQueue.decrement(w);
                 decrementTrackers(w);
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -50,6 +50,7 @@ quarkus.banner.enabled=false
 # Override with -Dquarkus.datasource.db-kind=postgresql -Dquarkus.datasource.jdbc.url=jdbc:postgresql://host:port/db
 %cli.quarkus.http.host-enabled=false
 %cli.quarkus.datasource.db-kind=sqlite
+%cli.quarkus.log.category."io.quarkiverse.quinoa.deployment.QuinoaProcessor".level=ERROR
 %cli.quarkus.quinoa=false
 
 # CORS for frontend development (dev profile only)

--- a/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/FreshDb.java
@@ -25,7 +25,7 @@ public class FreshDb {
     String dbKind;
 
     @BeforeEach
-    @AfterEach
+    //@AfterEach
     public void dropRows() throws SQLException {
         // Evict 2LC before truncating tables — prevents stale cached entities
         emf.getCache().evictAll();

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/H5mTest.java
@@ -598,42 +598,6 @@ public class H5mTest {
     }
 
     @Test
-    public void recalculate_jq_multi_input(QuarkusMainLauncher launcher) throws IOException {
-        String testName = StackWalker.getInstance()
-                .walk(s -> s.skip(0).findFirst())
-                .get()
-                .getMethodName();
-        Path folder = Files.createTempDirectory("h5m");
-        Path filePath = Files.writeString(Files.createTempFile(folder,"h5m",".json").toAbsolutePath(),
-                """
-                {
-                  "foo":[
-                   { "mem": "1gb", "cpu": 2},
-                   { "mem": "2gb", "cpu": 4}
-                  ]
-                }
-                """
-        );
-        List<LaunchResult> results = run(launcher,
-                new String[]{"add","folder",testName},
-                new String[]{"add","jq","to",testName,"foo",".foo[]"},
-                new String[]{"add","jq","to",testName,"cpu","{foo}:.cpu"},
-                new String[]{"add","jq","to",testName,"mem","{foo}:.mem"},
-                new String[]{"add","jq","to",testName,"fingerprint","{mem,cpu}:."},
-                new String[]{"list",testName,"nodes"},
-                new String[]{"upload",folder.toString(),"to",testName},
-                new String[]{"list","value","from",testName},
-                new String[]{"recalculate",testName},
-                new String[]{"list","value","from",testName}
-
-        );
-        results.forEach(result->{
-            assertEquals(0,result.exitCode(),result.getOutput());
-        });
-        LaunchResult result = results.getLast();
-        assertTrue(result.getOutput().contains("Count: 8"));
-    }
-    @Test
     public void calculate_fixedthreshold_node(QuarkusMainLauncher launcher) throws IOException {
         String testName = StackWalker.getInstance()
                 .walk(s -> s.skip(0).findFirst())

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/WorkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/WorkTest.java
@@ -29,8 +29,8 @@ public class WorkTest {
         Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1.id));
         Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2.id));
 
-        assertEquals(work1.hashCode(),work2.hashCode(),"both work should have the same hash code despite different values");
-        assertEquals(work1,work2,"work1 and work2 should be considered equal despite different source values");
+        assertNotEquals(work1.hashCode(),work2.hashCode(),"both work should not have the same hash code due to different values");
+        assertNotEquals(work1,work2,"work1 and work2 should not be considered equal due to different source values");
     }
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/queue/WorkQueueTest.java
@@ -12,6 +12,7 @@ import io.hyperfoil.tools.h5m.svc.WorkService;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.*;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -28,7 +29,7 @@ public class WorkQueueTest extends FreshDb {
 
     @Inject
     WorkService workService;
-
+    
     @Test
     public void isRoot_true() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         tm.begin();
@@ -103,7 +104,7 @@ public class WorkQueueTest extends FreshDb {
 
 
     @Test
-    public void reject_relativedifference_as_duplicate() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+    public void accept_relativedifference_with_different_sourceValues() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         tm.begin();
         NodeEntity rootNode = new JqNode("root",".root");
         rootNode.persist();
@@ -119,7 +120,7 @@ public class WorkQueueTest extends FreshDb {
         Work work1 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue1.id));
         Work work2 = new Work(relativeDifference,List.of(rootNode),List.of(rootValue2.id));
 
-        assertEquals(work1.hashCode(),work2.hashCode(),"both worth should have the same hashcode despite different values");
+        assertNotEquals(work1.hashCode(),work2.hashCode(),"both work should have different hashCodes");
 
         WorkQueue q = new WorkQueue();
 
@@ -127,7 +128,7 @@ public class WorkQueueTest extends FreshDb {
         assertEquals(1,q.size(),"first work should be added");
         q.addWorks(List.of(work2));
         assertTrue(q.isPending(work2),"work 2 should be pending since it matches work1");
-        assertEquals(1,q.size(),"seconds work should not be added because it should have the same hash");
+        assertEquals(2,q.size(),"seconds work should not be added because it should have the same hash");
         tm.commit();
     }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -198,41 +198,6 @@ public class RestEndpointTest extends FreshDb {
                 .statusCode(204);
     }
 
-    @Test
-    public void folder_recalculate() {
-        createFolder("recalc-test");
-
-        // Start recalculation — should return status with ID and progress fields
-        String id = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .when().post("/api/folder/recalc-test/recalculate")
-                .then()
-                .statusCode(200)
-                .body("id", org.hamcrest.Matchers.notNullValue())
-                .body("folderName", org.hamcrest.Matchers.equalTo("recalc-test"))
-                .body("state", org.hamcrest.Matchers.notNullValue())
-                .body("totalRoots", org.hamcrest.Matchers.notNullValue())
-                .body("completedRoots", org.hamcrest.Matchers.notNullValue())
-                .body("durationMs", org.hamcrest.Matchers.notNullValue())
-                .extract().path("id");
-
-        // Poll recalculation status
-        given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .when().get("/api/folder/recalculation/" + id)
-                .then()
-                .statusCode(200)
-                .body("id", org.hamcrest.Matchers.equalTo(id))
-                .body("state", org.hamcrest.Matchers.notNullValue());
-
-        // Non-existent recalculation should return 404
-        given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .when().get("/api/folder/recalculation/does-not-exist")
-                .then()
-                .statusCode(404);
-    }
-
     // -- Node endpoints --
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.jjq.value.*;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.api.Node;
@@ -36,6 +37,128 @@ public class NodeServiceTest extends FreshDb {
     ValueService valueService;
     @Inject
     EntityManager em;
+
+
+    @Test
+    public void isEphemeral_KEEP() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity node = new JqNode("keep",".keep");
+        node.ephemeral = EphemeralMode.KEEP;
+        node.persist();
+        tm.commit();
+        boolean result =  nodeService.isEphemeral(node);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void isEphemeral_DISCARD() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity node = new JqNode("node",".node");
+        node.ephemeral = EphemeralMode.DISCARD;
+        node.persist();
+        tm.commit();
+        boolean result =  nodeService.isEphemeral(node);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void isEphemeral_AUTO() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity node = new JqNode("node",".node");
+        node.ephemeral = EphemeralMode.AUTO;
+        node.persist();
+        NodeEntity child = new JqNode("child",".child",node);
+        child.ephemeral = EphemeralMode.AUTO;
+        child.persist();
+        tm.commit();
+
+        assertTrue(nodeService.isEphemeral(node),"auto node with child is ephemeral");
+        assertFalse(nodeService.isEphemeral(child),"auto node without child is not ephemeral");
+    }
+    @Test
+    public void isEphemeral_root() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity node = new RootNode();
+        node.persist();
+        NodeEntity child = new JqNode("child",".child",node);
+        child.ephemeral = EphemeralMode.AUTO;
+        child.persist();
+        tm.commit();
+
+        assertFalse(nodeService.isEphemeral(node),"root cannot be ephemeral");
+    }
+    @Test
+    public void isEphemeral_analysis_with_child() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity node = new RelativeDifference("rd","");
+        node.persist();
+        NodeEntity child = new JqNode("child",".child",node);
+        child.persist();
+        tm.commit();
+
+        assertFalse(nodeService.isEphemeral(node),"analysis node cannot be ephemeral");
+    }
+
+    @Test
+    public void getEphemeralSources_root_source() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity a = new JqNode("a",".a",root);
+        a.persist();
+        tm.commit();
+
+        Set<NodeEntity> found =  nodeService.getEphemeralSources(a);
+        assertNotNull(found);
+        assertTrue(found.isEmpty());
+    }
+
+    @Test
+    public void getEphemeralSources_single_source() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity a = new JqNode("a",".a",root);
+        a.persist();
+        NodeEntity b = new JqNode("b",".b",root,a);
+        b.persist();
+        tm.commit();
+
+        assertTrue(nodeService.isEphemeral(a));
+
+        Set<NodeEntity>  found =  nodeService.getEphemeralSources(b);
+        assertNotNull(found);
+        assertEquals(1,found.size());
+        assertTrue(found.contains(a));
+    }
+    @Test
+    public void getEphemeralSources_walk_source_dag() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity group = new JqNode("group",".group",root);
+        group.persist();
+        NodeEntity a = new JqNode("a",".a",group);
+        a.ephemeral=EphemeralMode.KEEP;
+        a.persist();
+        NodeEntity b = new JqNode("b",".b",a);
+        b.persist();
+        NodeEntity c = new JqNode("c",".c",b);
+        c.persist();
+        NodeEntity d = new JqNode("d",".d",c);
+        d.persist();
+        tm.commit();
+
+        Set<NodeEntity>  found =  nodeService.getEphemeralSources(d);
+        assertNotNull(found);
+
+        assertEquals(2,found.size());
+        assertTrue(found.contains(b));
+        assertTrue(found.contains(c));
+    }
+
 
     @Test
     public void create_without_group() {

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.jjq.value.JqValues;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
@@ -24,8 +25,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -127,9 +130,10 @@ public class RecalculateTest extends FreshDb {
         assertEquals("\"hello_done\"", transformValues.get(0).data.toString());
         tm.commit();
 
+        CompletableFuture.allOf(folder.group.getTopLevelNodes().stream().map(n->
+                folderService.recalculateNode(n.id).getFuture()
+                ).toList().toArray(new CompletableFuture[]{})).orTimeout(30, TimeUnit.SECONDS).join();
         // Recalculate and wait for completion
-        folderService.recalculate("recalc-test").getFuture()
-                .orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify values are unchanged (dedup should preserve identical values)
         tm.begin();
@@ -181,8 +185,10 @@ public class RecalculateTest extends FreshDb {
 
         // Recalculate — should suppress notifications
         eventObserver.clear();
-        folderService.recalculate("recalc-notify-test").getFuture()
-                .orTimeout(30, TimeUnit.SECONDS).join();
+        CompletableFuture.allOf(folder.group.getTopLevelNodes().stream().map(n->
+                folderService.recalculateNode(n.id).getFuture()
+        ).toList().toArray(new CompletableFuture[]{})).orTimeout(30, TimeUnit.SECONDS).join();
+
 
         List<ChangeDetectedEvent> recalcEvents = eventObserver.getEvents();
         boolean hasNonDispatchedEvent = recalcEvents.stream().anyMatch(e -> !e.dispatch());
@@ -254,12 +260,15 @@ public class RecalculateTest extends FreshDb {
     public void recalculate_returns_completable_future() throws Exception {
         // Verify that recalculate returns a future we can wait on
         tm.begin();
-        folderService.create("future-test");
+        long id = folderService.create("future-test");
+        FolderEntity folder = folderService.read(id);
         tm.commit();
 
         // Recalculate empty folder — should complete immediately
-        folderService.recalculate("future-test").getFuture()
-                .orTimeout(10, TimeUnit.SECONDS).join();
+        CompletableFuture.allOf(folder.group.getTopLevelNodes().stream().map(n->
+                folderService.recalculateNode(n.id).getFuture()
+        ).toList().toArray(new CompletableFuture[]{})).orTimeout(30, TimeUnit.SECONDS).join();
+
         // No exception = success
     }
 
@@ -313,8 +322,10 @@ public class RecalculateTest extends FreshDb {
                 "Each upload with y > 50 should produce a change detection");
 
         // Recalculate
-        folderService.recalculate("multi-recalc-test").getFuture()
-                .orTimeout(30, TimeUnit.SECONDS).join();
+        CompletableFuture.allOf(folder.group.getTopLevelNodes().stream().map(n->
+                folderService.recalculateNode(n.id).getFuture()
+        ).toList().toArray(new CompletableFuture[]{})).orTimeout(30, TimeUnit.SECONDS).join();
+
 
         // Verify change detection count is the same after recalculation
         tm.begin();
@@ -327,7 +338,7 @@ public class RecalculateTest extends FreshDb {
     }
 
     @Test
-    public void recalculate_after_node_update_uses_new_operation() throws Exception {
+    public void recalculateNode_after_node_update_uses_new_operation() throws Exception {
         // When a node's operation changes, recalculateNode should produce
         // values reflecting the new operation, not the old one.
         tm.begin();
@@ -378,7 +389,7 @@ public class RecalculateTest extends FreshDb {
     }
 
     @Test
-    public void recalculate_tracks_progress() throws Exception {
+    public void recalculateNode_tracks_progress() throws Exception {
         // Upload multiple values, then recalculate and verify progress tracking
         tm.begin();
         long folderId = folderService.create("progress-test");
@@ -399,12 +410,12 @@ public class RecalculateTest extends FreshDb {
         }
 
         // Start recalculation — returns tracker immediately
-        RecalculationTracker tracker = folderService.recalculate("progress-test");
+        RecalculationTracker tracker = folderService.recalculateNode(extract.id);
 
         assertNotNull(tracker, "Should return a recalculation tracker");
         assertNotNull(tracker.getId(), "Tracker should have an ID");
         assertEquals("progress-test", tracker.getFolderName());
-        assertEquals(-1, tracker.getNodeId(), "Full recalculate should have nodeId=-1");
+        assertEquals(extract.id, tracker.getNodeId(), "Full recalculate should have nodeId=-1");
 
         // Snapshot before completion
         RecalculationStatus before = tracker.toStatus();
@@ -482,7 +493,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Recalculate
-        folderService.recalculate("split-recalc-test").getFuture()
+        folderService.recalculateNode(valueNodeId).getFuture()
                 .orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify values are preserved — same count, same data
@@ -558,7 +569,7 @@ public class RecalculateTest extends FreshDb {
         // Recalculate — this must work even though extract.data is NULL.
         // The pipeline should re-extract from root.data → recompute extract → 
         // recompute transform → nullify extract again.
-        folderService.recalculate("ephemeral-recalc-test").getFuture()
+        folderService.recalculateNode(transformId).getFuture()
                 .orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: transform data should still be correct after recalculation
@@ -874,16 +885,16 @@ public class RecalculateTest extends FreshDb {
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Recalculate and wait
-        folderService.recalculate("tracking-test").getFuture()
+        folderService.recalculateNode(extract.id).getFuture()
                 .orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify tracking entity exists and is completed
         tm.begin();
         ProcessingTrackerEntity tracker = ProcessingTrackerEntity.find(
-                "type = ?1 and folderId = ?2", ProcessingType.RECALCULATE, folderId).firstResult();
+                "type = ?1 and folderId = ?2", ProcessingType.RECALCULATE_NODE, folderId).firstResult();
         assertNotNull(tracker, "Recalculation should create a tracking entity");
         assertTrue(tracker.completed, "Tracking entity should be marked completed");
-        assertEquals(-1, tracker.referenceId, "Full recalculate should have referenceId=-1");
+        assertEquals(extract.id, tracker.referenceId, "Full recalculate should have referenceId=-1");
         tm.commit();
     }
 
@@ -910,7 +921,7 @@ public class RecalculateTest extends FreshDb {
         // Simulate crash: create incomplete recalculation tracker
         tm.begin();
         ProcessingTrackerEntity tracker = new ProcessingTrackerEntity(
-                ProcessingType.RECALCULATE, folderId, -1);
+                ProcessingType.RECALCULATE_NODE, folderId, extractId);
         tracker.persist();
         long trackerId = tracker.id;
         tm.commit();
@@ -1230,21 +1241,6 @@ public class RecalculateTest extends FreshDb {
     }
 
     @Test
-    public void recalculate_rejects_when_upload_in_progress() throws Exception {
-        tm.begin();
-        long folderId = folderService.create("upload-guard-test");
-        // Simulate in-flight upload
-        ProcessingTrackerEntity inFlight = new ProcessingTrackerEntity(
-                ProcessingType.UPLOAD, folderId, 1L);
-        inFlight.persist();
-        tm.commit();
-
-        assertThrows(IllegalStateException.class,
-                () -> folderService.recalculate("upload-guard-test"),
-                "Should reject recalculation when uploads are in progress");
-    }
-
-    @Test
     public void findRecomputationStartNodes_diamond_dag() throws Exception {
         // Diamond: root → A[DISCARD] → C[KEEP]
         //          root → B[KEEP]    → C[KEEP]
@@ -1295,7 +1291,7 @@ public class RecalculateTest extends FreshDb {
     public void recovery_with_deleted_folder_cleans_up_tracker() throws Exception {
         tm.begin();
         ProcessingTrackerEntity tracker = new ProcessingTrackerEntity(
-                ProcessingType.RECALCULATE, 999999L, -1);
+                ProcessingType.RECALCULATE_NODE, 999999L, -1);
         tracker.persist();
         long trackerId = tracker.id;
         tm.commit();

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateWorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateWorkQueueTest.java
@@ -1,0 +1,455 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.api.EphemeralMode;
+import io.hyperfoil.tools.h5m.api.Upload;
+import io.hyperfoil.tools.h5m.api.Value;
+import io.hyperfoil.tools.h5m.entity.FolderEntity;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.hyperfoil.tools.h5m.entity.work.Work;
+import io.hyperfoil.tools.jjq.value.JqValues;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.transaction.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestProfile(WorkServiceTest.NoWorkers.class)
+public class RecalculateWorkQueueTest {
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    WorkService workService;
+
+    @Inject
+    FolderService folderService;
+    @Inject
+    NodeService nodeService;
+    @Inject
+    ValueService valueService;
+
+    private String printQueue(){
+        return workService.getQueue().stream().toList().stream().map(Object::toString).collect(Collectors.joining("\n"));
+    }
+
+    @Test
+    public void recalculateNode_before_first_upload_node() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        tm.begin();
+        long folderId = folderService.create(testName);
+        FolderEntity folder = folderService.read(folderId);
+
+        assertNotNull(folder);
+
+        NodeEntity a = new JqNode("a",".a",folder.group.root);
+        a.group=folder.group;
+        a.persist();
+        NodeEntity b = new JqNode("b",".",a);
+        b.group=folder.group;
+        b.persist();
+        tm.commit();
+
+        Upload uploaded = folderService.upload(testName,"",JqValues.parse(
+                """
+                { "a" : 1  }
+                """
+        ));
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload\n"+printQueue());
+
+        tm.begin();
+        NodeEntity found = nodeService.read(a.id);
+        found.operation = ".a + 1";
+        found.persist();
+        tm.commit();
+
+        RecalculationTracker aTracker = folderService.recalculateNode(found.id);
+
+        //TODO should aTracker be done because it doesn't queue any work or should it be one when upload is done?
+        assertFalse(aTracker.getFuture().isDone());
+        assertFalse(aTracker.getFuture().isCancelled());
+        assertFalse(uploaded.future.isDone());
+        assertFalse(uploaded.future.isCancelled());
+
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload\n"+printQueue());
+
+        Runnable todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        if(todo instanceof Work w){
+            assertTrue(w.isDispatch(),"work should be dispatch due to upload");
+        }else{
+            fail("runnable should be instance of Work");
+        }
+
+        workService.execute((Work)todo);
+
+        assertFalse(aTracker.getFuture().isDone());
+        assertFalse(aTracker.getFuture().isCancelled());
+        assertFalse(uploaded.future.isDone());
+        assertFalse(uploaded.future.isCancelled());
+
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a\n"+printQueue());
+        //check the value before it is removed by ephemeral
+        List<Value> aValues = valueService.getNodeValues(a.id);
+        assertEquals(1,aValues.size(),"a create 1 value:"+aValues);
+        Value aValue = aValues.getFirst();
+        assertNotNull(aValue);
+        assertEquals(JqValues.parse("2"),aValue.data(),"value should reflect change to node that occurred while queued");
+
+
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        if(todo instanceof Work w){
+            assertTrue(w.isDispatch(),"work should be dispatch due to upload");
+        }else{
+            fail("runnable should be instance of Work");
+        }
+        workService.execute((Work)todo);
+        assertEquals(0,workService.getQueue().size(),"the queue should be empty");
+
+        assertTrue(aTracker.getFuture().isDone());
+        assertFalse(aTracker.getFuture().isCancelled());
+        assertTrue(uploaded.future.isDone());
+        assertFalse(uploaded.future.isCancelled());
+
+
+        List<Value> bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        Value bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("2"),bValue.data(),"value should reflect change to node that occurred while queued");
+
+    }
+
+    @Test
+    //@Disabled("java.lang.IllegalStateException: Cannot recalculate while 1 upload(s) are in progress for folder recalculate_during_upload_uses_new_operation")
+    public void recalculateNode_pending_node_during_upload() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        tm.begin();
+        long folderId = folderService.create(testName);
+        FolderEntity folder = folderService.read(folderId);
+
+        assertNotNull(folder);
+
+        NodeEntity a = new JqNode("a",".a",folder.group.root);
+        a.group=folder.group;
+        a.ephemeral=EphemeralMode.KEEP;
+        a.persist();
+        NodeEntity b = new JqNode("b",".",a);
+        b.group=folder.group;
+        b.persist();
+        tm.commit();
+
+        Upload uploaded = folderService.upload(testName,"",JqValues.parse(
+            """
+            { "a" : 1  }
+            """
+        ));
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload");
+        Runnable todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a");
+
+        tm.begin();
+        NodeEntity found = nodeService.read(b.id);
+        found.operation = ". + 1";
+        found.persist();
+        tm.commit();
+
+        RecalculationTracker bTracker = folderService.recalculateNode(found.id);
+        //the changed node is already in the work queue and should not cause a new work to be queued
+        assertEquals(1,workService.getQueue().size());
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        if(todo instanceof Work w){
+            assertTrue(w.isDispatch(),"work should be dispatch because of upload");
+        }else{
+            fail("the runnable should be an instance of Work");
+        }
+        workService.execute((Work)todo);
+        assertEquals(0,workService.getQueue().size(),"the queue should be empty\n"+printQueue());
+
+        List<Value> bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        Value bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("2"),bValue.data(),"value should reflect change to node that occurred while queued");
+    }
+    @Test
+    //@Disabled("java.lang.IllegalStateException: Cannot recalculate while 1 upload(s) are in progress for folder recalculate_during_upload_uses_new_operation")
+    public void recalculateNode_active_node_during_upload() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        tm.begin();
+        long folderId = folderService.create(testName);
+        FolderEntity folder = folderService.read(folderId);
+
+        assertNotNull(folder);
+
+        NodeEntity a = new JqNode("a",".a",folder.group.root);
+        a.group=folder.group;
+        a.ephemeral= EphemeralMode.KEEP;
+        a.persist();
+        NodeEntity b = new JqNode("b",".",a);
+        b.group=folder.group;
+        b.persist();
+        tm.commit();
+
+        Upload uploaded = folderService.upload(testName,"",JqValues.parse(
+                """
+                { "a" : 1  }
+                """
+        ));
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload");
+        Runnable todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a");
+
+        todo = workService.getQueue().poll();
+        assertEquals(0,workService.getQueue().size(),"the queue should be empty");
+        assertNotNull(todo);
+
+        assertEquals(0,workService.getQueue().size());
+
+        tm.begin();
+        NodeEntity found = nodeService.read(b.id);
+        found.operation = ". + 1";
+        found.persist();
+        tm.commit();
+
+        folderService.recalculateNode(found.id);
+
+        assertEquals(0,workService.getQueue().size());
+        //the changed node is already in the work queue and should not cause a new work to be queued
+        if(todo instanceof Work w){
+            assertTrue(w.isDispatch(),"work should be dispatch because of upload");
+        }else{
+            fail("the runnable should be an instance of Work");
+        }
+        workService.execute((Work)todo);
+        assertEquals(0,workService.getQueue().size(),"the queue should be empty");
+
+        List<Value> bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        Value bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("2"),bValue.data(),"value should reflect change to node that occurred while queued");
+    }
+
+    @Test
+    //@Disabled("java.lang.IllegalStateException: Cannot recalculate while 1 upload(s) are in progress for folder recalculate_during_upload_uses_new_operation")
+    public void recalculateNode_ancestor_of_active_upload_node() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        tm.begin();
+        long folderId = folderService.create(testName);
+        FolderEntity folder = folderService.read(folderId);
+
+        assertNotNull(folder);
+
+        NodeEntity a = new JqNode("a",".a",folder.group.root);
+        a.group=folder.group;
+        a.persist();
+        NodeEntity b = new JqNode("b",".",a);
+        b.group=folder.group;
+        b.persist();
+        tm.commit();
+
+        Upload uploaded = folderService.upload(testName,"",JqValues.parse(
+                """
+                { "a" : 1  }
+                """
+        ));
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload");
+        Runnable todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a");
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        assertEquals(0,workService.getQueue().size(),"queue should be empty");
+
+        tm.begin();
+        NodeEntity found = nodeService.read(a.id);
+        found.operation = ".a + 1";
+        found.persist();
+        tm.commit();
+
+        folderService.recalculateNode(found.id);
+        assertEquals(1,workService.getQueue().size(),"a should be queued");
+        Runnable pending =  workService.getQueue().peek();
+        assertNotNull(pending);
+        if(pending instanceof Work w){
+            assertNotNull(w.getActiveNodes());
+            assertTrue(w.getActiveNodes().stream().anyMatch(n->n.name.equals(a.name)),"a should be pending");
+        }else{
+            fail("pending runnable should have been an instance of Work");
+        }
+
+        workService.execute((Work)todo);
+        assertEquals(1,workService.getQueue().size(),"finishing b should not queue more work");
+
+        List<Value> bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        Value bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("1"),bValue.data(),"value should use previous value from a");
+
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a");
+
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+        assertEquals(0,workService.getQueue().size(),"queue should be empty");
+
+
+        bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("2"),bValue.data(),"value should reflect change to node that occurred while queued");
+
+    }
+
+    @Test
+    public void recalculateNode_ancestor_of_pending_recalculate_node() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        String testName = StackWalker.getInstance()
+                .walk(s -> s.skip(0).findFirst())
+                .get()
+                .getMethodName();
+        tm.begin();
+        long folderId = folderService.create(testName);
+        FolderEntity folder = folderService.read(folderId);
+
+        assertNotNull(folder);
+
+        NodeEntity a = new JqNode("a",".a",folder.group.root);
+        a.group=folder.group;
+        a.persist();
+        NodeEntity b = new JqNode("b",".",a);
+        b.group=folder.group;
+        b.persist();
+        tm.commit();
+
+        assertTrue(nodeService.isEphemeral(a),"a should be ephemeral");
+
+        Upload uploaded = folderService.upload(testName,"",JqValues.parse(
+                """
+                { "a" : 1  }
+                """
+        ));
+        assertEquals(1,workService.getQueue().size(),"only a should be queued by upload");
+        Runnable todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+        assertEquals(1,workService.getQueue().size(),"b should be queued by a");
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+        assertEquals(0,workService.getQueue().size(),"queue should be empty");
+
+        tm.begin();
+        NodeEntity found = nodeService.read(b.id);
+        found.operation = ". + 1";
+        found.persist();
+        tm.commit();
+
+        assertTrue(uploaded.future.isDone(),"upload should be complete");
+
+        RecalculationTracker bTracker = folderService.recalculateNode(found.id);
+
+        assertEquals(2,workService.getQueue().size(),"queue should have a and b because a is ephemeral:\n"+printQueue());
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        if(todo instanceof Work w){
+            assertFalse(w.isCascade(),"a should not cascade");
+        }else{
+            fail("runnable should be a work instance");
+        }
+        workService.execute((Work)todo);
+        assertEquals(1,workService.getQueue().size(),"b should be queued");
+
+        tm.begin();
+        found = nodeService.read(a.id);
+        found.operation = ".a + 1";
+        found.persist();
+        tm.commit();
+
+        RecalculationTracker aTracker = folderService.recalculateNode(found.id);
+
+        assertFalse(bTracker.getFuture().isDone());
+        assertFalse(bTracker.getFuture().isCancelled());
+
+        assertEquals(2,workService.getQueue().size(),"queue should have a and b:\n"+printQueue());
+
+        todo = workService.getQueue().poll();
+        if(todo instanceof Work w){
+            assertNotNull(w.getActiveNodes());
+            assertTrue(w.getActiveNodes().stream().anyMatch(n->n.name.equals(a.name)),"a should be selected: "+w.getActiveNodes());
+        }else{
+            fail("pending runnable should have been an instance of Work");
+        }
+        workService.execute((Work)todo);
+
+        List<Value> aValues = valueService.getNodeValues(a.id);
+        assertEquals(1,aValues.size(),"a create 1 value:"+aValues);
+        Value aValue = aValues.getFirst();
+        assertNotNull(aValue);
+        assertEquals(JqValues.parse("2"),aValue.data(),"value should reflect change to node that occurred while queued");
+
+        assertEquals(1,workService.getQueue().size(),"b should be queued\n"+printQueue());
+
+        assertFalse(aTracker.getFuture().isDone());
+        assertFalse(bTracker.getFuture().isDone());
+
+        todo = workService.getQueue().poll();
+        assertNotNull(todo);
+        assertInstanceOf(Work.class, todo);
+        workService.execute((Work)todo);
+
+        assertEquals(0,workService.getQueue().size(),"queue should be empty");
+
+        assertTrue(aTracker.getFuture().isDone());
+        assertTrue(bTracker.getFuture().isDone());
+
+
+        List<Value> bValues = valueService.getNodeValues(b.id);
+        assertEquals(1,bValues.size(),"b create 1 value:"+bValues);
+        Value bValue = bValues.getFirst();
+        assertNotNull(bValue);
+        assertEquals(JqValues.parse("3"),bValue.data(),"value should reflect change to node that occurred while queued");
+    }
+
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/WorkServiceTest.java
@@ -1,0 +1,64 @@
+package io.hyperfoil.tools.h5m.svc;
+
+import io.hyperfoil.tools.h5m.FreshDb;
+import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.ValueEntity;
+import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.hyperfoil.tools.h5m.entity.work.Work;
+import io.hyperfoil.tools.jjq.value.JqValues;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.transaction.*;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestProfile(WorkServiceTest.NoWorkers.class)
+public class WorkServiceTest extends FreshDb {
+
+    public static class NoWorkers implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("h5m.worker.core", "0");
+        }
+    }
+
+    @Inject
+    TransactionManager tm;
+
+    @Inject
+    WorkService workService;
+
+
+
+    @Test
+    public void execute_not_cascade() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity parent = new JqNode("parent",".a",root);
+        parent.persist();
+        NodeEntity child = new JqNode("child",".b",parent);
+        child.persist();
+        ValueEntity value = new ValueEntity(null,root, JqValues.parse("""
+                { "a" : { "b" : "found" } }
+                """));
+        value.persist();
+
+        tm.commit();
+
+        Work parentWork = new Work(parent,parent.sources, List.of(value.id));
+        parentWork.setCascade(false);
+        workService.execute(parentWork);
+        assertEquals(0,workService.getQueue().size(),"parent should not queue child work");
+    }
+
+}


### PR DESCRIPTION
This introduces Work.cascade which prevents work from creating more work when it creates new Values. This option is used to recalculate ephemeral Values for recalculate without incurring the performance penalty of wasted additional computation for unnecessary nodes and sorting. 
This also fixes recalculate to work concurrently with upload and other recalculates that could impact the same scope. The RecalculateWorkQueueTest uses a WorkExecutor without threads to manually verify the queuing.
This PR also removes recalculate for a full folder.