### PR TITLE
Upload data UI

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.rest;
 
 import io.hyperfoil.tools.jjq.value.JqValue;
+import io.hyperfoil.tools.jjq.value.JqValues;
 import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.h5m.api.FolderSummary;
 import io.hyperfoil.tools.h5m.api.RecalculationStatus;
@@ -8,23 +9,40 @@ import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.ValueServiceInterface;
 import io.hyperfoil.tools.h5m.svc.RecalculationService;
 import io.hyperfoil.tools.h5m.svc.RecalculationTracker;
+import io.quarkus.runtime.configuration.MemorySize;
 import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.RestForm;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
+import static java.nio.file.Files.readAllBytes;
 
 @Path("/api/folder")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Folder", description = "Manage folders for uploaded data")
 public class FolderResource {
+
+    @ConfigProperty(name = "quarkus.http.limits.max-body-size")
+    MemorySize maxBodySize;
 
     @Inject
     FolderServiceInterface folderService;
@@ -83,15 +101,54 @@ public class FolderResource {
 
     @POST
     @Path("{id}/upload")
+    @Consumes(MULTIPART_FORM_DATA)
     @Authenticated
     @Operation(description = "Upload JSON data to a folder. Returns immediately with an uploadId.")
+    @APIResponse(responseCode = "200", description = "Upload successful, returns uploadId")
+    @APIResponse(responseCode = "400", description = "Request received but content is not valid JSON or URL scheme is not http/https")
     public long upload(
             @PathParam("id") long id,
-            JqValue data) {
-        if (data == null) {
-            throw new BadRequestException("Missing request body");
+            @RestForm("raw") String raw,
+            @RestForm("url") URL url,
+            @RestForm("file") FileUpload file) {
+
+        if (Stream.of(url, raw == null || raw.isBlank() ? null : raw, file).filter(Objects::nonNull).count() != 1) {
+            throw new BadRequestException("Provide exactly one of 'file', 'raw', or 'url'");
         }
-        return folderService.upload(id, data).uploadId;
+
+        byte[] bytes;
+
+        try {
+            if (url != null) {
+                if (!Set.of("http", "https").contains(url.getProtocol())) {
+                    throw new BadRequestException("Only http/https URLs are allowed");
+                }
+                URLConnection connection = url.openConnection();
+                connection.setConnectTimeout(5000);
+                connection.setReadTimeout(30000);
+                int readLimit = (int) Math.min(maxBodySize.asLongValue() + 1, Integer.MAX_VALUE);
+                try (var inputStream = connection.getInputStream()) {
+                    bytes = inputStream.readNBytes(readLimit);
+                }
+                if (bytes.length > maxBodySize.asLongValue()) {
+                    throw new BadRequestException("Content at '" + url + "' exceeds the maximum upload size");
+                }
+            } else if (file != null) {
+                bytes = readAllBytes(file.uploadedFile());
+            } else {
+                bytes = raw.getBytes(StandardCharsets.UTF_8);
+            }
+        } catch (BadRequestException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new BadRequestException("Failed to read upload data: " + e.getMessage());
+        }
+
+        try {
+            return folderService.upload(id, JqValues.parse(bytes)).uploadId;
+        } catch (Exception e) {
+            throw new BadRequestException("Invalid JSON: " + e.getMessage());
+        }
     }
 
     @GET

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,6 +56,8 @@ quarkus.banner.enabled=false
 %dev.quarkus.http.cors.methods=GET,POST,PUT,DELETE,OPTIONS
 %dev.quarkus.http.cors.headers=content-type,authorization
 
+quarkus.http.limits.max-body-size=200M
+
 quarkus.package.jar.type=fast-jar
 
 # open api

--- a/src/main/webui/src/app/components/DataTab.tsx
+++ b/src/main/webui/src/app/components/DataTab.tsx
@@ -1,5 +1,6 @@
 import type { View, ViewComponent } from '@client/types.gen.ts';
 
+import { UploadDataModal } from '@app/components/UploadDataModal';
 import { ViewConfigModal } from '@app/components/ViewConfigModal';
 import {
   Button,
@@ -7,7 +8,13 @@ import {
   Dropdown,
   ErrorBoundary,
   InlineLoading,
+  Pagination,
   SkeletonText,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListWrapper,
   Table,
   TableBody,
   TableCell,
@@ -91,6 +98,10 @@ export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: numb
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [editingView, setEditingView] = useState<View | null>(null);
   const [modalKey, setModalKey] = useState(0);
+  const [uploadModalOpen, setUploadModalOpen] = useState(false);
+  const [recentUploads, setRecentUploads] = useState<Array<{ fileName: string; uploadId: number; uploadedAt: Date }>>([]);
+  const [uploadsPage, setUploadsPage] = useState(1);
+  const [uploadsPageSize, setUploadsPageSize] = useState(10);
 
   const selectedView = useMemo((): View | null => {
     if (!views || views.length === 0) return null;
@@ -107,7 +118,78 @@ export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: numb
   }, [views, selectedViewId]);
 
   if (viewsLoading) return <SkeletonText paragraph={true} lineCount={3} />;
-  if (!views || views.length === 0) return <p>No views configured</p>;
+
+  const uploadButton = (
+    <Button kind="primary" size="md" onClick={() => setUploadModalOpen(true)}>
+      Upload data
+    </Button>
+  );
+
+  const uploadModal = (
+    <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load modal" />}>
+      <Suspense fallback={null}>
+        <UploadDataModal
+          open={uploadModalOpen}
+          onClose={() => setUploadModalOpen(false)}
+          folderId={folderId}
+          onUploadSuccess={(fileName, uploadId) => {
+            setRecentUploads((prev) => [{ fileName, uploadId, uploadedAt: new Date() }, ...prev]);
+            setUploadsPage(1);
+          }}
+        />
+      </Suspense>
+    </ErrorBoundary>
+  );
+
+  const uploadsStart = (uploadsPage - 1) * uploadsPageSize;
+  const pagedUploads = recentUploads.slice(uploadsStart, uploadsStart + uploadsPageSize);
+
+  const recentUploadsList = recentUploads.length > 0 ? (
+    <div style={{ marginBottom: 'var(--cds-spacing-05)' }}>
+      <StructuredListWrapper>
+        <StructuredListHead>
+          <StructuredListRow head>
+            <StructuredListCell head>Upload file</StructuredListCell>
+            <StructuredListCell head>Upload ID</StructuredListCell>
+            <StructuredListCell head>Uploaded at</StructuredListCell>
+          </StructuredListRow>
+        </StructuredListHead>
+        <StructuredListBody>
+          {pagedUploads.map((item, i) => (
+            <StructuredListRow key={`${item.uploadId}-${String(i)}`}>
+              <StructuredListCell>{item.fileName}</StructuredListCell>
+              <StructuredListCell>
+                <span style={{ fontWeight: 600, color: 'var(--cds-support-success)' }}>
+                  #{item.uploadId}
+                </span>
+              </StructuredListCell>
+              <StructuredListCell>{item.uploadedAt.toLocaleString()}</StructuredListCell>
+            </StructuredListRow>
+          ))}
+        </StructuredListBody>
+      </StructuredListWrapper>
+      <Pagination
+        totalItems={recentUploads.length}
+        pageSize={uploadsPageSize}
+        pageSizes={[10, 25, 50]}
+        page={uploadsPage}
+        onChange={({ page, pageSize }) => {
+          setUploadsPage(page);
+          setUploadsPageSize(pageSize);
+        }}
+        size="sm"
+      />
+    </div>
+  ) : null;
+
+  if (!views || views.length === 0) return (
+    <>
+      <div style={{ marginBottom: 'var(--cds-spacing-05)' }}>{uploadButton}</div>
+      {recentUploadsList}
+      <p>No views configured</p>
+      {uploadModal}
+    </>
+  );
 
   const dropdownItems = views.map((v: View) => ({
     id: String(v.id),
@@ -117,6 +199,7 @@ export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: numb
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'flex-end', gap: 'var(--cds-spacing-03)', marginBottom: 'var(--cds-spacing-05)' }}>
+        {uploadButton}
         <div style={{ maxWidth: '300px', flex: 1 }}>
           <Dropdown
             id="view-selector"
@@ -150,6 +233,7 @@ export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: numb
           New View
         </Button>
       </div>
+      {recentUploadsList}
       {selectedView && (!selectedView.components || selectedView.components.length === 0) && (
         <p style={{ opacity: 0.7 }}>
           This view has no columns configured. Click <strong>Configure</strong> to select which nodes to display.
@@ -174,6 +258,7 @@ export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: numb
           />
         </Suspense>
       </ErrorBoundary>
+      {uploadModal}
     </div>
   );
 };

--- a/src/main/webui/src/app/components/UploadDataModal.css
+++ b/src/main/webui/src/app/components/UploadDataModal.css
@@ -1,0 +1,21 @@
+.upload-drop-zone {
+  display: flex;
+  justify-content: center;
+}
+
+.upload-file-list {
+  border-top: 1px solid var(--cds-border-subtle-01);
+  padding-top: var(--cds-spacing-04);
+  margin-top: var(--cds-spacing-05);
+}
+
+.upload-file-list__count {
+  margin: 0 0 var(--cds-spacing-03);
+  font-size: 0.75rem;
+  color: var(--cds-text-secondary);
+}
+
+.upload-paste-json {
+  font-family: var(--cds-code-01-font-family, monospace);
+  font-size: 0.8125rem;
+}

--- a/src/main/webui/src/app/components/UploadDataModal.tsx
+++ b/src/main/webui/src/app/components/UploadDataModal.tsx
@@ -1,0 +1,266 @@
+import {
+  Button,
+  ComposedModal,
+  FileUploaderDropContainer,
+  FileUploaderItem,
+  InlineLoading,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  TextArea,
+  TextInput,
+} from '@carbon/react';
+import type { UploadData } from '@client/types.gen.ts';
+import { uploadMutation } from '@client/@tanstack/react-query.gen.ts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
+import { useNotification } from '@app/context/useNotification.tsx';
+import './UploadDataModal.css';
+
+interface UploadDataModalProps {
+  open: boolean;
+  onClose: () => void;
+  folderId: number;
+  onUploadSuccess: (fileName: string, uploadId: number) => void;
+}
+
+const TAB_FILE = 0;
+const TAB_FOLDER = 1;
+const TAB_PASTE = 2;
+const TAB_URL = 3;
+
+type FileStatus = 'pending' | 'success' | 'error';
+
+export const UploadDataModal = ({ open, onClose, folderId, onUploadSuccess }: UploadDataModalProps) => {
+  const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState(TAB_FILE);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+  const [currentStatus, setCurrentStatus] = useState<FileStatus | null>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const [pasteText, setPasteText] = useState('');
+  const [pasteError, setPasteError] = useState<string | null>(null);
+  const [urlInput, setUrlInput] = useState('');
+  const [urlError, setUrlError] = useState<string | null>(null);
+
+  const notifications = useNotification();
+  const upload = useMutation(uploadMutation());
+
+  const isUploading = currentStatus === 'pending';
+
+  function addFiles(incoming: File[]) {
+    const jsonFiles = incoming.filter((f) => f.name.endsWith('.json'));
+    if (jsonFiles.length === 0) {
+      notifications.warning('No .json files found.');
+      return;
+    }
+    setSelectedFiles((prev) => {
+      const existingNames = new Set(prev.map((f) => f.name));
+      const newFiles = jsonFiles.filter((f) => !existingNames.has(f.name));
+      return [...prev, ...newFiles];
+    });
+  }
+
+  function handleClose() {
+    setActiveTab(TAB_FILE);
+    setSelectedFiles([]);
+    setCurrentIndex(null);
+    setCurrentStatus(null);
+    setPasteText('');
+    setPasteError(null);
+    setUrlInput('');
+    setUrlError(null);
+    upload.reset();
+    onClose();
+  }
+
+  async function handleUpload() {
+    const items: Array<{ label: string; body: UploadData['body'] }> = [];
+
+    if (activeTab === TAB_FILE || activeTab === TAB_FOLDER) {
+      for (const file of selectedFiles) items.push({ label: file.name, body: { file } });
+    } else if (activeTab === TAB_PASTE && pasteError === null) {
+      const label = pasteText.trim().substring(0, 50) + (pasteText.trim().length >= 50 ? '...' : '');
+      items.push({ label, body: { raw: pasteText.trim() } });
+    } else if (activeTab === TAB_URL) {
+      items.push({ label: urlInput.trim(), body: { url: urlInput.trim() } });
+    }
+
+    if (items.length === 0) return;
+
+    let successCount = 0;
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]!;
+      setCurrentIndex(i);
+      setCurrentStatus('pending');
+
+      try {
+        const uploadId = await upload.mutateAsync({ path: { id: folderId }, body: item.body });
+        void queryClient.invalidateQueries();
+        onUploadSuccess(item.label, uploadId);
+        setCurrentStatus('success');
+        successCount++;
+      } catch (e: unknown) {
+        setCurrentStatus('error');
+        notifications.handleError(item.label, e);
+      }
+    }
+
+    if (successCount > 0) {
+      notifications.success(
+        items.length > 1
+          ? `${successCount} file${successCount > 1 ? 's' : ''} uploaded successfully`
+          : `'${items[0]!.label}' uploaded successfully`
+      );
+      setTimeout(handleClose, 500);
+    }
+  }
+
+  function fileUpload() {
+    if (selectedFiles.length === 0) return null;
+    return (
+      <div className="upload-file-list">
+        <p className="upload-file-list__count">
+          {selectedFiles.length} file{selectedFiles.length > 1 ? 's' : ''} selected
+        </p>
+        {selectedFiles.map((file, idx) => (
+          <FileUploaderItem
+            key={`${file.name}-${idx}`}
+            name={file.name}
+            status={
+              idx === currentIndex
+                ? currentStatus === 'pending' ? 'uploading' : 'complete'
+                : idx < (currentIndex ?? -1) ? 'complete' : 'edit'
+            }
+            invalid={idx === currentIndex && currentStatus === 'error'}
+            errorSubject="Upload failed"
+            onDelete={() => setSelectedFiles((prev) => prev.filter((_, i) => i !== idx))}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const canUpload =
+    !isUploading &&
+    !upload.isPending &&
+    (activeTab === TAB_FILE || activeTab === TAB_FOLDER
+      ? selectedFiles.length > 0 && currentIndex === null
+      : activeTab === TAB_PASTE
+        ? pasteText.trim().length > 0 && pasteError === null
+        : urlInput.trim().length > 0 && urlError === null);
+
+  return (
+    <ComposedModal open={open} onClose={handleClose} size="md">
+      <ModalHeader title="Upload data" />
+      <ModalBody>
+        <Tabs selectedIndex={activeTab} onChange={({ selectedIndex }) => {
+          setActiveTab(selectedIndex);
+        }}>
+          <TabList aria-label="Upload mode">
+            <Tab>File Upload</Tab>
+            <Tab>Folder Upload</Tab>
+            <Tab>Paste JSON</Tab>
+            <Tab>URL</Tab>
+          </TabList>
+          <TabPanels>
+
+            <TabPanel>
+              <div className="upload-drop-zone">
+                <FileUploaderDropContainer
+                  accept={['.json', 'application/json']}
+                  labelText="Drag and drop files here or click to upload (.json only)"
+                  multiple
+                  disabled={isUploading}
+                  onAddFiles={(_e, { addedFiles }) => addFiles(addedFiles)}
+                />
+              </div>
+              {fileUpload()}
+            </TabPanel>
+
+            <TabPanel>
+              <div className="upload-drop-zone">
+                <Button
+                  kind="tertiary"
+                  disabled={isUploading}
+                  onClick={() => folderInputRef.current?.click()}
+                >
+                  Choose a folder (all .json files inside)
+                </Button>
+                <input
+                  ref={folderInputRef}
+                  type="file"
+                  // @ts-expect-error — webkitdirectory is not in React's HTMLInputElement types
+                  webkitdirectory=""
+                  hidden
+                  onChange={(e) => { addFiles(Array.from(e.target.files ?? [])); e.target.value = ''; }}
+                />
+              </div>
+              {fileUpload()}
+            </TabPanel>
+
+            <TabPanel>
+              <TextArea
+                id="paste-json"
+                className="upload-paste-json"
+                labelText="Paste JSON content"
+                placeholder='{ "key": "value" }'
+                value={pasteText}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setPasteText(val);
+                  try { JSON.parse(val); setPasteError(null); }
+                  catch { setPasteError('Invalid JSON — Please check the pasted content'); }
+                }}
+                rows={10}
+                invalid={pasteError !== null}
+                invalidText={pasteError ?? ''}
+              />
+            </TabPanel>
+
+            <TabPanel>
+              <TextInput
+                id="url-input"
+                labelText="URL"
+                placeholder="https://example.com/data.json"
+                value={urlInput}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  setUrlInput(val);
+                  if (val.trim().length === 0) { setUrlError(null); }
+                  else if (!val.trim().startsWith('http://') && !val.trim().startsWith('https://')) {
+                    setUrlError('URL must start with http:// or https://');
+                  } else { setUrlError(null); }
+                }}
+                invalid={urlError !== null}
+                invalidText={urlError ?? ''}
+              />
+            </TabPanel>
+
+          </TabPanels>
+        </Tabs>
+
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={handleClose}>
+          {currentIndex !== null && !isUploading ? 'Close' : 'Cancel'}
+        </Button>
+        <Button
+          kind="primary"
+          onClick={() => { void handleUpload(); }}
+          disabled={!canUpload}
+        >
+          {isUploading || upload.isPending
+            ? <InlineLoading description="Uploading…" status="active" />
+            : 'Upload'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -27,6 +27,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+
 @QuarkusTest
 public class RestEndpointTest extends FreshDb {
 
@@ -172,9 +173,7 @@ public class RestEndpointTest extends FreshDb {
         long folderId = createFolder("upload-test");
 
         given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .queryParam("path", "results.json")
-                .body("{\"key\": \"value\"}")
+                .multiPart("raw", "{\"key\": \"value\"}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200);
@@ -436,9 +435,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Upload data via REST
         given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .queryParam("path", "$")
-                .body("{\"key\": \"hello\"}")
+                .multiPart("raw", "{\"key\": \"hello\"}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200);
@@ -958,13 +955,11 @@ public class RestEndpointTest extends FreshDb {
         Long throughputId=createNode(groupId, "throughput", ".throughput");
         Long buildId= createNode(groupId, "build_id", ".build_id");
 
-        given().contentType(MediaType.APPLICATION_JSON)
-                .body("{\"throughput\": 115, \"build_id\": 201}")
+        given().multiPart("raw", "{\"throughput\": 115, \"build_id\": 201}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then().statusCode(200);
 
-        given().contentType(MediaType.APPLICATION_JSON)
-                .body("{\"throughput\": 100, \"build_id\": 202}")
+        given().multiPart("raw", "{\"throughput\": 100, \"build_id\": 202}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then().statusCode(200);
 
@@ -1002,8 +997,7 @@ public class RestEndpointTest extends FreshDb {
         long folderId = createFolder("upload-id-test");
 
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"cpu\": 95}")
+                .multiPart("raw", "{\"cpu\": 95}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1025,7 +1019,7 @@ public class RestEndpointTest extends FreshDb {
     public void FolderUpload_empty_body_returns_error() {
         long folderId = createFolder("test-empty");
         given()
-                .contentType(MediaType.APPLICATION_JSON)
+                .multiPart("raw", "")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(400);
@@ -1035,10 +1029,10 @@ public class RestEndpointTest extends FreshDb {
     public void FolderUpload_tracking_record_created() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
         long folderId = createFolder("test-tracking");
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"cpu\": 95}")
+                .multiPart("raw", "{\"cpu\": 95}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
+                .statusCode(200)
                 .extract().as(Long.class);
 
         tm.begin();
@@ -1052,11 +1046,10 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void Upload_nonExistingFolder_returns_error() {
         given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"cpu\": 95}")
+                .multiPart("raw", "{\"cpu\": 95}")
                 .when().post("/api/folder/999999/upload")
                 .then()
-                .statusCode(500);
+                .statusCode(400);
     }
 
     @Test
@@ -1064,16 +1057,14 @@ public class RestEndpointTest extends FreshDb {
         long folderId = createFolder("upload-unique-ids-test");
 
         Long uploadId1 = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"cpu\": 95}")
+                .multiPart("raw", "{\"cpu\": 95}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
                 .extract().as(Long.class);
 
         Long uploadId2 = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"cpu\": 99}")
+                .multiPart("raw", "{\"cpu\": 99}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1089,8 +1080,7 @@ public class RestEndpointTest extends FreshDb {
         long folderId = createFolder("upload-status-empty");
 
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"value\": 42}")
+                .multiPart("raw", "{\"value\": 42}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1120,8 +1110,7 @@ public class RestEndpointTest extends FreshDb {
         createNode(groupId, "extract", ".value");
 
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"value\": 42}")
+                .multiPart("raw", "{\"value\": 42}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1168,8 +1157,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Upload data via REST with value=5 — below min=10, should trigger a threshold violation
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"value\": 5, \"env\": {\"type\": \"perf-test\"}}")
+                .multiPart("raw", "{\"value\": 5, \"env\": {\"type\": \"perf-test\"}}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1213,8 +1201,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Upload data via REST with value=50 — within [10, 100], no violation expected
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"value\": 50, \"env\": {\"type\": \"perf-test\"}}")
+                .multiPart("raw", "{\"value\": 50, \"env\": {\"type\": \"perf-test\"}}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
@@ -1261,8 +1248,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Upload data with value=5 — below min=10, triggers a violation
         Long uploadId = given()
-                .contentType(MediaType.APPLICATION_JSON)
-                .body("{\"value\": 5, \"env\": {\"type\": \"perf-test\"}}")
+                .multiPart("raw", "{\"value\": 5, \"env\": {\"type\": \"perf-test\"}}")
                 .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
**Problem statement**
The h5m web UI lacked the ability for users to upload JSON data to folders directly from the browser. Added Upload data functionality in the UI.

**Description**
Added a new upload modal to the folder view supporting multiple input modes -  file upload, raw JSON paste, and remote URL. Integrated the application-wide toast notification system for consistent user feedback across all upload outcomes and corrected failing REST endpoint tests to align with the current API contract. 

