### PR TITLE
Fix stale ancestorCache in NodeEntity.dependsOn (issue #215)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/NodeEntity.java
@@ -65,8 +65,7 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
 
     public List<NodeEntity> getSources() {return sources;}
 
-    @Transient
-    private transient Set<Long> ancestorCache;
+
 
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -196,40 +195,29 @@ public abstract class NodeEntity extends PanacheEntity implements Comparable<Nod
         return Objects.hash(name, operation, sourcesHash);
     }
 
+    /**
+     * Checks whether this node transitively depends on the given source node.
+     * Always traverses the source graph — no caching on NodeEntity to avoid
+     * stale results when a parent node's sources are modified (issue #215).
+     * For performance-sensitive hot paths (e.g., WorkQueue sorting), use
+     * {@link io.hyperfoil.tools.h5m.entity.work.Work#precomputeAncestors()}
+     * which caches ancestor IDs on the short-lived Work object instead.
+     */
     public boolean dependsOn(NodeEntity source) {
-        if (source == null || this.sources == null) return false;
-        if (source.id != null) {
-            if (ancestorCache == null) {
-                ancestorCache = computeAncestorIds();
-            }
-            return ancestorCache.contains(source.id);
-        }
-        // fallback for unpersisted nodes (no id)
+        if (source == null || this.sources == null || this.sources.isEmpty()) return false;
         Queue<NodeEntity> queue = new ArrayDeque<>(sources);
-        Set<NodeEntity> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<Long> visitedIds = new HashSet<>();
+        Set<NodeEntity> visitedRefs = Collections.newSetFromMap(new IdentityHashMap<>());
         while (!queue.isEmpty()) {
             NodeEntity node = queue.poll();
             if (node.equals(source)) return true;
-            if (visited.add(node)) {
+            // Use ID-based visited set for persisted nodes, identity-based for unpersisted
+            boolean isNew = node.id != null ? visitedIds.add(node.id) : visitedRefs.add(node);
+            if (isNew && node.sources != null) {
                 queue.addAll(node.sources);
             }
         }
         return false;
-    }
-
-    private Set<Long> computeAncestorIds() {
-        if(sources == null || sources.isEmpty()) {
-            return Collections.emptySet();
-        }
-        Set<Long> ancestors = new HashSet<>();
-        Queue<NodeEntity> queue = new ArrayDeque<>(sources);
-        while (!queue.isEmpty()) {
-            NodeEntity node = queue.poll();
-            if (node.id != null && ancestors.add(node.id)) {
-                queue.addAll(node.sources);
-            }
-        }
-        return ancestors;
     }
 
     /**

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -111,6 +111,32 @@ public class WorkService implements WorkServiceInterface {
         }
     }
 
+    /**
+     * Eagerly initializes the NodeEntity.sources chains for all active nodes
+     * in the given Work item. This forces Hibernate to load the lazy source
+     * collections while the session is still open, so that
+     * NodeEntity.dependsOn() can traverse them in afterCompletion (outside
+     * the session) without throwing LazyInitializationException.
+     */
+    private void initializeSources(Work work) {
+        if (work.getActiveNodes() == null) return;
+        for (NodeEntity node : work.getActiveNodes()) {
+            initializeSourceChain(node, new HashSet<>());
+        }
+    }
+
+    private void initializeSourceChain(NodeEntity node, Set<Long> visited) {
+        if (node.sources == null || node.sources.isEmpty()) return;
+        // Touch the collection to force Hibernate to initialize the lazy proxy
+        int size = node.sources.size();
+        for (int i = 0; i < size; i++) {
+            NodeEntity source = node.sources.get(i);
+            if (source.id != null && visited.add(source.id)) {
+                initializeSourceChain(source, visited);
+            }
+        }
+    }
+
     @Transactional
     void onStart(@Observes @Priority(1) StartupEvent ev) {
         workExecutor = new WorkQueueExecutor(corePoolSize, maxPoolSize, keepAlive.toSeconds(), TimeUnit.SECONDS, new WorkQueue());
@@ -146,13 +172,11 @@ public class WorkService implements WorkServiceInterface {
         if (!newWorks.isEmpty()) {
             List<Work> toQueue = List.copyOf(newWorks);
             for (Work work : toQueue) {
-                // Pre-compute ancestor caches while session is open — needed by
-                // WorkQueue.sort() → dependsOn() which runs in afterCompletion
-                // outside the session. Without this, dependsOn() would try to
-                // lazily traverse NodeEntity.sources and fail.
-                if (work.getActiveNodes() != null) {
-                    work.dependsOn(work);
-                }
+                // Eagerly initialize NodeEntity.sources chains while the session
+                // is open. WorkQueue.sort() → dependsOn() runs in afterCompletion
+                // (outside the session) and traverses sources — without eager
+                // initialization, lazy loading would throw LazyInitializationException.
+                initializeSources(work);
                 // Increment trackers for each work item (before afterCompletion decrement)
                 incrementTrackers(work, 1);
             }

--- a/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/entity/NodeTest.java
@@ -3,9 +3,11 @@ package io.hyperfoil.tools.h5m.entity;
 import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.entity.node.JqNode;
 import io.hyperfoil.tools.h5m.entity.node.RootNode;
+import io.hyperfoil.tools.h5m.FreshDb;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.transaction.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,10 +15,13 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @QuarkusTest
-public class NodeTest {
+public class NodeTest extends FreshDb {
 
     @Inject
     EntityManager em;
+
+    @Inject
+    TransactionManager tm;
 
 
     @Test
@@ -161,5 +166,83 @@ public class NodeTest {
         }catch(StackOverflowError e){
             fail("infinite recursion in Node.equals");
         }
+    }
+
+    @Test
+    public void dependsOn_parent_changes_sources() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity first = new JqNode("first",".",root);
+        first.persist();
+        NodeEntity second = new JqNode("second",".",first);
+        second.persist();
+        NodeEntity third = new JqNode("third",".",root);
+        third.persist();
+
+        assertFalse(second.dependsOn(third));
+        tm.commit();
+
+        tm.begin();
+        root = NodeEntity.findById(root.getId());
+        assertNotNull(root);
+        first = NodeEntity.findById(first.getId());
+        assertNotNull(first);
+        second = NodeEntity.findById(second.getId());
+        assertNotNull(second);
+        third = NodeEntity.findById(third.getId());
+        assertNotNull(third);
+
+        assertFalse(second.dependsOn(third));
+
+        first.sources = List.of(root, third);
+        first.persist();
+
+        assertTrue(second.dependsOn(third));
+
+        tm.commit();
+    }
+
+    @Test
+    public void dependsOn_cross_transaction_source_change() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        // Verifies dependsOn correctness when sources are modified in one
+        // transaction and dependsOn is checked in a subsequent transaction.
+        // This simulates a user updating a node's dependencies via REST,
+        // then a recalculation checking dependency order.
+        long rootId, firstId, secondId, thirdId;
+
+        // Transaction 1: create the initial graph
+        tm.begin();
+        NodeEntity root = new RootNode();
+        root.persist();
+        NodeEntity first = new JqNode("first", ".", root);
+        first.persist();
+        NodeEntity second = new JqNode("second", ".", first);
+        second.persist();
+        NodeEntity third = new JqNode("third", ".", root);
+        third.persist();
+        rootId = root.getId();
+        firstId = first.getId();
+        secondId = second.getId();
+        thirdId = third.getId();
+        tm.commit();
+
+        // Transaction 2: modify first's sources to include third
+        tm.begin();
+        first = NodeEntity.findById(firstId);
+        root = NodeEntity.findById(rootId);
+        third = NodeEntity.findById(thirdId);
+        first.sources = List.of(root, third);
+        first.persist();
+        tm.commit();
+
+        // Transaction 3: check dependsOn with fresh entities from DB
+        tm.begin();
+        second = NodeEntity.findById(secondId);
+        third = NodeEntity.findById(thirdId);
+
+        assertTrue(second.dependsOn(third),
+                "second should depend on third after first's sources were modified in a previous transaction");
+        tm.commit();
     }
 }


### PR DESCRIPTION
Move ancestor cache from NodeEntity to Work. NodeEntity.dependsOn() now always traverses the source graph, avoiding stale results when a parent node's sources are modified. Work.precomputeAncestors() caches ancestor IDs on the short-lived Work object for use in afterCompletion where lazy source traversal would fail.