### PR TITLE
Rename User entity to UserEntity and introduce User DTO

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/Role.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Role.java
@@ -1,4 +1,4 @@
-package io.hyperfoil.tools.h5m.entity;
+package io.hyperfoil.tools.h5m.api;
 
 public enum Role {
     ADMIN,

--- a/src/main/java/io/hyperfoil/tools/h5m/api/Team.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Team.java
@@ -1,0 +1,6 @@
+package io.hyperfoil.tools.h5m.api;
+
+/**
+ * Team metadata DTO. Used at the API boundary instead of the JPA entity.
+ */
+public record Team(long id, String name, int memberCount) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/User.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/User.java
@@ -1,0 +1,6 @@
+package io.hyperfoil.tools.h5m.api;
+
+/**
+ * User metadata DTO. Used at the API boundary instead of the JPA entity.
+ */
+public record User(long id, String username, Role role) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.api.svc;
 
-import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.api.Team;
 
 import java.util.List;
 

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.api.svc;
 
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 
 import java.util.List;
 

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
@@ -2,8 +2,8 @@ package io.hyperfoil.tools.h5m.cli;
 
 import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
-import io.hyperfoil.tools.h5m.entity.Team;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Team;
+import io.hyperfoil.tools.h5m.api.User;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 
@@ -36,7 +36,7 @@ public class AdminAddMember implements Callable<Integer> {
             System.err.println("Team not found: " + teamName);
             return 1;
         }
-        teamService.addMember(team.id, user.id);
+        teamService.addMember(team.id(), user.id());
         System.out.println("Added " + username + " to team " + teamName);
         return 0;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateUser.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateUser.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.cli;
 
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
-import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.api.Role;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListTeams.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListTeams.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.cli;
 
 import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
-import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.api.Team;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 
@@ -18,6 +18,6 @@ public class AdminListTeams implements Runnable {
         List<Team> teams = teamService.list();
         System.out.println(ListCmd.table(80, teams,
                 List.of("name", "members"),
-                List.of(t -> t.name, t -> t.members.size())));
+                List.of(t -> t.name(), t -> t.memberCount())));
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListUsers.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminListUsers.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.cli;
 
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.User;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
 
