### PR TITLE
Add lax-mode jsonpath conversion for legacy import (issue #230)

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
@@ -154,6 +154,137 @@ public class LoadLegacyTests implements Callable<Integer> {
         return NodeService.jsonpathToJq(jsonpath);
     }
 
+    /**
+     * Converts a PostgreSQL SQL/JSON path to a jq expression with lax-mode
+     * auto-array-unwrapping at each intermediate path segment.
+     * <p>
+     * PostgreSQL's default {@code lax} mode automatically unwraps arrays when
+     * traversing with dot notation (e.g., {@code $.a.b.c} will descend into
+     * arrays at {@code a} or {@code b} transparently). Standard jq requires
+     * explicit {@code []} to iterate arrays.
+     * <p>
+     * This method replicates lax semantics by wrapping each intermediate segment
+     * with a conditional: {@code if (.seg | type) == "array" then .seg[] else .seg end}.
+     * The final segment is left as-is.
+     */
+    static String jsonpathToJqLax(String jsonpath) {
+        String jq = NodeService.jsonpathToJq(jsonpath);
+        return applyLaxUnwrapping(jq);
+    }
+
+    /**
+     * Like {@link #jsonpathToJqLax(String)} but wraps the result in {@code [...]}
+     * to collect all matches into an array, matching {@code jsonb_path_query_array}
+     * with lax mode.
+     */
+    static String jsonpathToJqLaxArray(String jsonpath) {
+        String jq = jsonpathToJqLax(jsonpath);
+        if (jq.contains("[]?") || jq.contains("[] else")) {
+            return "[" + jq + "]";
+        } else {
+            return "[" + jq + " // empty]";
+        }
+    }
+
+    /**
+     * Post-processes a jq expression to add lax-mode conditional array unwrapping
+     * at each intermediate dot-access segment. Segments that already have iterators
+     * ({@code []?}) or pipes ({@code |}) are left unchanged.
+     */
+    static String applyLaxUnwrapping(String jq) {
+        if (jq == null || jq.equals(".") || !jq.startsWith(".")) return jq;
+
+        // If the expression contains pipes (filters, methods), only apply lax
+        // to the portion before the first pipe
+        String prefix = jq;
+        String suffix = "";
+        int pipeIdx = findFirstPipeOutsideParens(jq);
+        if (pipeIdx >= 0) {
+            prefix = jq.substring(0, pipeIdx).trim();
+            suffix = " " + jq.substring(pipeIdx).trim();
+        }
+
+        List<String> segments = splitDotSegments(prefix);
+        if (segments.size() <= 1) return jq;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.size(); i++) {
+            String seg = segments.get(i);
+            boolean isLast = (i == segments.size() - 1);
+            boolean hasIterator = seg.contains("[]");
+
+            if (isLast || hasIterator) {
+                if (sb.length() > 0 && !sb.toString().endsWith("| ")) sb.append(" | ");
+                sb.append(seg);
+            } else {
+                if (sb.length() > 0 && !sb.toString().endsWith("| ")) sb.append(" | ");
+                sb.append("if (").append(seg).append(" | type) == \"array\" then ")
+                  .append(seg).append("[] else ").append(seg).append(" end");
+            }
+        }
+        sb.append(suffix);
+        return sb.toString();
+    }
+
+    /**
+     * Splits a jq dot-access path into segments, respecting quoted keys and
+     * bracket access. For example:
+     * {@code .a.b.c} → {@code [".a", ".b", ".c"]},
+     * {@code .a[]?.b.c} → {@code [".a[]?", ".b", ".c"]}.
+     */
+    static List<String> splitDotSegments(String jq) {
+        List<String> segments = new ArrayList<>();
+        if (jq == null || jq.isEmpty()) return segments;
+
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        boolean inBrackets = false;
+
+        for (int i = 0; i < jq.length(); i++) {
+            char c = jq.charAt(i);
+            if (c == '"' && (i == 0 || jq.charAt(i - 1) != '\\')) {
+                inQuotes = !inQuotes;
+                current.append(c);
+            } else if (!inQuotes && c == '[') {
+                inBrackets = true;
+                current.append(c);
+            } else if (!inQuotes && c == ']') {
+                inBrackets = false;
+                current.append(c);
+            } else if (!inQuotes && !inBrackets && c == '?' && current.toString().endsWith("]")) {
+                current.append(c);
+            } else if (!inQuotes && !inBrackets && c == '.' && current.length() > 0) {
+                segments.add(current.toString());
+                current = new StringBuilder();
+                current.append(c);
+            } else {
+                current.append(c);
+            }
+        }
+        if (current.length() > 0) {
+            segments.add(current.toString());
+        }
+        return segments;
+    }
+
+    private static int findFirstPipeOutsideParens(String jq) {
+        boolean inQuotes = false;
+        int parenDepth = 0;
+        for (int i = 0; i < jq.length(); i++) {
+            char c = jq.charAt(i);
+            if (c == '"' && (i == 0 || jq.charAt(i - 1) != '\\')) {
+                inQuotes = !inQuotes;
+            } else if (!inQuotes && c == '(') {
+                parenDepth++;
+            } else if (!inQuotes && c == ')') {
+                parenDepth--;
+            } else if (!inQuotes && parenDepth == 0 && c == '|') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     @Inject
     FolderService folderService;
 
@@ -262,8 +393,8 @@ public class LoadLegacyTests implements Callable<Integer> {
 
             // Convert jsonpath to jq — sqlall (isArray) wraps in [...] to collect all matches
             String jqOperation = extractor.isArray
-                    ? NodeService.jsonpathToJqArray(extractor.jsonpath())
-                    : NodeService.jsonpathToJq(extractor.jsonpath());
+                    ? jsonpathToJqLaxArray(extractor.jsonpath())
+                    : jsonpathToJqLax(extractor.jsonpath());
             NodeEntity node = JqNode.parse(extractorName, jqOperation, nodeTracking::getNodes);
             if (node == null) {
                 System.err.println("failed to create node for extractor " + extractor);

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -1141,7 +1141,7 @@ public class NodeService implements NodeServiceInterface {
      * when the path doesn't exist — matching jsonb_path_query_array's behavior
      * of returning {@code []} for missing paths.
      */
-    public static String jsonpathToJqArray(String jsonpath) {
+     public static String jsonpathToJqArray(String jsonpath) {
         String jq = jsonpathToJq(jsonpath);
         if (jq.contains("[]?")) {
             // Has iterators — [...] naturally produces [] when no matches
@@ -1266,10 +1266,7 @@ public class NodeService implements NodeServiceInterface {
             result.append(" | select(").append(filterBody).append(")");
             i = parenEnd;
         }
-        // Convert remaining ."text()" style field access to ["text()"]
-        String output = result.toString();
-        output = output.replaceAll("\\.\"([^\"]+)\"", ".[\"$1\"]");
-        return output;
+        return result.toString();
     }
 
     public static String renameParameters(String function,Map<String,String> renames){

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTestsTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTestsTest.java
@@ -675,4 +675,102 @@ public class LoadLegacyTestsTest {
         assertFalse(JsNode.isNullEmptyOrIdentityFunction(entity.operation),"js node should have an operation that returns the input");
         assertEquals(2,entity.sources.size(),"both extractors should be sources for the node");
     }
+
+    // --- Lax jsonpath conversion tests ---
+
+    @Test
+    public void jsonpathToJqLax_simple_path() {
+        // $.a.b.c — intermediate segments a and b get conditional unwrapping
+        String result = LoadLegacyTests.jsonpathToJqLax("$.a.b.c");
+        assertTrue(result.contains("if (.a | type) == \"array\" then .a[] else .a end"),
+                "should unwrap intermediate segment a: " + result);
+        assertTrue(result.contains("if (.b | type) == \"array\" then .b[] else .b end"),
+                "should unwrap intermediate segment b: " + result);
+        assertTrue(result.endsWith(".c"), "final segment c should not be wrapped: " + result);
+    }
+
+    @Test
+    public void jsonpathToJqLax_single_segment() {
+        // $.a — single segment, no intermediate to unwrap
+        assertEquals(".a", LoadLegacyTests.jsonpathToJqLax("$.a"));
+    }
+
+    @Test
+    public void jsonpathToJqLax_two_segments() {
+        // $.a.b — only a is intermediate
+        String result = LoadLegacyTests.jsonpathToJqLax("$.a.b");
+        assertTrue(result.contains("if (.a | type) == \"array\" then .a[] else .a end"),
+                "should unwrap intermediate segment a: " + result);
+        assertTrue(result.endsWith(".b"), "final segment b should not be wrapped: " + result);
+    }
+
+    @Test
+    public void jsonpathToJqLax_with_existing_iterator() {
+        // $.a[*].b.c — a already has [*] (converted to []?), only b needs unwrapping
+        String result = LoadLegacyTests.jsonpathToJqLax("$.a[*].b.c");
+        assertTrue(result.contains(".a[]?"), "a should keep its iterator: " + result);
+        assertFalse(result.contains("if (.a"), "a should not get conditional (already has iterator): " + result);
+        assertTrue(result.contains("if (.b | type) == \"array\" then .b[] else .b end"),
+                "should unwrap intermediate segment b: " + result);
+        assertTrue(result.endsWith(".c"), "final segment c should not be wrapped: " + result);
+    }
+
+    @Test
+    public void jsonpathToJqLax_identity() {
+        // $ — just the root
+        assertEquals(".", LoadLegacyTests.jsonpathToJqLax("$"));
+    }
+
+    @Test
+    public void jsonpathToJqLax_produces_correct_jq_for_array_at_b() {
+        // Verify the actual jq from the issue works: {"a":{"b":[{"c":"one"}]}}
+        String jq = LoadLegacyTests.jsonpathToJqLax("$.a.b.c");
+        var program = io.hyperfoil.tools.jjq.JqProgram.compile(jq);
+        var input = JqValues.parse("{\"a\":{\"b\":[{\"c\":\"one\"}]}}");
+        var results = program.applyAll(input);
+        assertEquals(1, results.size(), "should produce one result: " + results);
+        assertEquals("one", results.get(0).asText(), "should extract 'one' through array: " + results);
+    }
+
+    @Test
+    public void jsonpathToJqLax_works_without_arrays() {
+        // Same path but no arrays — should still work (conditional is a no-op)
+        String jq = LoadLegacyTests.jsonpathToJqLax("$.a.b.c");
+        var program = io.hyperfoil.tools.jjq.JqProgram.compile(jq);
+        var input = JqValues.parse("{\"a\":{\"b\":{\"c\":\"one\"}}}");
+        var results = program.applyAll(input);
+        assertEquals(1, results.size(), "should produce one result: " + results);
+        assertEquals("one", results.get(0).asText(), "should extract 'one' without arrays: " + results);
+    }
+
+    @Test
+    public void jsonpathToJqLax_missing_path_returns_empty() {
+        // Missing intermediate key — should produce no results, not an error
+        String jq = LoadLegacyTests.jsonpathToJqLax("$.a.b.c");
+        var program = io.hyperfoil.tools.jjq.JqProgram.compile(jq);
+        var input = JqValues.parse("{\"a\":{\"d\":[{\"c\":\"one\"}]}}");
+        var results = program.applyAll(input);
+        // jq will return null for .b on {"d":...} — the conditional won't error
+        assertTrue(results.isEmpty() || results.get(0).isNull(),
+                "missing path should produce empty/null result: " + results);
+    }
+
+    @Test
+    public void jsonpathToJqLaxArray_wraps_in_brackets() {
+        String result = LoadLegacyTests.jsonpathToJqLaxArray("$.a.b.c");
+        assertTrue(result.startsWith("["), "should start with [: " + result);
+        assertTrue(result.endsWith("]"), "should end with ]: " + result);
+    }
+
+    @Test
+    public void jsonpathToJqLaxArray_produces_array_for_array_at_b() {
+        // Matches the example from issue #230
+        String jq = LoadLegacyTests.jsonpathToJqLaxArray("$.a.b.c");
+        var program = io.hyperfoil.tools.jjq.JqProgram.compile(jq);
+        var input = JqValues.parse("{\"a\":{\"b\":[{\"c\":\"one\"}]}}");
+        var results = program.applyAll(input);
+        assertEquals(1, results.size(), "should produce one result (the array): " + results);
+        assertTrue(results.get(0).isArray(), "result should be an array: " + results);
+        assertEquals("one", results.get(0).getElement(0).asText());
+    }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -2086,7 +2086,7 @@ public class NodeServiceTest extends FreshDb {
     @Test
     public void jsonpathToJq_filter_with_quoted_fields_and_trailing_path() {
         assertEquals(
-                ".faban.summary.benchResults.driverSummary[]? | select(.[\"@name\"] == \"MfgDriver\").customStats.stat[0].passed.[\"text()\"]",
+                ".faban.summary.benchResults.driverSummary[]? | select(.[\"@name\"] == \"MfgDriver\").customStats.stat[0].passed.\"text()\"",
                 NodeService.jsonpathToJq("$.faban.summary.benchResults.driverSummary[*] ? (@.\"@name\" == \"MfgDriver\").customStats.stat[0].passed.\"text()\""));
     }
 


### PR DESCRIPTION
PostgreSQL's default lax jsonpath mode auto-unwraps arrays when traversing with dot notation (e.g., $.a.b.c descends into arrays at a or b transparently). Standard jq requires explicit [] to iterate arrays, causing extraction failures when Horreum data has arrays at intermediate path segments.

Add jsonpathToJqLax() and jsonpathToJqLaxArray() to LoadLegacyTests that wrap each intermediate path segment with a conditional:
  if (.seg | type) == "array" then .seg[] else .seg end
Only used for Horreum legacy import — new h5m users write jq directly and don't need lax semantics. These methods are temporary and will be removed along with the rest of the legacy import code after all Horreum services have migrated.

FolderService's sql/sqlall backward-compat cases continue to use the non-lax NodeService.jsonpathToJq() — no dependency on CLI code.

Removed unnecessary ."key" to .["key"] conversion at the end of convertJsonpathFilters().