### PR TITLE
unify node type checking in sql

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -152,11 +152,11 @@ public class FolderService implements FolderServiceInterface {
             JOIN node r ON r.id = g.root_id
             LEFT JOIN value rv ON rv.node_id = r.id
             LEFT JOIN node n ON n.group_id = g.id AND n.id != r.id
-            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN ('ft', 'rd', 'sd', 'ed')
+            LEFT JOIN node dn ON dn.group_id = g.id AND dn.type IN DETECTION_NODES
             LEFT JOIN value dv ON dv.node_id = dn.id
             GROUP BY f.id, f.name
             ORDER BY f.name
-            """).getResultList();
+            """.replaceAll("DETECTION_NODES", NodeService.DETECTION_NODES)).getResultList();
 
         List<FolderSummary> summaries = new ArrayList<>();
         for (Object[] row : rows) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -47,7 +47,10 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class NodeService implements NodeServiceInterface {
 
-    private static final String ANALYSIS_NODES = "("+Arrays.stream(NodeType.values()).filter(NodeType::isAnalysis).map(t->"'"+t.display()+"'").collect(Collectors.joining(","))+")";
+    public static final String DETECTION_NODES ="("+Arrays.stream(NodeType.values()).filter(NodeType::isDetection).map(t->"'"+t.display()+"'").collect(Collectors.joining(","))+")";
+    public static final String ANALYSIS_NODES = "("+Arrays.stream(NodeType.values()).filter(NodeType::isAnalysis).map(t->"'"+t.display()+"'").collect(Collectors.joining(","))+")";
+    public static final String ROOT_OR_ANALYSIS_NODES = "('root',"+Arrays.stream(NodeType.values()).filter(NodeType::isAnalysis).map(t->"'"+t.display()+"'").collect(Collectors.joining(","))+")";
+
 
     private static final ConcurrentHashMap<String, JqProgram> JQ_CACHE = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, JqProgram> JSONATA_CACHE = new ConcurrentHashMap<>();
@@ -276,7 +279,7 @@ public class NodeService implements NodeServiceInterface {
             select exists(
                 select 1
                     from node n
-                    where n.id = :node_id and n.type != 'root' and n.type NOT IN ANALYSIS_NODES and (n.ephemeral = 'DISCARD' OR (
+                    where n.id = :node_id and n.type NOT IN ROOT_OR_ANALYSIS_NODES and (n.ephemeral = 'DISCARD' OR (
                         n.ephemeral = 'AUTO' and
                         EXISTS (
                             select 1
@@ -285,7 +288,11 @@ public class NodeService implements NodeServiceInterface {
                         )
                     ))
              )
-            """.replaceAll("ANALYSIS_NODES",ANALYSIS_NODES),Boolean.class).setParameter("node_id",node.id).getSingleResult();
+            """.replaceAll("ROOT_OR_ANALYSIS_NODES",ROOT_OR_ANALYSIS_NODES)
+                .replaceAll("ANALYSIS_NODES",ANALYSIS_NODES
+        ),Boolean.class)
+            .setParameter("node_id",node.id)
+            .getSingleResult();
         return result !=null && result;
     }
 

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ValueService.java
@@ -849,9 +849,9 @@ public class ValueService implements ValueServiceInterface {
                       SELECT 1 FROM node_edge ne
                       JOIN node child ON child.id = ne.child_id
                       WHERE ne.parent_id = node.id
-                        AND child.type NOT IN ('ft', 'rd', 'sd', 'ed', 'fp')
+                        AND child.type NOT IN ANALYSIS_NODES
                     )))
-                  AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed', 'fp')
+                  AND type NOT IN ROOT_OR_ANALYSIS_NODES
                   -- Protect nodes that are sources of analysis nodes.
                   -- Range, domain, and fingerprint source nodes need their
                   -- data for historical change detection queries.
@@ -859,11 +859,13 @@ public class ValueService implements ValueServiceInterface {
                     SELECT 1 FROM node_edge ne2
                     JOIN node det ON det.id = ne2.child_id
                     WHERE ne2.parent_id = node.id
-                      AND det.type IN ('ft', 'rd', 'sd', 'ed', 'fp')
+                      AND det.type IN ANALYSIS_NODES
                   )
               )
               AND data IS NOT NULL
-            """)
+            """.replaceAll("ROOT_OR_ANALYSIS_NODES",NodeService.ROOT_OR_ANALYSIS_NODES)
+                .replaceAll("ANALYSIS_NODES",NodeService.ANALYSIS_NODES)
+            )
             .setParameter("rootId", rootValueId)
             .executeUpdate();
     }
@@ -884,14 +886,15 @@ public class ValueService implements ValueServiceInterface {
             UPDATE node SET ephemeral = 'DISCARD'
             WHERE group_id = :groupId
               AND ephemeral = 'AUTO'
-              AND type NOT IN ('root', 'ft', 'rd', 'sd', 'ed', 'fp')
+              AND type NOT IN ROOT_OR_ANALYSIS_NODES
               AND EXISTS (
                 SELECT 1 FROM node_edge ne
                 JOIN node child ON child.id = ne.child_id
                 WHERE ne.parent_id = node.id
-                  AND child.type NOT IN ('ft', 'rd', 'sd', 'ed', 'fp')
+                  AND child.type NOT IN ANALYSIS_NODES
               )
-            """)
+            """.replaceAll("ROOT_OR_ANALYSIS_NODES",NodeService.ROOT_OR_ANALYSIS_NODES)
+                        .replaceAll("ANALYSIS_NODES",NodeService.ANALYSIS_NODES))
             .setParameter("groupId", groupId)
             .executeUpdate();
     }


### PR DESCRIPTION
There are a few places where the type of the node is checked in sql with static strings that have to be manually kept synchronized and up to date. Those checks are changed to use a variable in NodeService that computes the correct value based on NodeType.