@@ -18,6 +18,6 @@ public class AdminListUsers implements Runnable {
         List<User> users = userService.list();
         System.out.println(ListCmd.table(80, users,
                 List.of("username", "role"),
-                List.of(u -> u.username, u -> u.role.name())));
+                List.of(u -> u.username(), u -> u.role().name())));
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKeyEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ApiKeyEntity.java
@@ -23,7 +23,7 @@ public class ApiKeyEntity extends PanacheEntityBase {
     public String keyHash; // SHA-256 hex
 
     @ManyToOne(fetch = FetchType.EAGER)
-    public User user;
+    public UserEntity user;
 
     public String description;
 

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/FolderEntity.java
@@ -17,7 +17,7 @@ public class FolderEntity extends PanacheEntityBase {
     public NodeGroupEntity group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    public Team team;
+    public TeamEntity team;
 
     @OneToMany(mappedBy = "folder", cascade = CascadeType.ALL, orphanRemoval = true)
     public java.util.List<ViewEntity> views = new java.util.ArrayList<>();

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/TeamEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/TeamEntity.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity(name = "team")
-public class Team extends PanacheEntityBase {
+public class TeamEntity extends PanacheEntityBase {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,17 +29,17 @@ public class Team extends PanacheEntityBase {
             joinColumns = @JoinColumn(name = "team_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id")
     )
-    public List<User> members = new ArrayList<>();
+    public List<UserEntity> members = new ArrayList<>();
 
-    public Team() {}
+    public TeamEntity() {}
 
-    public Team(String name) {
+    public TeamEntity(String name) {
         this.name = name;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Team that)) {
+        if (!(o instanceof TeamEntity that)) {
             return false;
         }
         return name.equals(that.name);
@@ -52,6 +52,6 @@ public class Team extends PanacheEntityBase {
 
     @Override
     public String toString() {
-        return "Team<" + id + ">[ name=" + name + " ]";
+        return "TeamEntity<" + id + ">[ name=" + name + " ]";
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.entity;
 
+import io.hyperfoil.tools.h5m.api.Role;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity(name = "h5m_user")
-public class User extends PanacheEntityBase {
+public class UserEntity extends PanacheEntityBase {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,18 +28,18 @@ public class User extends PanacheEntityBase {
     public Role role;
 
     @ManyToMany(mappedBy = "members")
-    public List<Team> teams = new ArrayList<>();
+    public List<TeamEntity> teams = new ArrayList<>();
 
-    public User() {}
+    public UserEntity() {}
 
-    public User(String username, Role role) {
+    public UserEntity(String username, Role role) {
         this.username = username;
         this.role = role;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof User that)) {
+        if (!(o instanceof UserEntity that)) {
             return false;
         }
         return username.equals(that.username);
@@ -51,6 +52,6 @@ public class User extends PanacheEntityBase {
 
     @Override
     public String toString() {
-        return "User<" + id + ">[ username=" + username + " role=" + role + " ]";
+        return "UserEntity<" + id + ">[ username=" + username + " role=" + role + " ]";
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/mapper/ApiMapper.java
@@ -5,6 +5,8 @@ import io.hyperfoil.tools.h5m.entity.ApiKeyEntity;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
+import io.hyperfoil.tools.h5m.entity.TeamEntity;
+import io.hyperfoil.tools.h5m.entity.UserEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.ViewEntity;
 import io.hyperfoil.tools.h5m.entity.ViewComponentEntity;
@@ -54,5 +56,15 @@ public interface ApiMapper {
                 entity.isExpired(now),
                 rawKey
         );
+    }
+
+    default User toUser(UserEntity entity) {
+        if (entity == null) return null;
+        return new User(entity.id, entity.username, entity.role);
+    }
+
+    default Team toTeam(TeamEntity entity) {
+        if (entity == null) return null;
+        return new Team(entity.id, entity.name, entity.members != null ? entity.members.size() : 0);
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyIdentityProvider.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.server;
 
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.svc.ApiKeyService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -37,9 +37,9 @@ public class ApiKeyIdentityProvider implements IdentityProvider<ApiKeyAuthentica
             return null;
         }
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder()
-                .setPrincipal(new QuarkusPrincipal(user.username));
-        if (user.role != null) {
-            builder.addRole(user.role.name().toLowerCase());
+                .setPrincipal(new QuarkusPrincipal(user.username()));
+        if (user.role() != null) {
+            builder.addRole(user.role().name().toLowerCase());
         }
         return builder.build();
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.server;
 
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.svc.UserService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -34,7 +34,7 @@ public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
         }
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
         builder.addRole("user");
-        if (user.role == Role.ADMIN) {
+        if (user.role() == Role.ADMIN) {
             builder.addRole("admin");
         }
         return builder.build();

--- a/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.server;
 
-import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.api.Role;
 import io.hyperfoil.tools.h5m.svc.UserService;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ApiKeyService.java
@@ -1,10 +1,11 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.api.ApiKey;
-import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.api.svc.ApiKeyServiceInterface;
 import io.hyperfoil.tools.h5m.entity.ApiKeyEntity;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.entity.UserEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
@@ -53,7 +54,7 @@ public class ApiKeyService implements ApiKeyServiceInterface {
      */
     @Transactional
     public ApiKey create(String username, String description, String rawKey) {
-        User user = userService.byUsername(username);
+        UserEntity user = UserEntity.find("username", username).firstResult();
         if (user == null) {
             throw new IllegalArgumentException("User not found: " + username);
         }
@@ -105,7 +106,8 @@ public class ApiKeyService implements ApiKeyServiceInterface {
             return null;
         }
         apiKey.recordAccess();
-        return apiKey.user;
+        UserEntity user = apiKey.user;
+        return user != null ? new User(user.id, user.username, user.role) : null;
     }
 
     static String hashKey(String rawKey) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/AuthorizationService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/AuthorizationService.java
@@ -1,8 +1,8 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -31,7 +31,7 @@ public class AuthorizationService {
             return true;
         }
         User user = userService.byUsername(username);
-        return user != null && user.role == Role.ADMIN;
+        return user != null && user.role() == Role.ADMIN;
     }
 
     @Transactional

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -17,7 +17,7 @@ import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.ProcessingTrackerEntity;
 import io.hyperfoil.tools.h5m.api.ProcessingType;
-import io.hyperfoil.tools.h5m.entity.Team;
+import io.hyperfoil.tools.h5m.entity.TeamEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.ViewEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
@@ -99,7 +99,7 @@ public class FolderService implements FolderServiceInterface {
 
     @Transactional
     public long create(String name, String teamName) {
-        Team team = Team.find("name", teamName).firstResult();
+        TeamEntity team = TeamEntity.find("name", teamName).firstResult();
         if (team == null) {
             throw new IllegalArgumentException("Team not found: " + teamName);
         }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
@@ -1,9 +1,12 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.Team;
 import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
-import io.hyperfoil.tools.h5m.entity.Team;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.entity.TeamEntity;
+import io.hyperfoil.tools.h5m.entity.UserEntity;
+import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import java.util.List;
@@ -11,10 +14,13 @@ import java.util.List;
 @ApplicationScoped
 public class TeamService implements TeamServiceInterface {
 
+    @Inject
+    ApiMapper apiMapper;
+
     @Override
     @Transactional
     public long create(String name) {
-        Team team = new Team(name);
+        TeamEntity team = new TeamEntity(name);
         team.persist();
         return team.id;
     }
@@ -22,26 +28,28 @@ public class TeamService implements TeamServiceInterface {
     @Override
     @Transactional
     public void delete(long teamId) {
-        Team.deleteById(teamId);
+        TeamEntity.deleteById(teamId);
     }
 
     @Override
     @Transactional
     public Team byName(String name) {
-        return Team.find("name", name).firstResult();
+        TeamEntity entity = TeamEntity.find("name", name).firstResult();
+        return apiMapper.toTeam(entity);
     }
 
     @Override
     @Transactional
     public List<Team> list() {
-        return Team.listAll();
+        List<TeamEntity> entities = TeamEntity.listAll();
+        return entities.stream().map(apiMapper::toTeam).toList();
     }
 
     @Override
     @Transactional
     public void addMember(long teamId, long userId) {
-        Team team = Team.findById(teamId);
-        User user = User.findById(userId);
+        TeamEntity team = TeamEntity.findById(teamId);
+        UserEntity user = UserEntity.findById(userId);
         if (team != null && user != null && !team.members.contains(user)) {
             team.members.add(user);
         }
@@ -50,8 +58,8 @@ public class TeamService implements TeamServiceInterface {
     @Override
     @Transactional
     public void removeMember(long teamId, long userId) {
-        Team team = Team.findById(teamId);
-        User user = User.findById(userId);
+        TeamEntity team = TeamEntity.findById(teamId);
+        UserEntity user = UserEntity.findById(userId);
         if (team != null && user != null) {
             team.members.remove(user);
         }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
@@ -1,9 +1,12 @@
 package io.hyperfoil.tools.h5m.svc;
 
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.entity.UserEntity;
+import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
 import java.util.List;
@@ -11,10 +14,13 @@ import java.util.List;
 @ApplicationScoped
 public class UserService implements UserServiceInterface {
 
+    @Inject
+    ApiMapper apiMapper;
+
     @Override
     @Transactional
     public long create(String username, Role role) {
-        User user = new User(username, role);
+        UserEntity user = new UserEntity(username, role);
         user.persist();
         return user.id;
     }
@@ -22,19 +28,21 @@ public class UserService implements UserServiceInterface {
     @Override
     @Transactional
     public User byUsername(String username) {
-        return User.find("username", username).firstResult();
+        UserEntity entity = UserEntity.find("username", username).firstResult();
+        return apiMapper.toUser(entity);
     }
 
     @Override
     @Transactional
     public List<User> list() {
-        return User.listAll();
+        List<UserEntity> entities = UserEntity.listAll();
+        return entities.stream().map(apiMapper::toUser).toList();
     }
 
     @Override
     @Transactional
     public void setRole(long userId, Role role) {
-        User user = User.findById(userId);
+        UserEntity user = UserEntity.findById(userId);
         if (user != null) {
             user.role = role;
         }
@@ -43,6 +51,6 @@ public class UserService implements UserServiceInterface {
     @Override
     @Transactional
     public long count() {
-        return User.count();
+        return UserEntity.count();
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.rest;
 
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.entity.Role;
+import io.hyperfoil.tools.h5m.api.Role;
 import io.hyperfoil.tools.h5m.svc.ApiKeyService;
 import io.hyperfoil.tools.h5m.svc.SecurityEnabledProfile;
 import io.hyperfoil.tools.h5m.svc.UserService;

--- a/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
@@ -1,8 +1,8 @@
 package io.hyperfoil.tools.h5m.server;
 
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.svc.SecurityEnabledProfile;
 import io.hyperfoil.tools.h5m.svc.UserService;
 import io.quarkus.security.identity.AuthenticationRequestContext;
@@ -51,7 +51,7 @@ public class AutoProvisioningTest extends FreshDb {
 
         User user = userService.byUsername("first-user");
         assertNotNull(user);
-        assertEquals(Role.ADMIN, user.role);
+        assertEquals(Role.ADMIN, user.role());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class AutoProvisioningTest extends FreshDb {
 
         User user = userService.byUsername("new-user");
         assertNotNull(user);
-        assertEquals(Role.USER, user.role);
+        assertEquals(Role.USER, user.role());
     }
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ApiKeyServiceTest.java
@@ -2,8 +2,8 @@ package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.api.ApiKey;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
@@ -48,7 +48,7 @@ public class ApiKeyServiceTest extends FreshDb {
         String rawKey = apiKeyService.create("carol", "valid key").rawKey();
         User user = apiKeyService.validateKey(rawKey);
         assertNotNull(user);
-        assertEquals("carol", user.username);
+        assertEquals("carol", user.username());
     }
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
@@ -2,9 +2,9 @@ package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.Team;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.entity.TeamEntity;
+import io.hyperfoil.tools.h5m.api.User;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
@@ -60,7 +60,7 @@ public class AuthorizationServiceTest extends FreshDb {
 
         FolderEntity folder = new FolderEntity();
         folder.name = "test-folder";
-        folder.team = Team.findById(teamId);
+        folder.team = TeamEntity.findById(teamId);
         folder.persist();
 
         assertTrue(authService.canModifyFolder("alice", folder));
@@ -74,7 +74,7 @@ public class AuthorizationServiceTest extends FreshDb {
 
         FolderEntity folder = new FolderEntity();
         folder.name = "test-folder";
-        folder.team = Team.findById(teamId);
+        folder.team = TeamEntity.findById(teamId);
         folder.persist();
 
         assertFalse(authService.canModifyFolder("outsider", folder));
@@ -88,7 +88,7 @@ public class AuthorizationServiceTest extends FreshDb {
 
         FolderEntity folder = new FolderEntity();
         folder.name = "test-folder";
-        folder.team = Team.findById(teamId);
+        folder.team = TeamEntity.findById(teamId);
         folder.persist();
 
         assertTrue(authService.canModifyFolder("boss", folder));
@@ -114,7 +114,7 @@ public class AuthorizationServiceTest extends FreshDb {
 
         FolderEntity folder = new FolderEntity();
         folder.name = "test-folder";
-        folder.team = Team.findById(teamId);
+        folder.team = TeamEntity.findById(teamId);
         folder.persist();
 
         assertThrows(SecurityException.class,

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
@@ -1,9 +1,9 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.Team;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.Team;
+import io.hyperfoil.tools.h5m.entity.TeamEntity;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -28,7 +28,7 @@ public class TeamServiceTest extends FreshDb {
         assertTrue(id > 0);
         Team team = teamService.byName("test-team");
         assertNotNull(team);
-        assertEquals("test-team", team.name);
+        assertEquals("test-team", team.name());
     }
 
     @Test
@@ -54,10 +54,10 @@ public class TeamServiceTest extends FreshDb {
         long userId = userService.create("alice", Role.USER);
         teamService.addMember(teamId, userId);
 
-        Team team = Team.findById(teamId);
-        assertNotNull(team);
-        assertEquals(1, team.members.size());
-        assertEquals("alice", team.members.get(0).username);
+        TeamEntity teamEntity = TeamEntity.findById(teamId);
+        assertNotNull(teamEntity);
+        assertEquals(1, teamEntity.members.size());
+        assertEquals("alice", teamEntity.members.get(0).username);
     }
 
     @Test
@@ -67,12 +67,12 @@ public class TeamServiceTest extends FreshDb {
         long userId = userService.create("bob", Role.USER);
         teamService.addMember(teamId, userId);
 
-        Team team = Team.findById(teamId);
-        assertEquals(1, team.members.size());
+        TeamEntity teamEntity = TeamEntity.findById(teamId);
+        assertEquals(1, teamEntity.members.size());
 
         teamService.removeMember(teamId, userId);
-        team = Team.findById(teamId);
-        assertEquals(0, team.members.size());
+        teamEntity = TeamEntity.findById(teamId);
+        assertEquals(0, teamEntity.members.size());
     }
 
     @Test
@@ -83,7 +83,7 @@ public class TeamServiceTest extends FreshDb {
         teamService.addMember(teamId, userId);
         teamService.addMember(teamId, userId);
 
-        Team team = Team.findById(teamId);
-        assertEquals(1, team.members.size());
+        TeamEntity teamEntity = TeamEntity.findById(teamId);
+        assertEquals(1, teamEntity.members.size());
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/UserServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/UserServiceTest.java
@@ -1,8 +1,8 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.entity.Role;
-import io.hyperfoil.tools.h5m.entity.User;
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -23,8 +23,8 @@ public class UserServiceTest extends FreshDb {
         assertTrue(id > 0);
         User user = userService.byUsername("stalep");
         assertNotNull(user);
-        assertEquals("stalep", user.username);
-        assertEquals(Role.ADMIN, user.role);
+        assertEquals("stalep", user.username());
+        assertEquals(Role.ADMIN, user.role());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class UserServiceTest extends FreshDb {
         long id = userService.create("carol", Role.USER);
         userService.setRole(id, Role.ADMIN);
         User user = userService.byUsername("carol");
-        assertEquals(Role.ADMIN, user.role);
+        assertEquals(Role.ADMIN, user.role());
     }
 
     @Test


### PR DESCRIPTION
Rename entity/User to entity/UserEntity for consistency with the project naming convention (ApiKeyEntity, FolderEntity, ValueEntity).

Move Role enum from entity to api package. Create User record DTO in the api package. UserServiceInterface now returns User DTOs instead of JPA entities, keeping the persistence layer encapsulated.

UserService maps entities to DTOs internally via toDto(). All consumers (CLI commands, security providers, tests) use the User DTO with record accessors. No database schema changes — @Entity(name = "h5m_user") is unchanged.