### PR TITLE
Fixed folder delete when a folder has an upload

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -29,6 +29,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
 import org.hibernate.query.NativeQuery;
 
@@ -67,6 +68,9 @@ public class FolderService implements FolderServiceInterface {
 
     @Inject
     ApiMapper apiMapper;
+
+    @Inject
+    NotificationService notificationService;
 
 
 
@@ -205,11 +209,19 @@ public class FolderService implements FolderServiceInterface {
     @Override
     @Transactional
     public long delete(String name){
-        // Delete views and components before folder (bulk delete doesn't cascade)
-        em.createNativeQuery("DELETE FROM folder_view_component WHERE view_id IN (SELECT id FROM folder_view WHERE folder_id IN (SELECT id FROM folder WHERE name = :name))")
-            .setParameter("name", name).executeUpdate();
-        em.createNativeQuery("DELETE FROM folder_view WHERE folder_id IN (SELECT id FROM folder WHERE name = :name)")
-            .setParameter("name", name).executeUpdate();
+        FolderEntity folder = FolderEntity.find("name", name).firstResult();
+        if (folder == null) {
+            throw new NotFoundException("Folder not found: " + name);
+        }
+
+        valueService.deleteForFolder(folder.id);
+        notificationService.deleteForFolder(folder.id);
+        processingService.deleteForFolder(folder.id);
+
+        em.createNativeQuery("DELETE FROM folder_view_component WHERE view_id IN (SELECT id FROM folder_view WHERE folder_id = :fid)")
+                .setParameter("fid", folder.id).executeUpdate();
+        em.createNativeQuery("DELETE FROM folder_view WHERE folder_id = :fid")
+                .setParameter("fid", folder.id).executeUpdate();
         return FolderEntity.delete("name", name);
     }
 

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NotificationService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NotificationService.java
@@ -17,6 +17,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.Optional;
  */
 @ApplicationScoped
 public class NotificationService {
+    @Inject
+    EntityManager em;
 
     @Inject
     Instance<NotificationPlugin> plugins;
@@ -150,4 +153,13 @@ public class NotificationService {
         log.changeCount = changeCount;
         log.persist();
     }
+
+    @Transactional
+    public void deleteForFolder(long folderId) {
+        em.createNativeQuery("DELETE FROM notification_config WHERE folder_id = :fid")
+                .setParameter("fid", folderId).executeUpdate();
+        em.createNativeQuery("DELETE FROM notification_log WHERE folder_id = :fid")
+                .setParameter("fid", folderId).executeUpdate();
+    }
+
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
@@ -458,4 +458,9 @@ public class ProcessingService {
         }
         return hasNonDetectionChild && !isDetectionSource;
     }
+
+    public void deleteForFolder(long folderId) {
+        em.createNativeQuery("DELETE FROM processing_tracker WHERE folder_id = :fid")
+                .setParameter("fid", folderId).executeUpdate();
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -103,6 +103,16 @@ public class ValueService implements ValueServiceInterface {
     }
 
     @Transactional
+    public void deleteForFolder(long folderId) {
+        // Bulk delete - no parent count checks needed since entire folder is going away
+        em.createNativeQuery("DELETE FROM value_edge WHERE child_id IN (SELECT id FROM value WHERE folder_id = :fid)")
+                .setParameter("fid", folderId).executeUpdate();
+        em.createNativeQuery("DELETE FROM value WHERE folder_id = :fid")
+                .setParameter("fid", folderId).executeUpdate();
+    }
+
+
+    @Transactional
     public ValueEntity byId(Long id){
         return ValueEntity.findById(id);
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -5,10 +5,14 @@ import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
+import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
+import io.hyperfoil.tools.h5m.entity.NotificationConfig;
+import io.hyperfoil.tools.h5m.entity.NotificationLog;
 import io.hyperfoil.tools.h5m.entity.ProcessingTrackerEntity;
 import io.hyperfoil.tools.h5m.api.ProcessingType;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
+import io.hyperfoil.tools.h5m.notification.NotificationMethod;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -443,5 +447,53 @@ public class FolderServiceTest extends FreshDb {
                 JqValues.parse("{\"cpu\": 99}")).uploadId;
 
         assertNotEquals(id1, id2, "Each upload should return a unique ID");
+    }
+    @Test
+    public void delete_folder_with_uploads() throws Exception {
+        tm.begin();
+        folderService.create("delete-upload-test");
+        tm.commit();
+
+
+        tm.begin();
+        FolderEntity folder = FolderEntity.find("name", "delete-upload-test").firstResult();
+        long groupId = folder.group.id;
+
+        NodeEntity nodeA = new JqNode("Node A", ".a");
+        nodeA.group = folder.group;
+        nodeA.persist();
+        long nodeId = nodeA.id;
+
+
+        NotificationConfig config = new NotificationConfig(folder, NotificationMethod.WEBHOOK, "{\"url\": \"http://example.com\"}");
+        config.persist();
+        long configId = config.id;
+
+        NotificationLog log = new NotificationLog();
+        log.folder = folder;
+        log.method = "webhook";
+        log.destination = "http://example.com";
+        log.status = "sent";
+        log.nodeId = 1L;
+        log.nodeName = "test-node";
+        log.changeCount = 1;
+        log.persist();
+        long logId = log.id;
+        tm.commit();
+
+        folderService.upload("delete-upload-test", null,
+                JqValues.parse("{\"cpu\": 95}"))
+                .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
+
+        long deleted = folderService.delete("delete-upload-test");
+
+        tm.begin();
+        assertNull(FolderEntity.find("name", "delete-upload-test").firstResult(), "Folder should not exist after deletion");
+        assertEquals(1, deleted, "One folder should have been deleted");
+        assertNotNull(NodeGroupEntity.findById(groupId), "Node group should still exist after folder deletion");
+        assertNull(NotificationConfig.findById(configId), "Notification config should be deleted ");
+        assertNull(NotificationLog.findById(logId), "Notification log should be deleted");
+        assertNotNull(NodeEntity.findById(nodeId), "Node should not be deleted");
+        tm.commit();
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -63,6 +63,29 @@ public class ValueServiceTest extends FreshDb {
         assertNotNull(found);
     }
 
+    @Test
+    public void deleteForFolder_removes_all_folder_values() throws Exception {
+        tm.begin();
+        NodeGroupEntity group = new NodeGroupEntity("deleteForFolder-test");
+        group.persist();
+        FolderEntity folder = new FolderEntity();
+        folder.name = "deleteForFolder-test";
+        folder.group = group;
+        folder.persist();
+        ValueEntity v1 = new ValueEntity(folder, group.root, JqString.of("a"));
+        v1.persist();
+        ValueEntity v2 = new ValueEntity(folder, group.root, JqString.of("b"));
+        v2.persist();
+        long v1Id = v1.id;
+        long v2Id = v2.id;
+        tm.commit();
+
+        valueService.deleteForFolder(folder.id);
+
+        assertNull(ValueEntity.findById(v1Id), "v1 should be deleted");
+        assertNull(ValueEntity.findById(v2Id), "v2 should be deleted");
+    }
+
 
     @Test
     public void delete_does_not_cascade_to_shared_child() throws HeuristicRollbackException, SystemException, HeuristicMixedException, RollbackException, NotSupportedException {


### PR DESCRIPTION
Deleting a folder that has uploads was failing with a 500 due to a FK constraint violation on the value table. The bulk delete bypasses JPA cascade, so dependent rows were not cleaned up before the folder row was deleted.

  Changes:
  - FolderService.delete() now explicitly cleans up all dependent rows in the correct FK order before deleting the folder
  - Added delete_folder_with_uploads test in FolderServiceTest to cover this scenario 


Close issue #204 