### PR TITLE
Fix ephemeral nullification: protect fingerprint source nodes (issue …

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ProcessingService.java
@@ -417,28 +417,29 @@ public class ProcessingService {
      * <ul>
      *   <li>KEEP — never ephemeral</li>
      *   <li>DISCARD — always ephemeral</li>
-     *   <li>AUTO — ephemeral only if the node has non-detection children
-     *       and is not itself a direct source of a detection node</li>
+      *   <li>AUTO — ephemeral only if the node has non-analysis children
+     *       and is not itself a direct source of an analysis node</li>
      * </ul>
      * Uses the already-loaded group nodes to check graph structure in-memory.
+     * Must match the logic in {@link ValueService#nullifyEphemeralData(long)}.
      */
     private boolean isEphemeral(NodeEntity node, List<NodeEntity> allGroupNodes) {
         if (node.ephemeral == EphemeralMode.KEEP) return false;
         if (node.ephemeral == EphemeralMode.DISCARD) return true;
         // AUTO: check graph structure to determine if data was nullified
-        boolean hasNonDetectionChild = false;
-        boolean isDetectionSource = false;
+        boolean hasNonAnalysisChild = false;
+        boolean isAnalysisSource = false;
         for (NodeEntity other : allGroupNodes) {
             if (other.sources != null && other.sources.stream()
                     .anyMatch(s -> s.getId().equals(node.getId()))) {
-                if (other.type().isDetection()) {
-                    isDetectionSource = true;
+                if (other.type().isAnalysis()) {
+                    isAnalysisSource = true;
                 } else {
-                    hasNonDetectionChild = true;
+                    hasNonAnalysisChild = true;
                 }
             }
         }
-        return hasNonDetectionChild && !isDetectionSource;
+        return hasNonAnalysisChild && !isAnalysisSource;
     }
 
     public void deleteForFolder(long folderId) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -844,22 +844,22 @@ public class ValueService implements ValueServiceInterface {
             WHERE id IN (SELECT v_id FROM descendants)
               AND node_id IN (
                 SELECT id FROM node WHERE
-                  (ephemeral = 'DISCARD'
-                   OR (ephemeral = 'AUTO' AND EXISTS (
-                     SELECT 1 FROM node_edge ne
-                     JOIN node child ON child.id = ne.child_id
-                     WHERE ne.parent_id = node.id
-                       AND child.type NOT IN ('ft', 'rd', 'sd', 'ed')
-                   )))
-                  AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
-                  -- Protect nodes that are sources of detection nodes.
-                  -- Range, domain, and fingerprint nodes need their data
-                  -- for historical change detection queries.
+                   (ephemeral = 'DISCARD'
+                    OR (ephemeral = 'AUTO' AND EXISTS (
+                      SELECT 1 FROM node_edge ne
+                      JOIN node child ON child.id = ne.child_id
+                      WHERE ne.parent_id = node.id
+                        AND child.type NOT IN ('ft', 'rd', 'sd', 'ed', 'fp')
+                    )))
+                  AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed', 'fp')
+                  -- Protect nodes that are sources of analysis nodes.
+                  -- Range, domain, and fingerprint source nodes need their
+                  -- data for historical change detection queries.
                   AND NOT EXISTS (
                     SELECT 1 FROM node_edge ne2
                     JOIN node det ON det.id = ne2.child_id
                     WHERE ne2.parent_id = node.id
-                      AND det.type IN ('ft', 'rd', 'sd', 'ed')
+                      AND det.type IN ('ft', 'rd', 'sd', 'ed', 'fp')
                   )
               )
               AND data IS NOT NULL
@@ -884,12 +884,12 @@ public class ValueService implements ValueServiceInterface {
             UPDATE node SET ephemeral = 'DISCARD'
             WHERE group_id = :groupId
               AND ephemeral = 'AUTO'
-              AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed')
+              AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed', 'fp')
               AND EXISTS (
                 SELECT 1 FROM node_edge ne
                 JOIN node child ON child.id = ne.child_id
                 WHERE ne.parent_id = node.id
-                  AND child.type NOT IN ('ft', 'rd', 'sd', 'ed')
+                  AND child.type NOT IN ('ft', 'rd', 'sd', 'ed', 'fp')
               )
             """)
             .setParameter("groupId", groupId)


### PR DESCRIPTION
…#236)

The ephemeral nullification logic in nullifyEphemeralData() and markAutoEphemeral() used a detection-only type list ('ft','rd','sd','ed') that excluded fingerprint nodes ('fp'). This caused nodes like fwName (source of a fingerprint node) to have their data incorrectly nullified after upload processing.

NodeService.isEphemeral() correctly used the full ANALYSIS_NODES set which includes 'fp', but the three other ephemeral checks were inconsistent:

- ValueService.nullifyEphemeralData(): add 'fp' to both the 'has non-analysis children' check and the 'protect sources of analysis nodes' check
- ValueService.markAutoEphemeral(): add 'fp' to the type exclusion list
- ProcessingService.isEphemeral(): use isAnalysis() instead of isDetection() so fingerprint nodes are treated as analysis nodes

All four ephemeral checks now consistently use the analysis node set (ed, fp, ft, rd, sd), matching NodeType.isAnalysis().