### PR TITLE
Use resource IDs in REST paths and return full entities from create operations

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/FolderServiceInterface.java
@@ -29,7 +29,7 @@ public interface FolderServiceInterface {
      * @param name The name of the folder.
      * @return The folder with the given name.
      */
-    Folder byName(String name);
+    Folder find(String name);
 
     /**
      * Gets the upload count for all folders.
@@ -42,29 +42,28 @@ public interface FolderServiceInterface {
      * Creates a new folder with the given name.
      *
      * @param name The name of the folder to create.
-     * @return The ID of the created folder.
+     * @return The created folder.
      */
-    long create(String name);
+    Folder create(String name);
 
     /**
-     * Deletes a folder by its name.
+     * Deletes a folder by its ID.
      *
-     * @param name The name of the folder to delete.
-     * @return The ID of the deleted folder.
+     * @param id The ID of the folder to delete.
      */
-    long delete(String name);
+    void delete(long id);
 
     /**
-     * Uploads data to a specific path within a folder.
+     * Uploads data to a folder.
      * Returns immediately with an {@link Upload} containing the upload ID and a future
      * that completes when all processing finishes.
      *
-     * @param name The name of the folder.
+     * @param folderId The ID of the folder.
      * @param data The JSON data to upload.
      * @return an Upload with the upload ID (safe to return to callers) and
      *         a future (for callers that need to await completion).
      */
-    Upload upload(String name, JqValue data);
+    Upload upload(long folderId, JqValue data);
 
     /**
      * Selectively recalculates values for a specific node and its dependents.
@@ -77,10 +76,10 @@ public interface FolderServiceInterface {
     /**
      * Retrieves the structural representation of a folder.
      *
-     * @param name The name of the folder.
+     * @param folderId The ID of the folder.
      * @return The JSON representation of the folder's structure.
      */
-    JqValue structure(String name);
+    JqValue structure(long folderId);
 
     /**
      * Retrieves dashboard summaries for all folders.
@@ -92,18 +91,18 @@ public interface FolderServiceInterface {
     /**
      * Exports a folder's node graph to a JSON file.
      *
-     * @param folderName The folder to export.
+     * @param folderId The folder ID.
      * @param outputPath Path to write the JSON file.
      */
-    void export(String folderName, Path outputPath) throws IOException;
+    void export(long folderId, Path outputPath) throws IOException;
 
     /**
      * Imports a folder and its node graph from a JSON file.
      *
      * @param inputPath Path to the JSON file.
      * @param overwrite If true, delete existing folder before importing.
-     * @return The folder name that was imported.
+     * @return The imported folder.
      */
-    String importFolder(Path inputPath, boolean overwrite) throws IOException;
+    Folder importFolder(Path inputPath, boolean overwrite) throws IOException;
 
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeGroupServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeGroupServiceInterface.java
@@ -21,7 +21,7 @@ public interface NodeGroupServiceInterface {
      * @param groupName The name of the node group.
      * @return The node group with the given name.
      */
-    NodeGroup byName(String groupName);
+    NodeGroup find(String groupName);
 
     /**
      * Deletes a node group by its ID.

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeServiceInterface.java
@@ -17,9 +17,9 @@ public interface NodeServiceInterface {
      * @param groupId   The ID of the group the node belongs to.
      * @param type      The type of the node.
      * @param operation The operation associated with the node.
-     * @return The ID of the created node.
+     * @return The created node.
      */
-    Long create(String name, Long groupId, NodeType type, String operation);
+    Node create(String name, Long groupId, NodeType type, String operation);
 
     /**
      * Creates a new node with sources and configuration.
@@ -29,10 +29,10 @@ public interface NodeServiceInterface {
      * @param type          The type of the node.
      * @param sources       A list of source node IDs.
      * @param configuration The configuration object for the node.
-     * @return The ID of the created node.
+     * @return The created node.
      * @throws IllegalArgumentException If the configuration is invalid for the given node type.
      */
-    Long createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration);
+    Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration);
 
     /**
      * Deletes a node by its ID.

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
@@ -10,7 +10,7 @@ public interface TeamServiceInterface {
 
     void delete(long teamId);
 
-    Team byName(String name);
+    Team find(String name);
 
     List<Team> list();
 

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/ViewServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/ViewServiceInterface.java
@@ -13,10 +13,10 @@ public interface ViewServiceInterface {
     /**
      * Lists all views for a folder.
      *
-     * @param folderName The folder name.
+     * @param folderId The folder ID.
      * @return A list of views for the folder.
      */
-    List<View> getViews(String folderName);
+    List<View> getViews(long folderId);
 
     /**
      * Gets a single view by ID.
@@ -29,11 +29,11 @@ public interface ViewServiceInterface {
     /**
      * Creates a new view for a folder.
      *
-     * @param folderName The folder name.
+     * @param folderId The folder ID.
      * @param view The view to create.
      * @return The created view with generated ID.
      */
-    View createView(String folderName, View view);
+    View createView(long folderId, View view);
 
     /**
      * Updates an existing view.
@@ -55,9 +55,9 @@ public interface ViewServiceInterface {
      * Gets the filtered pivoted data for a view.
      * Returns one row per upload with only the nodes referenced by the view's components.
      *
-     * @param folderName The folder name.
+     * @param folderId The folder ID.
      * @param viewId The view ID.
      * @return A list of JSON objects, one per upload.
      */
-    List<JqValue> getViewData(String folderName, Long viewId);
+    List<JqValue> getViewData(long folderId, Long viewId);
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
@@ -72,7 +72,7 @@ public class AddEDivisive implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if (foundGroup == null) {
             System.err.println("node group with name " + groupName + " does not exist");
             return 1;
@@ -140,7 +140,7 @@ public class AddEDivisive implements Callable<Integer> {
             }
         }
 
-        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null).id();
         List<Long> sources = List.of(fingerprintId, groupByNode.id(), rangeNode.id(), domainNode.id());
         nodeService.createConfigured(name, foundGroup.id(), NodeType.EDIVISIVE, sources,
                 new EDivisiveConfig(windowLen, maxPvalue, minMagnitude, maxSeriesLength, fingerprintFilter));

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
@@ -62,7 +62,7 @@ public class AddFixedThreshold implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if (foundGroup == null) {
             System.err.println("node group with name " + groupName + " does not exist");
             return 1;
@@ -119,7 +119,7 @@ public class AddFixedThreshold implements Callable<Integer> {
             }
         }
 
-        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null).id();
         nodeService.createConfigured(name, foundGroup.id(), NodeType.FIXED_THRESHOLD, List.of(fingerprintId, groupByNode.id(), rangeNode.id()), new FixedThresholdConfig(min, max, minInclusive, maxInclusive, fingerprintFilter));
 
         return 0;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddFolder.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddFolder.java
@@ -28,7 +28,7 @@ public class AddFolder implements Callable<Integer> {
             System.out.printf("Enter name: ");
             name = sc.nextLine();
         }
-        NodeGroup existingGroup =  nodeGroupService.byName(name);
+        NodeGroup existingGroup =  nodeGroupService.find(name);
         if(existingGroup != null){
             System.err.println(name+" conflicts with an existing node group");
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddJq.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddJq.java
@@ -38,7 +38,7 @@ public class AddJq implements Callable<Integer> {
                 System.out.printf("Enter target group / folder name: ");
                 groupName = sc.nextLine();
             }
-            foundGroup =  nodeGroupService.byName(groupName);
+            foundGroup =  nodeGroupService.find(groupName);
             if(foundGroup == null){
                 System.err.println("could not find "+groupName);
                 groupName = null;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddJs.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddJs.java
@@ -55,7 +55,7 @@ public class AddJs implements Callable<Integer> {
             return 1;
         }
 
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if(foundGroup == null){
             System.err.println("unable to find group: "+groupName);
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddJsonata.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddJsonata.java
@@ -60,7 +60,7 @@ public class AddJsonata implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup =  nodeGroupService.byName(groupName);
+        NodeGroup foundGroup =  nodeGroupService.find(groupName);
         if(foundGroup == null){
             System.err.println("group not found");
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddNotification.java
@@ -41,7 +41,7 @@ public class AddNotification implements Callable<Integer> {
     @Override
     @Transactional
     public Integer call() throws Exception {
-        Folder folder = folderService.byName(folderName);
+        Folder folder = folderService.find(folderName);
         if (folder == null) {
             System.err.println("Folder not found: " + folderName);
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
@@ -59,7 +59,7 @@ public class AddRelativeDifference implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if(foundGroup==null){
             System.err.println("node group with name "+groupName+" does not exist");
             return 1;
@@ -129,7 +129,7 @@ public class AddRelativeDifference implements Callable<Integer> {
             }
         }
 
-        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null).id();
         List<Long> sources = domainNode == null ? List.of(fingerprintId, groupByNode.id(), rangeNode.id()) : List.of(fingerprintId, groupByNode.id(), rangeNode.id(), domainNode.id());
         nodeService.createConfigured(name, foundGroup.id(), NodeType.RELATIVE_DIFFERENCE, sources, new RelativeDifferenceConfig(filter, threshold, window, minPrevious, fingerprintFilter));
 

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddSplit.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddSplit.java
@@ -32,7 +32,7 @@ public class AddSplit  implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if(foundGroup == null){
             System.err.println("could not find target group/test "+groupName);
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
@@ -70,7 +70,7 @@ public class AddStdDevAnomaly implements Callable<Integer> {
             System.err.println("missing group name");
             return 1;
         }
-        NodeGroup foundGroup = nodeGroupService.byName(groupName);
+        NodeGroup foundGroup = nodeGroupService.find(groupName);
         if (foundGroup == null) {
             System.err.println("node group with name " + groupName + " does not exist");
             return 1;
@@ -140,7 +140,7 @@ public class AddStdDevAnomaly implements Callable<Integer> {
             }
         }
 
-        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null);
+        Long fingerprintId = nodeService.createConfigured("_fp-" + name, foundGroup.id(), NodeType.FINGERPRINT, fingerprintNodes, null).id();
         List<Long> sources = domainNode == null
                 ? List.of(fingerprintId, groupByNode.id(), rangeNode.id())
                 : List.of(fingerprintId, groupByNode.id(), rangeNode.id(), domainNode.id());

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminAddMember.java
@@ -31,7 +31,7 @@ public class AdminAddMember implements Callable<Integer> {
             System.err.println("User not found: " + username);
             return 1;
         }
-        Team team = teamService.byName(teamName);
+        Team team = teamService.find(teamName);
         if (team == null) {
             System.err.println("Team not found: " + teamName);
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ExportFolder.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ExportFolder.java
@@ -28,7 +28,12 @@ public class ExportFolder implements Callable<Integer> {
             : Path.of(folderName + ".json");
 
         try {
-            folderService.export(folderName, path);
+            var folder = folderService.find(folderName);
+            if (folder == null) {
+                System.err.println("Folder not found: " + folderName);
+                return 1;
+            }
+            folderService.export(folder.id(), path);
             System.out.println("Exported folder '" + folderName + "' to " + path);
             return 0;
         } catch (Exception e) {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/H5m.java
@@ -67,13 +67,13 @@ public class H5m implements QuarkusApplication {
 
     @CommandLine.Command(name="structure",description = "use yaup to compute the structure of a folder",aliases = {"shape"}, mixinStandardHelpOptions = true)
     public int structure(String folderName){
-        try {
-            JqValue structure = folderService.structure(folderName);
-            System.out.println(JqValues.toPrettyJsonString(structure));
-        } catch (NoResultException e) {
+        Folder folder = folderService.find(folderName);
+        if (folder == null) {
             System.err.println("could not find folder "+folderName);
             return 1;
         }
+        JqValue structure = folderService.structure(folder.id());
+        System.out.println(JqValues.toPrettyJsonString(structure));
         return 0;
     }
     @CommandLine.Command(name="upload",description = "")
@@ -83,7 +83,7 @@ public class H5m implements QuarkusApplication {
             @CommandLine.Option(names = {"to"},description = "grouping node" ,arity = "1")
             String folderName
     ){
-        Folder folder = folderService.byName(folderName);
+        Folder folder = folderService.find(folderName);
         if(folder == null){
             System.err.println("could not find folder "+folderName);
             return 1;
@@ -102,7 +102,7 @@ public class H5m implements QuarkusApplication {
                 JqValue read = JqValues.parse(Files.readString(f.toPath()));
                 if(read!=null){
                     try {
-                        Upload upload = folderService.upload(folderName, read);
+                        Upload upload = folderService.upload(folder.id(), read);
                         upload.future.orTimeout(5, TimeUnit.MINUTES).join();
                     } catch (NoResultException e) {
                         System.err.println("could not find folder " + folderName);

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ImportFolder.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ImportFolder.java
@@ -31,8 +31,8 @@ public class ImportFolder implements Callable<Integer> {
         }
 
         try {
-            String folderName = folderService.importFolder(path, overwrite);
-            System.out.println("Imported folder '" + folderName + "' from " + path);
+            var folder = folderService.importFolder(path, overwrite);
+            System.out.println("Imported folder '" + folder.name() + "' from " + path);
             return 0;
         } catch (Exception e) {
             System.err.println("Import failed: " + e.getMessage());

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ListNode.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ListNode.java
@@ -41,7 +41,7 @@ public class ListNode implements Callable<Integer> {
             cmd.usage(System.err);
             return 1;
         }
-        NodeGroup nodeGroup = nodeGroupService.byName(groupName);
+        NodeGroup nodeGroup = nodeGroupService.find(groupName);
         if(nodeGroup == null){
             System.err.println("NodeEntity group "+groupName+" not found");
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ListNotification.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ListNotification.java
@@ -32,7 +32,7 @@ public class ListNotification implements Callable<Integer> {
             return 0;
         }
 
-        Folder folder = folderService.byName(folderName);
+        Folder folder = folderService.find(folderName);
         if (folder == null) {
             System.err.println("Folder not found: " + folderName);
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/ListValue.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/ListValue.java
@@ -61,7 +61,7 @@ public class ListValue implements Callable<Integer> {
             cmd.usage(System.err);
             return 1;
         }
-        NodeGroup nodeGroup = nodeGroupService.byName(groupName);
+        NodeGroup nodeGroup = nodeGroupService.find(groupName);
         if(nodeGroup == null){
             System.err.println("NodeEntity group "+groupName+" not found");
             return 1;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyRuns.java
@@ -84,7 +84,7 @@ public class LoadLegacyRuns implements Callable<Integer> {
             System.out.println("loaded "+tests.size()+" legacy tests");
             for(Long testId : tests.keySet()){
                 String name = tests.get(testId);
-                Folder folder = folderService.byName(name);
+                Folder folder = folderService.find(name);
                 if(folder == null){
                     System.out.println("Failed to find Folder for test "+name+" id="+testId);
                     continue;
@@ -134,7 +134,7 @@ public class LoadLegacyRuns implements Callable<Integer> {
                                 // getCharacterStream() path required.
                                 byte[] bytes = rs.getBytes("data");
                                 JqValue data = JqValues.parse(bytes);
-                                batchFutures.add(folderService.upload(folder.name(), data).future);
+                                batchFutures.add(folderService.upload(folder.id(), data).future);
                                 count++;
                             }
                         }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
@@ -968,7 +968,7 @@ public class LoadLegacyTests implements Callable<Integer> {
 
                     if ("Default".equals(viewName)) {
                         // Check if Default view already exists (created by folderService.create)
-                        List<View> existing = viewService.getViews(folderName);
+                        List<View> existing = viewService.getViews(folderId);
                         View defaultView = existing.stream()
                                 .filter(v -> "Default".equals(v.name()))
                                 .findFirst().orElse(null);
@@ -976,11 +976,11 @@ public class LoadLegacyTests implements Callable<Integer> {
                             viewService.updateView(defaultView.id(),
                                     new View(defaultView.id(), "Default", folderId, components));
                         } else {
-                            viewService.createView(folderName,
+                            viewService.createView(folderId,
                                     new View(null, "Default", null, components));
                         }
                     } else {
-                        viewService.createView(folderName,
+                        viewService.createView(folderId,
                                 new View(null, viewName, null, components));
                     }
                     System.out.println("  Imported view '" + viewName + "' with " + components.size() + " columns");

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveCmd.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveCmd.java
@@ -33,8 +33,8 @@ public class RemoveCmd implements Callable<Integer> {
             cmd.usage(System.out);
             return 0;
         }
-        Folder folder = folderService.byName(name);
-        NodeGroup nodeGroup = nodeGroupService.byName(name);
+        Folder folder = folderService.find(name);
+        NodeGroup nodeGroup = nodeGroupService.find(name);
         List<Node> nodes = nodeService.findNodeByFqdn(name);
 
         if (folder != null) {
@@ -44,7 +44,7 @@ public class RemoveCmd implements Callable<Integer> {
                 nodes.forEach(n-> System.err.println("  node = "+n.fqdn()));
             }else{
                 System.out.println("deleting "+name+" folder");
-                folderService.delete(name);
+                folderService.delete(folder.id());
             }
         } else if (nodeGroup != null) {
             if(!nodes.isEmpty()) {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveFolder.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/RemoveFolder.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.cli;
 
+import io.hyperfoil.tools.h5m.api.Folder;
 import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import jakarta.inject.Inject;
 import picocli.CommandLine;
@@ -17,8 +18,11 @@ public class RemoveFolder implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        if(folderService.delete(name) == 0){
-            System.err.println("FolderEntity "+name+" not found");
+        Folder folder = folderService.find(name);
+        if (folder == null) {
+            System.err.println("FolderEntity " + name + " not found");
+        } else {
+            folderService.delete(folder.id());
         }
         return 0;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/VerifyLegacy.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/VerifyLegacy.java
@@ -350,7 +350,7 @@ public class VerifyLegacy implements Callable<Integer> {
         }
 
         // Get h5m views
-        List<View> h5mViews = viewService.getViews(testName);
+        List<View> h5mViews = viewService.getViews(folderService.find(testName).id());
         Map<String, View> h5mViewsByName = new LinkedHashMap<>();
         for (View v : h5mViews) {
             h5mViewsByName.put(v.name(), v);

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 @Path("/api/folder")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Folder", description = "Manage folders for uploaded data")
 public class FolderResource {
 
@@ -52,11 +51,11 @@ public class FolderResource {
     }
 
     @GET
-    @Path("{name}")
+    @Path("find")
     @PermitAll
     @Operation(description = "Retrieve a folder by its name")
-    public Folder byFolderName(@PathParam("name") String name) {
-        return folderService.byName(name);
+    public Folder findFolder(@QueryParam("name") String name) {
+        return folderService.find(name);
     }
 
     @GET
@@ -68,32 +67,31 @@ public class FolderResource {
     }
 
     @POST
-    @Path("{name}")
     @Authenticated
     @Operation(description = "Create a new folder")
-    public long createFolder(@PathParam("name") String name) {
+    public Folder createFolder(@QueryParam("name") String name) {
         return folderService.create(name);
     }
 
     @DELETE
-    @Path("{name}")
+    @Path("{id}")
     @Authenticated
-    @Operation(description = "Delete a folder by its name")
-    public long deleteFolder(@PathParam("name") String name) {
-        return folderService.delete(name);
+    @Operation(description = "Delete a folder by its ID")
+    public void deleteFolder(@PathParam("id") long id) {
+        folderService.delete(id);
     }
 
     @POST
-    @Path("{name}/upload")
+    @Path("{id}/upload")
     @Authenticated
     @Operation(description = "Upload JSON data to a folder. Returns immediately with an uploadId.")
     public long upload(
-            @PathParam("name") String name,
+            @PathParam("id") long id,
             JqValue data) {
         if (data == null) {
             throw new BadRequestException("Missing request body");
         }
-        return folderService.upload(name, data).uploadId;
+        return folderService.upload(id, data).uploadId;
     }
 
     @GET
@@ -109,11 +107,11 @@ public class FolderResource {
     }
 
     @GET
-    @Path("{name}/structure")
+    @Path("{id}/structure")
     @PermitAll
     @Operation(description = "Get the structural representation of a folder")
-    public JqValue structure(@PathParam("name") String name) {
-        return folderService.structure(name);
+    public JqValue structure(@PathParam("id") long id) {
+        return folderService.structure(id);
     }
 
     @GET

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
@@ -12,7 +12,6 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 @Path("/api/group")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "NodeGroup", description = "Manage node groups (transformation pipelines)")
 public class NodeGroupResource {
 
@@ -20,7 +19,7 @@ public class NodeGroupResource {
     NodeGroupServiceInterface nodeGroupService;
 
     @GET
-    @Path("id/{id}")
+    @Path("{id}")
     @PermitAll
     @Operation(description = "Retrieve a node group by its ID")
     public NodeGroup byId(@PathParam("id") Long groupId) {
@@ -28,11 +27,11 @@ public class NodeGroupResource {
     }
 
     @GET
-    @Path("{name}")
+    @Path("find")
     @PermitAll
     @Operation(description = "Retrieve a node group by its name")
-    public NodeGroup byGroupName(@PathParam("name") String groupName) {
-        return nodeGroupService.byName(groupName);
+    public NodeGroup findGroup(@QueryParam("name") String groupName) {
+        return nodeGroupService.find(groupName);
     }
 
     @DELETE

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 
 @Path("/api/node")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Node", description = "Manage transformation nodes in the DAG pipeline")
 public class NodeResource {
 
@@ -48,7 +47,7 @@ public class NodeResource {
     @POST
     @Authenticated
     @Operation(description = "Create a new node with an operation")
-    public Long createNode(
+    public Node createNode(
             @QueryParam("name") @NotEmpty String name,
             @QueryParam("groupId") @NotNull Long groupId,
             @QueryParam("type") @NotNull NodeType type,
@@ -60,7 +59,7 @@ public class NodeResource {
     @Path("configured")
     @Authenticated
     @Operation(description = "Create a new node with sources and configuration")
-    public Long createConfigured(
+    public Node createConfigured(
             @QueryParam("name") @NotEmpty String name,
             @QueryParam("groupId") @NotNull Long groupId,
             @QueryParam("type") @NotNull NodeType type,

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 @Path("/api/notification")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Notification", description = "Manage notification configurations for change detection")
 public class NotificationResource {
 
@@ -33,7 +32,7 @@ public class NotificationResource {
     @Authenticated
     @Transactional
     @Operation(description = "Create a notification config for a folder")
-    public long createConfig(
+    public NotificationConfigResponse createConfig(
             @QueryParam("folderId") @Parameter(description = "Folder ID") long folderId,
             @QueryParam("method") @Parameter(description = "Notification method") NotificationMethod method,
             @QueryParam("secrets") @Parameter(description = "Secret config data (tokens, passwords)") String secrets,
@@ -45,7 +44,7 @@ public class NotificationResource {
         }
         NotificationConfig config = new NotificationConfig(folder, method, data, secrets);
         config.persist();
-        return config.id;
+        return new NotificationConfigResponse(config.id, folderId, config.method, config.data, config.template, config.enabled);
     }
 
     @GET
@@ -65,7 +64,7 @@ public class NotificationResource {
     @Authenticated
     @Transactional
     @Operation(description = "Update a notification config")
-    public void updateConfig(
+    public NotificationConfigResponse updateConfig(
             @PathParam("id") long id,
             @QueryParam("method") @Parameter(description = "New notification method") NotificationMethod method,
             @QueryParam("enabled") @Parameter(description = "Enable or disable") Boolean enabled,
@@ -88,6 +87,7 @@ public class NotificationResource {
         if (enabled != null) {
             config.enabled = enabled;
         }
+        return new NotificationConfigResponse(config.id, config.folder != null ? config.folder.id : null, config.method, config.data, config.template, config.enabled);
     }
 
     @DELETE

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
@@ -17,7 +17,6 @@ import java.util.List;
 
 @Path("/api/value")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "Value", description = "Manage computed values produced by nodes")
 public class ValueResource {
 

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
@@ -13,9 +13,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
-@Path("/api/folder/{name}/view")
+@Path("/api/folder/{folderId}/view")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 @Tag(name = "View", description = "Manage views for folder data presentation")
 public class ViewResource {
 
@@ -26,30 +25,30 @@ public class ViewResource {
     @Path("/")
     @PermitAll
     @Operation(description = "List all views for a folder")
-    public List<View> getViews(@PathParam("name") String folderName) {
-        return viewService.getViews(folderName);
+    public List<View> getViews(@PathParam("folderId") long folderId) {
+        return viewService.getViews(folderId);
     }
 
     @GET
     @Path("/{viewId}")
     @PermitAll
     @Operation(description = "Get a view definition")
-    public View getView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
+    public View getView(@PathParam("folderId") long folderId, @PathParam("viewId") Long viewId) {
         return viewService.getView(viewId);
     }
 
     @POST
     @Authenticated
     @Operation(description = "Create a new view for a folder")
-    public View createView(@PathParam("name") String folderName, View view) {
-        return viewService.createView(folderName, view);
+    public View createView(@PathParam("folderId") long folderId, View view) {
+        return viewService.createView(folderId, view);
     }
 
     @PUT
     @Path("/{viewId}")
     @Authenticated
     @Operation(description = "Update a view")
-    public View updateView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId, View view) {
+    public View updateView(@PathParam("folderId") long folderId, @PathParam("viewId") Long viewId, View view) {
         return viewService.updateView(viewId, view);
     }
 
@@ -57,7 +56,7 @@ public class ViewResource {
     @Path("/{viewId}")
     @Authenticated
     @Operation(description = "Delete a view (cannot delete the Default view)")
-    public void deleteView(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
+    public void deleteView(@PathParam("folderId") long folderId, @PathParam("viewId") Long viewId) {
         viewService.deleteView(viewId);
     }
 
@@ -65,7 +64,7 @@ public class ViewResource {
     @Path("/{viewId}/data")
     @PermitAll
     @Operation(description = "Get filtered pivoted data for a view")
-    public List<JqValue> getViewData(@PathParam("name") String folderName, @PathParam("viewId") Long viewId) {
-        return viewService.getViewData(folderName, viewId);
+    public List<JqValue> getViewData(@PathParam("folderId") long folderId, @PathParam("viewId") Long viewId) {
+        return viewService.getViewData(folderId, viewId);
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -75,7 +75,7 @@ public class FolderService implements FolderServiceInterface {
 
     @Override
     @Transactional
-    public long create(String name){
+    public Folder create(String name){
         if(FolderEntity.find("name",name).firstResult() !=null){
             throw new WebApplicationException("Folder already exists:" + name, 409);
         }
@@ -84,7 +84,7 @@ public class FolderService implements FolderServiceInterface {
         entity.group = new NodeGroupEntity(name); //TODO do we auto-create a nodeGroup?
         FolderEntity.persist(entity);
         createDefaultView(entity);
-        return entity.id;
+        return apiMapper.toFolder(entity);
     }
 
     @Transactional
@@ -98,15 +98,15 @@ public class FolderService implements FolderServiceInterface {
     }
 
     @Transactional
-    public long create(String name, String teamName) {
+    public Folder create(String name, String teamName) {
         TeamEntity team = TeamEntity.find("name", teamName).firstResult();
         if (team == null) {
             throw new IllegalArgumentException("Team not found: " + teamName);
         }
-        long id = create(name);
-        FolderEntity entity = FolderEntity.findById(id);
+        Folder folder = create(name);
+        FolderEntity entity = FolderEntity.findById(folder.id());
         entity.team = team;
-        return id;
+        return folder;
     }
 
     @Transactional
@@ -116,7 +116,7 @@ public class FolderService implements FolderServiceInterface {
 
     @Override
     @Transactional
-    public Folder byName(String name){
+    public Folder find(String name){
         FolderEntity entity = FolderEntity.find("name", name).firstResult();
         return entity != null ? apiMapper.toFolder(entity) : null;
     }
@@ -204,30 +204,30 @@ public class FolderService implements FolderServiceInterface {
 
     @Override
     @Transactional
-    public long delete(String name){
-        FolderEntity folder = FolderEntity.find("name", name).firstResult();
+    public void delete(long id){
+        FolderEntity folder = FolderEntity.findById(id);
         if (folder == null) {
-            throw new NotFoundException("Folder not found: " + name);
+            throw new NotFoundException("Folder not found: " + id);
         }
 
-        valueService.deleteForFolder(folder.id);
-        notificationService.deleteForFolder(folder.id);
-        processingService.deleteForFolder(folder.id);
+        valueService.deleteForFolder(id);
+        notificationService.deleteForFolder(id);
+        processingService.deleteForFolder(id);
 
         em.createNativeQuery("DELETE FROM folder_view_component WHERE view_id IN (SELECT id FROM folder_view WHERE folder_id = :fid)")
-                .setParameter("fid", folder.id).executeUpdate();
+                .setParameter("fid", id).executeUpdate();
         em.createNativeQuery("DELETE FROM folder_view WHERE folder_id = :fid")
-                .setParameter("fid", folder.id).executeUpdate();
-        return FolderEntity.delete("name", name);
+                .setParameter("fid", id).executeUpdate();
+        FolderEntity.delete("id", id);
     }
 
     @Override
     @Transactional
-    public JqValue structure(String name) {
+    public JqValue structure(long folderId) {
         FolderEntity folder = em.createQuery(
-                "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
+                "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.id = :id",
                 FolderEntity.class
-        ).setParameter("name", name).getSingleResult();
+        ).setParameter("id", folderId).getSingleResult();
 
         NodeEntity root = folder.group.root;
         List<ValueEntity> uploads = valueService.getValues(root);
@@ -254,12 +254,12 @@ public class FolderService implements FolderServiceInterface {
      * callback is wired outside the transaction since it only needs the future.
      */
     @Override
-    public Upload upload(String name, JqValue data) {
+    public Upload upload(long folderId, JqValue data) {
         Upload upload = workService.callInNewTransaction(() -> {
             FolderEntity folder = em.createQuery(
-                    "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
+                    "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.id = :id",
                     FolderEntity.class
-            ).setParameter("name", name).getSingleResult();
+            ).setParameter("id", folderId).getSingleResult();
             ValueEntity newValue = valueService.create(new ValueEntity(folder, folder.group.root, data));
 
             // Track this upload for crash recovery — marked completed when all work finishes
@@ -317,11 +317,11 @@ public class FolderService implements FolderServiceInterface {
      * @param outputPath path to write the JSON file
      */
     @Transactional
-    public void export(String folderName, Path outputPath) throws IOException {
+    public void export(long folderId, Path outputPath) throws IOException {
         FolderEntity folder = em.createQuery(
-            "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.name = :name",
+            "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.sources LEFT JOIN FETCH g.root WHERE f.id = :id",
             FolderEntity.class
-        ).setParameter("name", folderName).getSingleResult();
+        ).setParameter("id", folderId).getSingleResult();
 
         // Root node first, then remaining nodes ordered by id.
         // Auto-increment ids ensure parents are always created before children,
@@ -336,11 +336,11 @@ public class FolderService implements FolderServiceInterface {
             .getResultList()
             .forEach(n -> nodeList.add(serializeNode(n)));
 
-        JqObject root = JqObject.of("folder", JqString.of(folderName),
+        JqObject root = JqObject.of("folder", JqString.of(folder.name),
             "nodes", JqArray.of(nodeList.toArray(new JqValue[0])));
 
         Files.writeString(outputPath, JqValues.toPrettyJsonString(root));
-        Log.infof("Exported folder '%s' with %d nodes to %s", folderName, nodeList.size(), outputPath);
+        Log.infof("Exported folder '%s' with %d nodes to %s", folder.name, nodeList.size(), outputPath);
     }
 
     /**
@@ -351,7 +351,7 @@ public class FolderService implements FolderServiceInterface {
      * @return the folder name that was imported
      */
     @Transactional
-    public String importFolder(Path inputPath, boolean overwrite) throws IOException {
+    public Folder importFolder(Path inputPath, boolean overwrite) throws IOException {
         JqValue root = JqValues.parse(Files.readString(inputPath));
         if (!(root instanceof JqObject rootObj)) {
             throw new IllegalArgumentException("Import file must contain a JSON object, got: " + root.getClass().getSimpleName());
@@ -372,15 +372,14 @@ public class FolderService implements FolderServiceInterface {
         if (existing != null) {
             if (!overwrite) {
                 Log.infof("Folder '%s' already exists, skipping (use --overwrite to replace)", folderName);
-                return folderName;
+                return apiMapper.toFolder(existing);
             }
-            delete(folderName);
+            delete(existing.id);
             em.flush();
             em.clear();
         }
 
-        long folderId = create(folderName);
-        FolderEntity folder = read(folderId);
+        FolderEntity folder = read(create(folderName).id());
         NodeGroupEntity group = folder.group;
 
         Map<Long, NodeEntity> idMap = new HashMap<>();
@@ -457,7 +456,7 @@ public class FolderService implements FolderServiceInterface {
         em.merge(group);
 
         Log.infof("Imported folder '%s' with %d nodes from %s", folderName, nodeArray.length(), inputPath);
-        return folderName;
+        return apiMapper.toFolder(folder);
     }
 
     /**

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeGroupService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeGroupService.java
@@ -42,7 +42,7 @@ public class NodeGroupService implements NodeGroupServiceInterface {
 
     @Override
     @Transactional
-    public NodeGroup byName(String name){
+    public NodeGroup find(String name){
         return apiMapper.toNodeGroup(NodeGroupEntity.find("name",name).firstResult(), new CycleAvoidingContext());
     }
 

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -98,7 +98,7 @@ public class NodeService implements NodeServiceInterface {
 
     @Override
     @Transactional
-    public Long create(String name, Long groupId, NodeType type, String operation){
+    public Node create(String name, Long groupId, NodeType type, String operation){
         NodeEntity node = switch (type) {
             case JQ -> JqNode.parse(name, operation, n -> internalFindNodeByFqdn(n, groupId));
             case JS -> JsNode.parse(name, operation, n -> internalFindNodeByFqdn(n, groupId));
@@ -111,12 +111,12 @@ public class NodeService implements NodeServiceInterface {
             node.sources.add(node.group.root);
         }
         em.persist(node);
-        return node.id;
+        return apiMapper.toNode(node, new CycleAvoidingContext());
     }
 
     @Override
     @Transactional
-    public Long createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration) {
+    public Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration) {
         NodeEntity node = switch (type) {
             case FINGERPRINT -> new FingerprintNode(name, "");
             case FIXED_THRESHOLD -> new FixedThreshold(name, toFixedThresholdConfig(configuration).toJsonString());
@@ -129,7 +129,7 @@ public class NodeService implements NodeServiceInterface {
         node.sources = NodeEntity.findByIds(sources);
 
         em.persist(node);
-        return node.id;
+        return apiMapper.toNode(node, new CycleAvoidingContext());
     }
 
     /** Convert configuration (Map from REST or record from CLI) to JqObject for FixedThreshold. */

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
@@ -33,9 +33,9 @@ public class TeamService implements TeamServiceInterface {
 
     @Override
     @Transactional
-    public Team byName(String name) {
+    public Team find(String name) {
         TeamEntity entity = TeamEntity.find("name", name).firstResult();
-        return apiMapper.toTeam(entity);
+        return entity != null ? apiMapper.toTeam(entity) : null;
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/ViewService.java
@@ -33,8 +33,8 @@ public class ViewService implements ViewServiceInterface {
 
     @Override
     @Transactional
-    public List<View> getViews(String folderName) {
-        FolderEntity folder = findFolder(folderName);
+    public List<View> getViews(long folderId) {
+        FolderEntity folder = findFolder(folderId);
         return folder.views.stream().map(apiMapper::toView).toList();
     }
 
@@ -50,8 +50,8 @@ public class ViewService implements ViewServiceInterface {
 
     @Override
     @Transactional
-    public View createView(String folderName, View view) {
-        FolderEntity folder = findFolder(folderName);
+    public View createView(long folderId, View view) {
+        FolderEntity folder = findFolder(folderId);
 
         ViewEntity entity = new ViewEntity(view.name(), folder);
         entity.components = new ArrayList<>();
@@ -136,7 +136,7 @@ public class ViewService implements ViewServiceInterface {
 
     @Override
     @Transactional
-    public List<JqValue> getViewData(String folderName, Long viewId) {
+    public List<JqValue> getViewData(long folderId, Long viewId) {
         ViewEntity view = em.createQuery(
             "SELECT v FROM folder_view v LEFT JOIN FETCH v.components c LEFT JOIN FETCH c.node WHERE v.id = :id",
             ViewEntity.class
@@ -145,7 +145,7 @@ public class ViewService implements ViewServiceInterface {
             throw new NotFoundException("View not found: " + viewId);
         }
 
-        FolderEntity folder = findFolder(folderName);
+        FolderEntity folder = findFolder(folderId);
         Long rootNodeId = folder.group.root.id;
 
         List<Long> nodeIds = view.components.stream()
@@ -159,13 +159,13 @@ public class ViewService implements ViewServiceInterface {
         return valueService.getGroupedValues(rootNodeId, nodeIds);
     }
 
-    private FolderEntity findFolder(String folderName) {
+    private FolderEntity findFolder(long folderId) {
         FolderEntity folder = em.createQuery(
-            "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.root WHERE f.name = :name",
+            "SELECT f FROM folder f JOIN FETCH f.group g LEFT JOIN FETCH g.root WHERE f.id = :id",
             FolderEntity.class
-        ).setParameter("name", folderName).getSingleResult();
+        ).setParameter("id", folderId).getSingleResult();
         if (folder == null) {
-            throw new NotFoundException("Folder not found: " + folderName);
+            throw new NotFoundException("Folder not found: " + folderId);
         }
         // Initialize views and their components (avoids MultipleBagFetchException)
         folder.views.size();

--- a/src/main/webui/src/app/components/CreateFolderModal.tsx
+++ b/src/main/webui/src/app/components/CreateFolderModal.tsx
@@ -43,7 +43,7 @@ export const CreateFolderModal = ({ open, onClose }: CreateFolderModalProps) => 
       setError('Folder name cannot be empty');
       return;
     }
-    createFolder.mutate({ path: { name: folderName.trim() } });
+    createFolder.mutate({ query: { name: folderName.trim() } });
   };
 
   return (

--- a/src/main/webui/src/app/components/DataTab.tsx
+++ b/src/main/webui/src/app/components/DataTab.tsx
@@ -26,16 +26,16 @@ function formatCellValue(value: unknown): string {
 }
 
 const ViewDataTable = ({
-  folderName,
+  folderId,
   view,
 }: {
-  folderName: string;
+  folderId: number;
   view: View;
 }) => {
   const viewId = view.id;
   const { data: rows, isLoading, isError } = useQuery(
     getViewDataOptions({
-      path: { name: folderName, viewId: viewId! },
+      path: { folderId, viewId: viewId! },
     }),
   );
 
@@ -83,9 +83,9 @@ const ViewDataTable = ({
   );
 };
 
-export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: number }) => {
+export const DataTab = ({ folderId, groupId }: { folderId: number; groupId: number }) => {
   const { data: views, isLoading: viewsLoading } = useQuery(
-    getViewsOptions({ path: { name: folderName } }),
+    getViewsOptions({ path: { folderId } }),
   );
   const [selectedViewId, setSelectedViewId] = useState<number | null>(null);
   const [configModalOpen, setConfigModalOpen] = useState(false);
@@ -158,7 +158,7 @@ export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: 
       {selectedView && selectedView.components && selectedView.components.length > 0 && (
         <ViewDataTable
           key={`${String(selectedView.id)}-${String(selectedView.components?.length ?? 0)}-${selectedView.components?.map(c => String(c.nodeId)).join(',') ?? ''}`}
-          folderName={folderName}
+          folderId={folderId}
           view={selectedView}
         />
       )}
@@ -168,7 +168,7 @@ export const DataTab = ({ folderName, groupId }: { folderName: string; groupId: 
             key={modalKey}
             open={configModalOpen}
             onClose={() => setConfigModalOpen(false)}
-            folderName={folderName}
+            folderId={folderId}
             groupId={groupId}
             view={editingView}
           />

--- a/src/main/webui/src/app/components/ViewConfigModal.tsx
+++ b/src/main/webui/src/app/components/ViewConfigModal.tsx
@@ -18,7 +18,7 @@ import { useCallback, useState } from 'react';
 interface ViewConfigModalProps {
   open: boolean;
   onClose: () => void;
-  folderName: string;
+  folderId: number;
   groupId: number;
   view?: View | null;
 }
@@ -29,7 +29,7 @@ interface NodeItem {
   nodeId: number;
 }
 
-export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: ViewConfigModalProps) => {
+export const ViewConfigModal = ({ open, onClose, folderId, groupId, view }: ViewConfigModalProps) => {
   const queryClient = useQueryClient();
   const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
   const isEditing = view != null && view.id != null;
@@ -94,7 +94,7 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
   const createMutation = useMutation({
     mutationFn: (data: View) =>
       ViewService.createView({
-        path: { name: folderName },
+        path: { folderId },
         body: data,
       }),
     onSuccess: () => {
@@ -114,7 +114,7 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
   const updateMutation = useMutation({
     mutationFn: (data: View) =>
       ViewService.updateView({
-        path: { name: folderName, viewId: view!.id! },
+        path: { folderId, viewId: view!.id! },
         body: data,
       }),
     onSuccess: () => {
@@ -134,7 +134,7 @@ export const ViewConfigModal = ({ open, onClose, folderName, groupId, view }: Vi
   const deleteMutation = useMutation({
     mutationFn: () =>
       ViewService.deleteView({
-        path: { name: folderName, viewId: view!.id! },
+        path: { folderId, viewId: view!.id! },
       }),
     onSuccess: () => {
       void queryClient.refetchQueries({ predicate: (q) => {

--- a/src/main/webui/src/app/pages/DashboardPage.tsx
+++ b/src/main/webui/src/app/pages/DashboardPage.tsx
@@ -91,7 +91,7 @@ const SummaryCards = ({ summaries }: { summaries: FolderSummary[] }) => {
 const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [confirmFolder, setConfirmFolder] = useState<string | null>(null);
+  const [confirmFolder, setConfirmFolder] = useState<FolderSummary | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const deleteFolder = useMutation({
@@ -161,7 +161,7 @@ const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
                   iconDescription="Delete folder"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setConfirmFolder(summary.name ?? '');
+                    setConfirmFolder(summary);
                   }}
                 />
               </StructuredListCell>
@@ -174,13 +174,13 @@ const FolderTable = ({ summaries }: { summaries: FolderSummary[] }) => {
     <Modal
       open={confirmFolder !== null}
       danger
-      modalHeading={`Delete "${confirmFolder ?? ''}"`}
+      modalHeading={`Delete "${confirmFolder?.name ?? ''}"`}
       primaryButtonText="Delete"
       secondaryButtonText="Cancel"
       onRequestClose={() => { setConfirmFolder(null); setDeleteError(null); }}
       onSecondarySubmit={() => { setConfirmFolder(null); setDeleteError(null); }}
       onRequestSubmit={() => {
-        deleteFolder.mutate({ path: { name: confirmFolder ?? '' } });
+        deleteFolder.mutate({ path: { id: confirmFolder!.id! } });
       }}
     >
       <p>Are you sure you want to delete this folder? This action cannot be undone.</p>

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -171,8 +171,8 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
       </TabList>
       <TabPanels>
         <TabPanel>
-          {folder.name && folder.groupId != null ? (
-            <DataTab folderName={folder.name} groupId={folder.groupId} />
+          {folder.id != null && folder.groupId != null ? (
+            <DataTab folderId={folder.id} groupId={folder.groupId} />
           ) : (
             <p>Folder name not available</p>
           )}

--- a/src/main/webui/test/components/DataTab.test.tsx
+++ b/src/main/webui/test/components/DataTab.test.tsx
@@ -102,7 +102,7 @@ function renderDataTab(views: View[] = mockViews, viewData: unknown[] = mockView
   queryClient.setQueryData(['byId'], mockNodeGroup);
 
   return renderWithProviders(
-    <DataTab folderName="test-folder" groupId={1} />,
+    <DataTab folderId={42} groupId={1} />,
     { queryClient },
   );
 }

--- a/src/main/webui/test/components/ViewConfigModal.test.tsx
+++ b/src/main/webui/test/components/ViewConfigModal.test.tsx
@@ -73,7 +73,7 @@ function renderModal(props: {
     <ViewConfigModal
       open={props.open ?? true}
       onClose={props.onClose ?? vi.fn()}
-      folderName="test-folder"
+      folderId={42}
       groupId={1}
       view={props.view ?? null}
     />,

--- a/src/test/java/io/hyperfoil/tools/h5m/benchmark/ClosureBenchmarkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/benchmark/ClosureBenchmarkTest.java
@@ -58,6 +58,7 @@ public class ClosureBenchmarkTest extends FreshDb {
     void upload_20_rhivos_runs() throws Exception {
         // Import the node graph
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long folderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Pre-load all run data into memory
         JqValue[] runData = new JqValue[RHIVOS_FILES.length];
@@ -74,7 +75,7 @@ public class ClosureBenchmarkTest extends FreshDb {
             int fileIndex = i % RHIVOS_FILES.length;
             long uploadStart = System.currentTimeMillis();
 
-            folderService.upload("rhivos-perf-comprehensive", runData[fileIndex])
+            folderService.upload(folderId, runData[fileIndex])
                     .future.orTimeout(120, TimeUnit.SECONDS).join();
 
             long uploadEnd = System.currentTimeMillis();

--- a/src/test/java/io/hyperfoil/tools/h5m/benchmark/EdgeTableBenchmarkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/benchmark/EdgeTableBenchmarkTest.java
@@ -226,7 +226,7 @@ public class EdgeTableBenchmarkTest extends FreshDb {
 
         // Create folder first, then add nodes to its group so upload triggers value computation
         tm.begin();
-        long folderId = folderService.create("bench_folder");
+        long folderId = folderService.create("bench_folder").id();
         FolderEntity folder = folderService.read(folderId);
         long groupId = folder.group.id;
         long rootId = folder.group.root.id;
@@ -240,7 +240,7 @@ public class EdgeTableBenchmarkTest extends FreshDb {
 
         // Upload data — let @Transactional handle the commit so work queue
         // threads can see the persisted data before starting execution
-        folderService.upload("bench_folder",
+        folderService.upload(folderId,
                 JqValues.parse("{\"data\": 42}"));
         awaitWorkQueue();
 
@@ -256,7 +256,7 @@ public class EdgeTableBenchmarkTest extends FreshDb {
         cleanDb();
 
         tm.begin();
-        long folderId = folderService.create("bench_folder");
+        long folderId = folderService.create("bench_folder").id();
         FolderEntity folder = folderService.read(folderId);
         long groupId = folder.group.id;
         long rootId = folder.group.root.id;
@@ -264,7 +264,7 @@ public class EdgeTableBenchmarkTest extends FreshDb {
 
         graphBuilder.buildDiamondInGroup(groupId, rootId, layers, width);
 
-        folderService.upload("bench_folder",
+        folderService.upload(folderId,
                 JqValues.parse("{\"data\": 42}"));
         awaitWorkQueue();
 

--- a/src/test/java/io/hyperfoil/tools/h5m/benchmark/UploadPipelineBenchmarkTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/benchmark/UploadPipelineBenchmarkTest.java
@@ -156,15 +156,15 @@ public class UploadPipelineBenchmarkTest extends FreshDb {
                 name, WARMUP, MEASURE,
                 this::cleanDb,
                 () -> {
-                    setupFlatNodes(name, nodeCount);
-                    uploadAndWait(name, data);
+                    long folderId = setupFlatNodes(name, nodeCount);
+                    uploadAndWait(folderId, data);
                 }
         );
 
         // Final run for reporting
         cleanDb();
-        setupFlatNodes(name, nodeCount);
-        uploadAndWait(name, data);
+        long folderId = setupFlatNodes(name, nodeCount);
+        uploadAndWait(folderId, data);
         reportCounts(name, nodeCount, files.length);
         results.add(result);
     }
@@ -176,21 +176,21 @@ public class UploadPipelineBenchmarkTest extends FreshDb {
                 name, WARMUP, MEASURE,
                 this::cleanDb,
                 () -> {
-                    setupChainedNodes(name);
-                    uploadAndWait(name, data);
+                    long folderId = setupChainedNodes(name);
+                    uploadAndWait(folderId, data);
                 }
         );
 
         cleanDb();
-        setupChainedNodes(name);
-        uploadAndWait(name, data);
+        long folderId = setupChainedNodes(name);
+        uploadAndWait(folderId, data);
         reportCounts(name, 3, files.length);
         results.add(result);
     }
 
-    private void setupFlatNodes(String folderName, int nodeCount) throws Exception {
+    private long setupFlatNodes(String folderName, int nodeCount) throws Exception {
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -209,11 +209,12 @@ public class UploadPipelineBenchmarkTest extends FreshDb {
         }
         folder.group.persist();
         tm.commit();
+        return folderId;
     }
 
-    private void setupChainedNodes(String folderName) throws Exception {
+    private long setupChainedNodes(String folderName) throws Exception {
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -234,11 +235,12 @@ public class UploadPipelineBenchmarkTest extends FreshDb {
 
         folder.group.persist();
         tm.commit();
+        return folderId;
     }
 
-    private void uploadAndWait(String folderName, JqValue[] data) throws Exception {
+    private void uploadAndWait(long folderId, JqValue[] data) throws Exception {
         for (int i = 0; i < data.length; i++) {
-            folderService.upload(folderName, data[i]);
+            folderService.upload(folderId, data[i]);
             // Drain work queue every 10 uploads to prevent connection pool exhaustion
             // when chained nodes create cascading work items
             if ((i + 1) % 10 == 0) {

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/ApiKeyAuthTest.java
@@ -27,7 +27,8 @@ public class ApiKeyAuthTest extends FreshDb {
     void write_endpoint_returns_401_without_auth() {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
-                .when().post("/api/folder/test")
+                .queryParam("name", "test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(401);
     }
@@ -48,7 +49,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + key)
-                .when().post("/api/folder/auth-test")
+                .queryParam("name", "auth-test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(200);
     }
@@ -58,7 +60,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer H5M_INVALID_KEY_12345678")
-                .when().post("/api/folder/test")
+                .queryParam("name", "test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(401);
     }
@@ -73,7 +76,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + key)
-                .when().post("/api/folder/test")
+                .queryParam("name", "test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(401);
     }
@@ -115,7 +119,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + bootstrapKey)
-                .when().post("/api/folder/bootstrap-test")
+                .queryParam("name", "bootstrap-test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(200);
     }
@@ -130,7 +135,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + bootstrapKey)
-                .when().post("/api/folder/bootstrap-test")
+                .queryParam("name", "bootstrap-test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(200);
     }
@@ -189,7 +195,8 @@ public class ApiKeyAuthTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "Bearer " + keyToRevoke)
-                .when().post("/api/folder/test")
+                .queryParam("name", "test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(401);
     }

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -57,17 +57,20 @@ public class RestEndpointTest extends FreshDb {
     @Inject
     FolderService folderService;
 
-    private void createFolder(String name) {
-        given()
+    private long createFolder(String name) {
+        return given()
                 .contentType(MediaType.APPLICATION_JSON)
-                .when().post("/api/folder/" + name)
+                .queryParam("name", name)
+                .when().post("/api/folder")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .extract().jsonPath().getLong("id");
     }
 
     private Long getGroupId(String name) {
         return given()
-                .when().get("/api/group/" + name)
+                .queryParam("name", name)
+                .when().get("/api/group/find")
                 .then()
                 .extract().jsonPath().getLong("id");
     }
@@ -92,7 +95,7 @@ public class RestEndpointTest extends FreshDb {
                 .when().post("/api/node/configured")
                 .then()
                 .statusCode(200)
-                .extract().as(Long.class);
+                .extract().jsonPath().getLong("id");
     }
 
     private Long createNodeWithType(Long groupId, String name, String type, String operation) {
@@ -105,7 +108,7 @@ public class RestEndpointTest extends FreshDb {
                 .when().post("/api/node")
                 .then()
                 .statusCode(200)
-                .extract().as(Long.class);
+                .extract().jsonPath().getLong("id");
     }
 
     // -- Folder endpoints --
@@ -115,7 +118,8 @@ public class RestEndpointTest extends FreshDb {
         createFolder("test-folder");
 
         given()
-                .when().get("/api/folder/test-folder")
+                .queryParam("name", "test-folder")
+                .when().get("/api/folder/find")
                 .then()
                 .statusCode(200)
                 .body("name", equalTo("test-folder"))
@@ -165,18 +169,18 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void folder_upload_and_structure() {
-        createFolder("upload-test");
+        long folderId = createFolder("upload-test");
 
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .queryParam("path", "results.json")
                 .body("{\"key\": \"value\"}")
-                .when().post("/api/folder/upload-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200);
 
         given()
-                .when().get("/api/folder/upload-test/structure")
+                .when().get("/api/folder/" + folderId + "/structure")
                 .then()
                 .statusCode(200)
                 .body(notNullValue());
@@ -184,16 +188,17 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void folder_delete() {
-        createFolder("delete-me");
+        long folderId = createFolder("delete-me");
 
         given()
-                .when().delete("/api/folder/delete-me")
+                .when().delete("/api/folder/" + folderId)
                 .then()
-                .statusCode(200);
+                .statusCode(204);
 
         // null return becomes 204 No Content
         given()
-                .when().get("/api/folder/delete-me")
+                .queryParam("name", "delete-me")
+                .when().get("/api/folder/find")
                 .then()
                 .statusCode(204);
     }
@@ -261,7 +266,8 @@ public class RestEndpointTest extends FreshDb {
         createFolder("group-test");
 
         given()
-                .when().get("/api/group/group-test")
+                .queryParam("name", "group-test")
+                .when().get("/api/group/find")
                 .then()
                 .statusCode(200)
                 .body("name", equalTo("group-test"))
@@ -271,7 +277,8 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void group_get_nonexistent() {
         given()
-                .when().get("/api/group/nonexistent")
+                .queryParam("name", "nonexistent")
+                .when().get("/api/group/find")
                 .then()
                 .statusCode(204);
     }
@@ -423,7 +430,7 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void upload_and_verify_jq_values_via_rest() throws InterruptedException {
-        createFolder("e2e-test");
+        long folderId = createFolder("e2e-test");
         Long groupId = getGroupId("e2e-test");
         Long jqNodeId = createNode(groupId, "extract", ".key");
 
@@ -432,7 +439,7 @@ public class RestEndpointTest extends FreshDb {
                 .contentType(MediaType.APPLICATION_JSON)
                 .queryParam("path", "$")
                 .body("{\"key\": \"hello\"}")
-                .when().post("/api/folder/e2e-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200);
 
@@ -467,10 +474,11 @@ public class RestEndpointTest extends FreshDb {
     public void dashboard_returns_folder_summary_with_rhivos_upload() throws Exception {
         // Import rhivos node graph and upload a run
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
-            folderService.upload("rhivos-perf-comprehensive", runData)
+            folderService.upload(rhivosFolderId, runData)
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
@@ -489,11 +497,12 @@ public class RestEndpointTest extends FreshDb {
     public void dashboard_counts_multiple_uploads() throws Exception {
         // Import rhivos node graph and upload two runs
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         for (String runFile : List.of("/rhivos/40375.json", "/rhivos/40376.json")) {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
-                folderService.upload("rhivos-perf-comprehensive", runData)
+                folderService.upload(rhivosFolderId, runData)
                         .future.orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
@@ -511,10 +520,11 @@ public class RestEndpointTest extends FreshDb {
     public void value_data_returns_json_for_uploaded_rhivos_run() throws Exception {
         // Import rhivos node graph and upload a run
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
-            folderService.upload("rhivos-perf-comprehensive", runData)
+            folderService.upload(rhivosFolderId, runData)
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
@@ -546,10 +556,10 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void view_default_created_for_new_folder() {
-        createFolder("view-default");
+        long folderId = createFolder("view-default");
 
         given()
-                .when().get("/api/folder/view-default/view/")
+                .when().get("/api/folder/" + folderId + "/view/")
                 .then()
                 .statusCode(200)
                 .body("size()", equalTo(1))
@@ -560,10 +570,11 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_default_created_on_import_empty() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Default view should exist but be empty (users configure it)
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/")
                 .then()
                 .statusCode(200)
                 .body("size()", equalTo(1))
@@ -575,6 +586,7 @@ public class RestEndpointTest extends FreshDb {
     public void view_create_and_retrieve() throws Exception {
         // Import rhivos nodes so we have real node IDs to reference
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Find node IDs for "user" and "uuid" by querying the group
         tm.begin();
@@ -597,7 +609,7 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(viewJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .body("name", equalTo("test-view"))
@@ -608,7 +620,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Retrieve it
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .when().get("/api/folder/" + rhivosFolderId + "/view/" + viewId)
                 .then()
                 .statusCode(200)
                 .body("name", equalTo("test-view"))
@@ -616,7 +628,7 @@ public class RestEndpointTest extends FreshDb {
 
         // List should contain Default + test-view
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/")
                 .then()
                 .statusCode(200)
                 .body("size()", equalTo(2));
@@ -625,6 +637,7 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_update_changes_components() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         tm.begin();
         FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
@@ -645,7 +658,7 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(createJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .extract().jsonPath().getLong("id");
@@ -662,7 +675,7 @@ public class RestEndpointTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(updateJson)
-                .when().put("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .when().put("/api/folder/" + rhivosFolderId + "/view/" + viewId)
                 .then()
                 .statusCode(200)
                 .body("name", equalTo("updatable-renamed"))
@@ -673,6 +686,7 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_update_with_same_header_names() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         tm.begin();
         FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
@@ -694,7 +708,7 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(createJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .extract().jsonPath().getLong("id");
@@ -713,7 +727,7 @@ public class RestEndpointTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(updateJson)
-                .when().put("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .when().put("/api/folder/" + rhivosFolderId + "/view/" + viewId)
                 .then()
                 .statusCode(200)
                 .body("components.size()", equalTo(2))
@@ -726,6 +740,7 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_delete_works() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         tm.begin();
         FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
@@ -741,20 +756,20 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(createJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .extract().jsonPath().getLong("id");
 
         // Delete it
         given()
-                .when().delete("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .when().delete("/api/folder/" + rhivosFolderId + "/view/" + viewId)
                 .then()
                 .statusCode(204);
 
         // Custom view should be gone, only Default remains
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/")
                 .then()
                 .statusCode(200)
                 .body("size()", equalTo(1))
@@ -764,10 +779,11 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_delete_default_rejected() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Find the auto-created Default view's ID
         Long viewId = given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/")
                 .then()
                 .statusCode(200)
                 .body("[0].name", equalTo("Default"))
@@ -775,7 +791,7 @@ public class RestEndpointTest extends FreshDb {
 
         // Attempting to delete "Default" should fail
         given()
-                .when().delete("/api/folder/rhivos-perf-comprehensive/view/" + viewId)
+                .when().delete("/api/folder/" + rhivosFolderId + "/view/" + viewId)
                 .then()
                 .statusCode(anyOf(equalTo(400), equalTo(500)));
     }
@@ -784,6 +800,7 @@ public class RestEndpointTest extends FreshDb {
     public void view_data_returns_filtered_rhivos_values() throws Exception {
         // Import rhivos nodes
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Create the view BEFORE uploading — nodes referenced by views are
         // excluded from ephemeral nullification, so this must happen first
@@ -808,7 +825,7 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(viewJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .extract().jsonPath().getLong("id");
@@ -817,13 +834,13 @@ public class RestEndpointTest extends FreshDb {
         // because they are referenced by the view
         try (InputStream is = getClass().getResourceAsStream("/rhivos/40375.json")) {
             io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
-            folderService.upload("rhivos-perf-comprehensive", runData)
+            folderService.upload(rhivosFolderId, runData)
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Get view data — should return filtered results with only start_time and end_time columns
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId + "/data")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/" + viewId + "/data")
                 .then()
                 .statusCode(200)
                 .body("size()", greaterThan(0))
@@ -834,6 +851,7 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_data_with_multiple_uploads() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         // Create the view BEFORE uploading — nodes referenced by views are
         // excluded from ephemeral nullification
@@ -852,7 +870,7 @@ public class RestEndpointTest extends FreshDb {
         Long viewId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(viewJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 .extract().jsonPath().getLong("id");
@@ -861,14 +879,14 @@ public class RestEndpointTest extends FreshDb {
         for (String runFile : List.of("/rhivos/40375.json", "/rhivos/40376.json")) {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 io.hyperfoil.tools.jjq.value.JqValue runData = io.hyperfoil.tools.jjq.value.JqValues.parse(is.readAllBytes());
-                folderService.upload("rhivos-perf-comprehensive", runData)
+                folderService.upload(rhivosFolderId, runData)
                         .future.orTimeout(30, TimeUnit.SECONDS).join();
             }
         }
 
         // View data should have one row per upload
         given()
-                .when().get("/api/folder/rhivos-perf-comprehensive/view/" + viewId + "/data")
+                .when().get("/api/folder/" + rhivosFolderId + "/view/" + viewId + "/data")
                 .then()
                 .statusCode(200)
                 .body("size()", equalTo(2))
@@ -879,6 +897,7 @@ public class RestEndpointTest extends FreshDb {
     @Test
     public void view_component_ordering() throws Exception {
         folderService.importFolder(Path.of("src/test/resources/rhivos/nodes.json"), false);
+        long rhivosFolderId = folderService.find("rhivos-perf-comprehensive").id();
 
         tm.begin();
         FolderEntity folder = FolderEntity.find("name", "rhivos-perf-comprehensive").firstResult();
@@ -901,7 +920,7 @@ public class RestEndpointTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(viewJson)
-                .when().post("/api/folder/rhivos-perf-comprehensive/view")
+                .when().post("/api/folder/" + rhivosFolderId + "/view")
                 .then()
                 .statusCode(200)
                 // Components should be ordered by headerOrder
@@ -929,10 +948,11 @@ public class RestEndpointTest extends FreshDb {
     public void labelValues_returns_grouped_values() throws InterruptedException {
         Long folderId = given()
                 .contentType(MediaType.APPLICATION_JSON)
-                .when().post("/api/folder/lv-test")
+                .queryParam("name", "lv-test")
+                .when().post("/api/folder")
                 .then()
                 .statusCode(200)
-                .extract().as(Long.class);
+                .extract().jsonPath().getLong("id");
 
         Long groupId = getGroupId("lv-test");
         Long throughputId=createNode(groupId, "throughput", ".throughput");
@@ -940,12 +960,12 @@ public class RestEndpointTest extends FreshDb {
 
         given().contentType(MediaType.APPLICATION_JSON)
                 .body("{\"throughput\": 115, \"build_id\": 201}")
-                .when().post("/api/folder/lv-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then().statusCode(200);
 
         given().contentType(MediaType.APPLICATION_JSON)
                 .body("{\"throughput\": 100, \"build_id\": 202}")
-                .when().post("/api/folder/lv-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then().statusCode(200);
 
         long deadline = System.currentTimeMillis() + 10_000;
@@ -979,12 +999,12 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void upload_returns_uploadId() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
-        createFolder("upload-id-test");
+        long folderId = createFolder("upload-id-test");
 
         Long uploadId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"cpu\": 95}")
-                .when().post("/api/folder/upload-id-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
                 .extract().as(Long.class);
@@ -1003,21 +1023,21 @@ public class RestEndpointTest extends FreshDb {
 
     @Test
     public void FolderUpload_empty_body_returns_error() {
-        createFolder("test-empty");
+        long folderId = createFolder("test-empty");
         given()
                 .contentType(MediaType.APPLICATION_JSON)
-                .when().post("/api/folder/test-empty/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(400);
     }
 
     @Test
     public void FolderUpload_tracking_record_created() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
-        createFolder("test-tracking");
+        long folderId = createFolder("test-tracking");
         Long uploadId = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"cpu\": 95}")
-                .when().post("/api/folder/test-tracking/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .extract().as(Long.class);
 
@@ -1034,19 +1054,19 @@ public class RestEndpointTest extends FreshDb {
         given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"cpu\": 95}")
-                .when().post("/api/folder/test-folderg/upload")
+                .when().post("/api/folder/999999/upload")
                 .then()
                 .statusCode(500);
     }
 
     @Test
     public void multiple_uploads_return_unique_ids() {
-        createFolder("upload-unique-ids-test");
+        long folderId = createFolder("upload-unique-ids-test");
 
         Long uploadId1 = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"cpu\": 95}")
-                .when().post("/api/folder/upload-unique-ids-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
                 .extract().as(Long.class);
@@ -1054,7 +1074,7 @@ public class RestEndpointTest extends FreshDb {
         Long uploadId2 = given()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body("{\"cpu\": 99}")
-                .when().post("/api/folder/upload-unique-ids-test/upload")
+                .when().post("/api/folder/" + folderId + "/upload")
                 .then()
                 .statusCode(200)
                 .extract().as(Long.class);

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
@@ -73,7 +73,7 @@ public class EDivisiveTest extends FreshDb {
      */
     private long setupAndUpload(String folderName, double[] series, int windowLen, double maxPvalue) throws Exception {
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
 
         // Create nodes: root -> value (extracts .v), domain (extracts .d) -> fingerprint -> edivisive
@@ -111,7 +111,7 @@ public class EDivisiveTest extends FreshDb {
         // Upload each value as a separate run with an incrementing domain value
         for (int i = 0; i < series.length; i++) {
             String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", series[i], i);
-            folderService.upload(folderName, JqValues.parse(json))
+            folderService.upload(folderId, JqValues.parse(json))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
@@ -208,7 +208,7 @@ public class EDivisiveTest extends FreshDb {
         String folderName = "recomp-test";
 
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode valueNode = new JqNode("value", ".v", folder.group.root);
@@ -244,7 +244,7 @@ public class EDivisiveTest extends FreshDb {
         // Upload first batch: step from 100 to 200
         for (int i = 0; i < 10; i++) {
             double v = i < 5 ? 100.0 : 200.0;
-            folderService.upload(folderName, JqValues.parse(String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", v, i)))
+            folderService.upload(folderId, JqValues.parse(String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", v, i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
@@ -255,7 +255,7 @@ public class EDivisiveTest extends FreshDb {
 
         // Upload more data — all at 200 (extending the second segment)
         for (int i = 0; i < 5; i++) {
-            folderService.upload(folderName, JqValues.parse(String.format("{\"v\": 200.0, \"fp\": \"default\", \"d\": %d}", 10 + i)))
+            folderService.upload(folderId, JqValues.parse(String.format("{\"v\": 200.0, \"fp\": \"default\", \"d\": %d}", 10 + i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
@@ -292,7 +292,7 @@ public class EDivisiveTest extends FreshDb {
     public void rest_createConfigured_edivisive() throws Exception {
         // Test that the createConfigured path works for EDIVISIVE nodes
         tm.begin();
-        long folderId = folderService.create("rest-ed-test");
+        long folderId = folderService.create("rest-ed-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode rangeNode = new JqNode("range", ".y", folder.group.root);
@@ -308,10 +308,10 @@ public class EDivisiveTest extends FreshDb {
         long fpSourceId = fpSource.id;
         tm.commit();
 
-        Long fpNodeId = nodeService.createConfigured("_fp-test", groupId, NodeType.FINGERPRINT, List.of(fpSourceId), null);
+        Long fpNodeId = nodeService.createConfigured("_fp-test", groupId, NodeType.FINGERPRINT, List.of(fpSourceId), null).id();
         Long edNodeId = nodeService.createConfigured("ed-test", groupId, NodeType.EDIVISIVE,
                 List.of(fpNodeId, folder.group.root.id, rangeId),
-                new EDivisiveConfig(10, 0.01, 0.0, 200, null));
+                new EDivisiveConfig(10, 0.01, 0.0, 200, null)).id();
 
         assertNotNull(edNodeId, "Should return a valid node ID");
 
@@ -334,7 +334,7 @@ public class EDivisiveTest extends FreshDb {
         // detected independently per fingerprint
         String folderName = "multi-fp-test";
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode valueNode = new JqNode("value", ".v", folder.group.root);
@@ -369,19 +369,19 @@ public class EDivisiveTest extends FreshDb {
 
         // Alpha: stable at 100 for 10 uploads, then step to 200
         for (int i = 0; i < 10; i++) {
-            folderService.upload(folderName, JqValues.parse(
+            folderService.upload(folderId, JqValues.parse(
                     String.format("{\"v\": 100.0, \"fp\": \"alpha\", \"d\": %d}", i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
         for (int i = 10; i < 20; i++) {
-            folderService.upload(folderName, JqValues.parse(
+            folderService.upload(folderId, JqValues.parse(
                     String.format("{\"v\": 200.0, \"fp\": \"alpha\", \"d\": %d}", i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 
         // Beta: completely stable at 500 (no change points expected)
         for (int i = 0; i < 20; i++) {
-            folderService.upload(folderName, JqValues.parse(
+            folderService.upload(folderId, JqValues.parse(
                     String.format("{\"v\": 500.0, \"fp\": \"beta\", \"d\": %d}", i + 100)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
@@ -413,7 +413,7 @@ public class EDivisiveTest extends FreshDb {
         String folderName = "ooo-test";
 
         tm.begin();
-        long folderId = folderService.create(folderName);
+        long folderId = folderService.create(folderName).id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode valueNode = new JqNode("value", ".v", folder.group.root);
@@ -448,7 +448,7 @@ public class EDivisiveTest extends FreshDb {
 
         // Upload stable series at y=100
         for (int i = 0; i < 20; i++) {
-            folderService.upload(folderName, JqValues.parse(
+            folderService.upload(folderId, JqValues.parse(
                     String.format("{\"v\": 100.0, \"fp\": \"default\", \"d\": %d}", i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
@@ -464,7 +464,7 @@ public class EDivisiveTest extends FreshDb {
         // This won't necessarily change the analysis since e-divisive looks at the
         // most recent N values. domain=15 is within the window.
         // The key point: the upload should not crash and should re-analyze correctly.
-        folderService.upload(folderName, JqValues.parse(
+        folderService.upload(folderId, JqValues.parse(
                 "{\"v\": 100.0, \"fp\": \"default\", \"d\": 15}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -814,6 +814,7 @@ public class EDivisiveTest extends FreshDb {
         for (int i = 10; i < 20; i++) series[i] = 200.0 + (i % 3);
 
         long edId = setupAndUpload("recalc-pipeline-test", series, 5, 0.05);
+        long recalcFolderId = folderService.find("recalc-pipeline-test").id();
 
         // Count change points after initial uploads
         tm.begin();
@@ -826,7 +827,7 @@ public class EDivisiveTest extends FreshDb {
         // Upload 5 more values at y=200 (extending the series without adding a new change point)
         for (int i = 0; i < 5; i++) {
             String json = String.format("{\"v\": %f, \"fp\": \"default\", \"d\": %d}", 200.0 + (i % 3), 20 + i);
-            folderService.upload("recalc-pipeline-test", JqValues.parse(json))
+            folderService.upload(recalcFolderId, JqValues.parse(json))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
 

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderImportExportTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderImportExportTest.java
@@ -32,7 +32,7 @@ public class FolderImportExportTest extends FreshDb {
     public void export_and_import_roundtrip() throws Exception {
         // Create a folder with a small node graph: root -> a -> b, root -> c
         tm.begin();
-        long folderId = folderService.create("roundtrip-test");
+        long folderId = folderService.create("roundtrip-test").id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -57,7 +57,7 @@ public class FolderImportExportTest extends FreshDb {
         // Export
         Path exportFile = Files.createTempFile("h5m-export-", ".json");
         try {
-            folderService.export("roundtrip-test", exportFile);
+            folderService.export(folderId, exportFile);
 
             // Verify export file
             JqValue exported = JqValues.parse(Files.readString(exportFile));
@@ -67,24 +67,22 @@ public class FolderImportExportTest extends FreshDb {
             assertEquals("root", nodes.getElement(0).getField("type").asString(""), "First node should be root");
 
             // Delete the original folder
-            tm.begin();
-            folderService.delete("roundtrip-test");
-            tm.commit();
+            folderService.delete(folderId);
 
             // Verify it's gone
-            assertNull(folderService.byName("roundtrip-test"), "Folder should be deleted");
+            assertNull(folderService.find("roundtrip-test"), "Folder should be deleted");
 
             // Import
-            String importedName = folderService.importFolder(exportFile, false);
-            assertEquals("roundtrip-test", importedName);
+            var imported2 = folderService.importFolder(exportFile, false);
+            assertEquals("roundtrip-test", imported2.name());
 
             // Verify the imported folder
-            assertNotNull(folderService.byName("roundtrip-test"), "Folder should exist after import");
+            assertNotNull(folderService.find("roundtrip-test"), "Folder should exist after import");
 
             // Verify node count
             tm.begin();
             FolderEntity imported = folderService.read(
-                folderService.byName("roundtrip-test").id()
+                folderService.find("roundtrip-test").id()
             );
             // group.sources contains all non-root nodes
             int nodeCount = imported.group.sources.size();
@@ -116,13 +114,13 @@ public class FolderImportExportTest extends FreshDb {
                 """);
 
             // Import without overwrite — should skip
-            String result = folderService.importFolder(exportFile, false);
-            assertEquals("existing-folder", result);
+            var result = folderService.importFolder(exportFile, false);
+            assertEquals("existing-folder", result.name());
 
             // Verify the original folder is unchanged (no extra nodes)
             tm.begin();
             FolderEntity folder = folderService.read(
-                folderService.byName("existing-folder").id()
+                folderService.find("existing-folder").id()
             );
             int nodeCount = folder.group.sources.size();
             tm.commit();
@@ -153,13 +151,13 @@ public class FolderImportExportTest extends FreshDb {
                 """);
 
             // Import with overwrite
-            String result = folderService.importFolder(exportFile, true);
-            assertEquals("overwrite-test", result);
+            var result = folderService.importFolder(exportFile, true);
+            assertEquals("overwrite-test", result.name());
 
             // Verify the folder was replaced with the new structure
             tm.begin();
             FolderEntity folder = folderService.read(
-                folderService.byName("overwrite-test").id()
+                folderService.find("overwrite-test").id()
             );
             int nodeCount = folder.group.sources.size();
             tm.commit();
@@ -173,7 +171,7 @@ public class FolderImportExportTest extends FreshDb {
     @Test
     public void export_preserves_node_types_and_operations() throws Exception {
         tm.begin();
-        long folderId = folderService.create("types-test");
+        long folderId = folderService.create("types-test").id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -187,7 +185,7 @@ public class FolderImportExportTest extends FreshDb {
 
         Path exportFile = Files.createTempFile("h5m-export-", ".json");
         try {
-            folderService.export("types-test", exportFile);
+            folderService.export(folderId, exportFile);
 
             JqValue exported = JqValues.parse(Files.readString(exportFile));
             JqValue nodes = exported.getField("nodes");

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/FolderServiceTest.java
@@ -67,7 +67,7 @@ public class FolderServiceTest extends FreshDb {
     public void recovery_reprocesses_incomplete_upload() throws Exception {
         // Set up folder with a JQ node
         tm.begin();
-        long folderId = folderService.create("recovery-test");
+        long folderId = folderService.create("recovery-test").id();
         FolderEntity folder = folderService.read(folderId);
         JqNode jqNode = new JqNode("extract", ".key", folder.group.root);
         jqNode.group = folder.group;
@@ -132,7 +132,7 @@ public class FolderServiceTest extends FreshDb {
     public void recovery_skips_missing_folder() throws Exception {
         // Create a root value in a folder, then delete the folder but leave tracking
         tm.begin();
-        long folderId = folderService.create("temp-folder");
+        long folderId = folderService.create("temp-folder").id();
         FolderEntity folder = folderService.read(folderId);
         ValueEntity rootValue = valueService.create(new ValueEntity(folder, folder.group.root,
                 JqValues.parse("{\"key\": \"orphaned\"}")));
@@ -159,7 +159,7 @@ public class FolderServiceTest extends FreshDb {
         // their values but before the tracking record was marked completed.
         // Recovery should dedup everything (no new values) and still complete.
         tm.begin();
-        long folderId = folderService.create("already-computed");
+        long folderId = folderService.create("already-computed").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode extractKey = new JqNode("extractKey", ".key", folder.group.root);
@@ -225,7 +225,7 @@ public class FolderServiceTest extends FreshDb {
     public void ephemeral_discard_data_nulled_after_upload() throws Exception {
         // ephemeral=DISCARD: data should be nulled after upload
         tm.begin();
-        long folderId = folderService.create("ephemeral-discard-test");
+        long folderId = folderService.create("ephemeral-discard-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode node = new JqNode("extract", ".key", folder.group.root);
@@ -235,7 +235,7 @@ public class FolderServiceTest extends FreshDb {
         long nodeId = node.id;
         tm.commit();
 
-        folderService.upload("ephemeral-discard-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"k1\"}"))
                 .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
@@ -250,7 +250,7 @@ public class FolderServiceTest extends FreshDb {
     public void ephemeral_keep_data_preserved_after_upload() throws Exception {
         // ephemeral=KEEP: data should always be preserved
         tm.begin();
-        long folderId = folderService.create("ephemeral-keep-test");
+        long folderId = folderService.create("ephemeral-keep-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode node = new JqNode("extract", ".key", folder.group.root);
@@ -260,7 +260,7 @@ public class FolderServiceTest extends FreshDb {
         long nodeId = node.id;
         tm.commit();
 
-        folderService.upload("ephemeral-keep-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"k1\"}"))
                 .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
@@ -278,7 +278,7 @@ public class FolderServiceTest extends FreshDb {
         // Node graph: root → parent (.key) → child ({parent}:.length)
         // parent is intermediate because child depends on it
         tm.begin();
-        long folderId = folderService.create("ephemeral-auto-test");
+        long folderId = folderService.create("ephemeral-auto-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         // Parent node — ephemeral=AUTO (default), will have a non-detection child
@@ -300,7 +300,7 @@ public class FolderServiceTest extends FreshDb {
         // No need to call markAutoEphemeral — the inlined AUTO logic in
         // nullifyEphemeralData resolves AUTO nodes based on graph structure
 
-        folderService.upload("ephemeral-auto-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"k1\"}"))
                 .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
@@ -322,7 +322,7 @@ public class FolderServiceTest extends FreshDb {
     public void ephemeral_auto_leaf_data_preserved() throws Exception {
         // ephemeral=AUTO: leaf node (no children) should keep data
         tm.begin();
-        long folderId = folderService.create("ephemeral-leaf-test");
+        long folderId = folderService.create("ephemeral-leaf-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode leaf = new JqNode("leaf", ".key", folder.group.root);
@@ -332,7 +332,7 @@ public class FolderServiceTest extends FreshDb {
         long leafId = leaf.id;
         tm.commit();
 
-        folderService.upload("ephemeral-leaf-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"k1\"}"))
                 .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
@@ -349,7 +349,7 @@ public class FolderServiceTest extends FreshDb {
         // Set up folder with two independent top-level nodes extracting different fields.
         // Verifies that recovery processes all nodes, not just the first one.
         tm.begin();
-        long folderId = folderService.create("multi-node-test");
+        long folderId = folderService.create("multi-node-test").id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -401,10 +401,10 @@ public class FolderServiceTest extends FreshDb {
     @Test
     public void upload_id_matches_root_value() throws Exception {
         tm.begin();
-        folderService.create("upload-root-match-test");
+        long folderId = folderService.create("upload-root-match-test").id();
         tm.commit();
 
-        long uploadId = folderService.upload("upload-root-match-test",
+        long uploadId = folderService.upload(folderId,
                 JqValues.parse("{\"cpu\": 95}")).uploadId;
 
         tm.begin();
@@ -417,10 +417,10 @@ public class FolderServiceTest extends FreshDb {
     @Test
     public void upload_creates_processing_tracker() throws Exception {
         tm.begin();
-        folderService.create("upload-tracker-svc-test");
+        long folderId = folderService.create("upload-tracker-svc-test").id();
         tm.commit();
 
-        long uploadId = folderService.upload("upload-tracker-svc-test",
+        long uploadId = folderService.upload(folderId,
                 JqValues.parse("{\"cpu\": 95}")).uploadId;
 
         tm.begin();
@@ -434,12 +434,12 @@ public class FolderServiceTest extends FreshDb {
     @Test
     public void upload_returns_unique_ids_per_upload() throws Exception {
         tm.begin();
-        folderService.create("upload-unique-svc-test");
+        long folderId = folderService.create("upload-unique-svc-test").id();
         tm.commit();
 
-        long id1 = folderService.upload("upload-unique-svc-test",
+        long id1 = folderService.upload(folderId,
                 JqValues.parse("{\"cpu\": 95}")).uploadId;
-        long id2 = folderService.upload("upload-unique-svc-test",
+        long id2 = folderService.upload(folderId,
                 JqValues.parse("{\"cpu\": 99}")).uploadId;
 
         assertNotEquals(id1, id2, "Each upload should return a unique ID");
@@ -447,7 +447,7 @@ public class FolderServiceTest extends FreshDb {
     @Test
     public void delete_folder_with_uploads() throws Exception {
         tm.begin();
-        folderService.create("delete-upload-test");
+        long folderId = folderService.create("delete-upload-test").id();
         tm.commit();
 
 
@@ -477,15 +477,14 @@ public class FolderServiceTest extends FreshDb {
         long logId = log.id;
         tm.commit();
 
-        folderService.upload("delete-upload-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"cpu\": 95}"))
                 .future.orTimeout(30, java.util.concurrent.TimeUnit.SECONDS).join();
 
-        long deleted = folderService.delete("delete-upload-test");
+        folderService.delete(folderId);
 
         tm.begin();
         assertNull(FolderEntity.find("name", "delete-upload-test").firstResult(), "Folder should not exist after deletion");
-        assertEquals(1, deleted, "One folder should have been deleted");
         assertNotNull(NodeGroupEntity.findById(groupId), "Node group should still exist after folder deletion");
         assertNull(NotificationConfig.findById(configId), "Notification config should be deleted ");
         assertNull(NotificationLog.findById(logId), "Notification log should be deleted");

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -2959,7 +2959,7 @@ public class NodeServiceTest extends FreshDb {
         tm.begin();
         FolderService folderService = jakarta.enterprise.inject.spi.CDI.current().select(FolderService.class).get();
         WorkService workService = jakarta.enterprise.inject.spi.CDI.current().select(WorkService.class).get();
-        long folderId = folderService.create("cascade-test");
+        long folderId = folderService.create("cascade-test").id();
         FolderEntity folder = folderService.read(folderId);
         NodeEntity root = folder.group.root;
 
@@ -2982,7 +2982,7 @@ public class NodeServiceTest extends FreshDb {
         // Upload data — this creates Work items via WorkService.create()
         // which calls em.merge(work) with activeNodes and sourceNodes
         
-        folderService.upload("cascade-test", JqValues.parse("{\"key\": \"hello\"}"));
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"));
 
         // Wait for the work queue to process
         long deadline = System.currentTimeMillis() + 10_000;

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
@@ -99,7 +99,7 @@ public class RecalculateTest extends FreshDb {
     public void recalculate_produces_same_values_as_upload() throws Exception {
         // Set up folder with a chain: root -> extract (.key) -> transform (. + "_done")
         tm.begin();
-        long folderId = folderService.create("recalc-test");
+        long folderId = folderService.create("recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
@@ -118,7 +118,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("recalc-test",  JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify values exist
@@ -149,7 +149,7 @@ public class RecalculateTest extends FreshDb {
     public void recalculate_suppresses_notifications() throws Exception {
         // Set up folder with a fixed threshold that will detect a violation
         tm.begin();
-        long folderId = folderService.create("recalc-notify-test");
+        long folderId = folderService.create("recalc-notify-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode rangeNode = new JqNode("range", ".y", folder.group.root);
@@ -167,15 +167,15 @@ public class RecalculateTest extends FreshDb {
 
         // Create fingerprint + fixed threshold nodes
         Long fpNodeId = nodeService.createConfigured("_fp", groupId,
-                io.hyperfoil.tools.h5m.api.NodeType.FINGERPRINT, List.of(fpSourceId), null);
+                io.hyperfoil.tools.h5m.api.NodeType.FINGERPRINT, List.of(fpSourceId), null).id();
         Long ftNodeId = nodeService.createConfigured("ft", groupId,
                 io.hyperfoil.tools.h5m.api.NodeType.FIXED_THRESHOLD,
                 List.of(fpNodeId, folder.group.root.id, rangeId),
-                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null));
+                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null)).id();
 
         // Upload a value that exceeds the threshold
         eventObserver.clear();
-        folderService.upload("recalc-notify-test",  JqValues.parse("{\"y\": 100, \"fp\": \"default\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"y\": 100, \"fp\": \"default\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Upload should dispatch notifications
@@ -204,7 +204,7 @@ public class RecalculateTest extends FreshDb {
         // Set up: root -> a (.key) -> b (. + "_b") and root -> c (.other)
         // Recalculating 'a' should affect a and b, but not c
         tm.begin();
-        long folderId = folderService.create("selective-test");
+        long folderId = folderService.create("selective-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -229,7 +229,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload
-        folderService.upload("selective-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -260,7 +260,7 @@ public class RecalculateTest extends FreshDb {
     public void recalculate_returns_completable_future() throws Exception {
         // Verify that recalculate returns a future we can wait on
         tm.begin();
-        long id = folderService.create("future-test");
+        long id = folderService.create("future-test").id();
         FolderEntity folder = folderService.read(id);
         tm.commit();
 
@@ -277,7 +277,7 @@ public class RecalculateTest extends FreshDb {
         // Upload multiple values, verify change detection fires, then recalculate
         // and verify change detection results are consistent (same count).
         tm.begin();
-        long folderId = folderService.create("multi-recalc-test");
+        long folderId = folderService.create("multi-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode rangeNode = new JqNode("range", ".y", folder.group.root);
@@ -299,15 +299,15 @@ public class RecalculateTest extends FreshDb {
 
         // Create fingerprint + fixed threshold (max=50 → y=100 will violate)
         Long fpNodeId = nodeService.createConfigured("_fp", groupId,
-                io.hyperfoil.tools.h5m.api.NodeType.FINGERPRINT, List.of(fpSourceId), null);
+                io.hyperfoil.tools.h5m.api.NodeType.FINGERPRINT, List.of(fpSourceId), null).id();
         Long ftNodeId = nodeService.createConfigured("ft", groupId,
                 io.hyperfoil.tools.h5m.api.NodeType.FIXED_THRESHOLD,
                 List.of(fpNodeId, folder.group.root.id, rangeId),
-                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null));
+                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null)).id();
 
         // Upload 3 values that all exceed the threshold
         for (int i = 0; i < 3; i++) {
-            folderService.upload("multi-recalc-test",
+            folderService.upload(folderId,
                     JqValues.parse(String.format("{\"y\": %d, \"fp\": \"default\"}", 100 + i * 10)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
@@ -342,7 +342,7 @@ public class RecalculateTest extends FreshDb {
         // When a node's operation changes, recalculateNode should produce
         // values reflecting the new operation, not the old one.
         tm.begin();
-        long folderId = folderService.create("update-recalc-test");
+        long folderId = folderService.create("update-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
@@ -354,7 +354,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("update-recalc-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -392,7 +392,7 @@ public class RecalculateTest extends FreshDb {
     public void recalculateNode_tracks_progress() throws Exception {
         // Upload multiple values, then recalculate and verify progress tracking
         tm.begin();
-        long folderId = folderService.create("progress-test");
+        long folderId = folderService.create("progress-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
@@ -404,7 +404,7 @@ public class RecalculateTest extends FreshDb {
 
         // Upload 3 values
         for (int i = 0; i < 3; i++) {
-            folderService.upload("progress-test",
+            folderService.upload(folderId,
                     JqValues.parse(String.format("{\"key\": \"value_%d\"}", i)))
                     .future.orTimeout(30, TimeUnit.SECONDS).join();
         }
@@ -444,7 +444,7 @@ public class RecalculateTest extends FreshDb {
         //
         // Pipeline: root → each (.items[]) → value ({each}:.v)
         tm.begin();
-        long folderId = folderService.create("split-recalc-test");
+        long folderId = folderService.create("split-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         // JQ node that splits the array — produces multiple values
@@ -467,7 +467,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data with 2 items (datasets) per upload
-        folderService.upload("split-recalc-test",  JqValues.parse(
+        folderService.upload(folderId, JqValues.parse(
                 "{\"items\": [{\"v\": 10}, {\"v\": 20}]}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -482,7 +482,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload a second data point
-        folderService.upload("split-recalc-test",  JqValues.parse(
+        folderService.upload(folderId, JqValues.parse(
                 "{\"items\": [{\"v\": 30}, {\"v\": 40}]}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -526,7 +526,7 @@ public class RecalculateTest extends FreshDb {
         // reads the recomputed extract data, produces the same result.
         // After recalculate: extract.data nullified again, transform.data preserved.
         tm.begin();
-        long folderId = folderService.create("ephemeral-recalc-test");
+        long folderId = folderService.create("ephemeral-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
@@ -550,7 +550,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("ephemeral-recalc-test",  JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: extract data should be NULL (ephemeral), transform data should be present
@@ -595,7 +595,7 @@ public class RecalculateTest extends FreshDb {
         // recalculateNode(C) must walk up past B and A to find the root,
         // then recompute A → B → C via cascade.
         tm.begin();
-        long folderId = folderService.create("chain-recalc-test");
+        long folderId = folderService.create("chain-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -623,7 +623,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("chain-recalc-test", JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify after upload: A and B are nullified, C has data
@@ -676,7 +676,7 @@ public class RecalculateTest extends FreshDb {
         // C has two sources: A (KEEP, has data) and B (DISCARD, data=NULL)
         // recalculateNode(C) must walk up B's chain (to root) but not A's.
         tm.begin();
-        long folderId = folderService.create("mixed-recalc-test");
+        long folderId = folderService.create("mixed-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -705,7 +705,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("mixed-recalc-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -747,7 +747,7 @@ public class RecalculateTest extends FreshDb {
         // Pipeline: root → A(.key) [KEEP]
         // recalculateNode(A) — source is root (always has data), no walk needed.
         tm.begin();
-        long folderId = folderService.create("toplevel-recalc-test");
+        long folderId = folderService.create("toplevel-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -759,7 +759,7 @@ public class RecalculateTest extends FreshDb {
         long nodeAId = nodeA.id;
         tm.commit();
 
-        folderService.upload("toplevel-recalc-test", JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         tm.begin();
@@ -779,7 +779,7 @@ public class RecalculateTest extends FreshDb {
     public void findRecomputationStartNodes_returns_target_when_sources_available() throws Exception {
         // Unit test for the helper method directly
         tm.begin();
-        long folderId = folderService.create("start-nodes-test");
+        long folderId = folderService.create("start-nodes-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -807,7 +807,7 @@ public class RecalculateTest extends FreshDb {
     public void findRecomputationStartNodes_walks_up_past_ephemeral() throws Exception {
         // Unit test: A[DISCARD] → B[KEEP], recalculating B should start from A
         tm.begin();
-        long folderId = folderService.create("walk-up-test");
+        long folderId = folderService.create("walk-up-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -836,7 +836,7 @@ public class RecalculateTest extends FreshDb {
         // Unit test: A[DISCARD] → B[DISCARD] → C[KEEP]
         // recalculating C should start from A (walk all the way up)
         tm.begin();
-        long folderId = folderService.create("walk-chain-test");
+        long folderId = folderService.create("walk-chain-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -872,7 +872,7 @@ public class RecalculateTest extends FreshDb {
         // Verify that recalculate() creates a ProcessingTrackerEntity
         // and marks it completed when processing finishes.
         tm.begin();
-        long folderId = folderService.create("tracking-test");
+        long folderId = folderService.create("tracking-test").id();
         FolderEntity folder = folderService.read(folderId);
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
         extract.group = folder.group;
@@ -881,7 +881,7 @@ public class RecalculateTest extends FreshDb {
         folder.group.persist();
         tm.commit();
 
-        folderService.upload("tracking-test",  JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Recalculate and wait
@@ -903,7 +903,7 @@ public class RecalculateTest extends FreshDb {
         // Simulate a crash during recalculation by manually creating an
         // incomplete tracker, then calling recovery.
         tm.begin();
-        long folderId = folderService.create("recovery-recalc-test");
+        long folderId = folderService.create("recovery-recalc-test").id();
         FolderEntity folder = folderService.read(folderId);
         JqNode extract = new JqNode("extract", ".key", folder.group.root);
         extract.group = folder.group;
@@ -915,7 +915,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("recovery-recalc-test",  JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Simulate crash: create incomplete recalculation tracker
@@ -951,7 +951,7 @@ public class RecalculateTest extends FreshDb {
         // ephemeral source chain: root → A[DISCARD] → B[DISCARD] → C[KEEP]
         // Recovery should walk up the ephemeral chain and recompute correctly.
         tm.begin();
-        long folderId = folderService.create("recovery-ephemeral-test");
+        long folderId = folderService.create("recovery-ephemeral-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -979,7 +979,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload data
-        folderService.upload("recovery-ephemeral-test",  JqValues.parse("{\"key\": \"hello\"}"))
+        folderService.upload(folderId, JqValues.parse("{\"key\": \"hello\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
         // Verify: A and B nullified, C has data
@@ -1033,7 +1033,7 @@ public class RecalculateTest extends FreshDb {
         // producing "world", but B and C still have old values.
         // Recovery should detect the incomplete state and re-process B and C.
         tm.begin();
-        long folderId = folderService.create("mid-process-test");
+        long folderId = folderService.create("mid-process-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -1061,7 +1061,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload initial data
-        folderService.upload("mid-process-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -1133,7 +1133,7 @@ public class RecalculateTest extends FreshDb {
         // Simulate: node A's operation changed to .other, but crash before reprocessing.
         // Recovery must walk up the ephemeral chain and recompute everything.
         tm.begin();
-        long folderId = folderService.create("mid-ephemeral-test");
+        long folderId = folderService.create("mid-ephemeral-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -1161,7 +1161,7 @@ public class RecalculateTest extends FreshDb {
         tm.commit();
 
         // Upload initial data
-        folderService.upload("mid-ephemeral-test",
+        folderService.upload(folderId,
                 JqValues.parse("{\"key\": \"hello\", \"other\": \"world\"}"))
                 .future.orTimeout(30, TimeUnit.SECONDS).join();
 
@@ -1227,7 +1227,7 @@ public class RecalculateTest extends FreshDb {
     @Test
     public void recalculateNode_rejects_node_without_group() throws Exception {
         tm.begin();
-        long folderId = folderService.create("no-group-test");
+        long folderId = folderService.create("no-group-test").id();
         FolderEntity folder = folderService.read(folderId);
         JqNode orphan = new JqNode("orphan", ".key", folder.group.root);
         // Intentionally leave group=null to simulate an orphan node
@@ -1247,7 +1247,7 @@ public class RecalculateTest extends FreshDb {
         // C has two sources: A (ephemeral) and B (KEEP).
         // Start nodes should include A (needs recompute) but not B.
         tm.begin();
-        long folderId = folderService.create("diamond-test");
+        long folderId = folderService.create("diamond-test").id();
         FolderEntity folder = folderService.read(folderId);
 
         JqNode nodeA = new JqNode("a", ".key", folder.group.root);
@@ -1307,7 +1307,7 @@ public class RecalculateTest extends FreshDb {
     @Test
     public void recovery_with_deleted_node_cleans_up_tracker() throws Exception {
         tm.begin();
-        long folderId = folderService.create("recovery-deleted-node-test");
+        long folderId = folderService.create("recovery-deleted-node-test").id();
         tm.commit();
 
         tm.begin();

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateWorkQueueTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateWorkQueueTest.java
@@ -49,7 +49,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -62,7 +62,7 @@ public class RecalculateWorkQueueTest {
         b.persist();
         tm.commit();
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
                 """
                 { "a" : 1  }
                 """
@@ -141,7 +141,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -155,7 +155,7 @@ public class RecalculateWorkQueueTest {
         b.persist();
         tm.commit();
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
             """
             { "a" : 1  }
             """
@@ -201,7 +201,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -215,7 +215,7 @@ public class RecalculateWorkQueueTest {
         b.persist();
         tm.commit();
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
                 """
                 { "a" : 1  }
                 """
@@ -267,7 +267,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -280,7 +280,7 @@ public class RecalculateWorkQueueTest {
         b.persist();
         tm.commit();
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
                 """
                 { "a" : 1  }
                 """
@@ -350,7 +350,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -365,7 +365,7 @@ public class RecalculateWorkQueueTest {
 
         assertTrue(nodeService.isEphemeral(a),"a should be ephemeral");
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
                 """
                 { "a" : 1  }
                 """
@@ -461,7 +461,7 @@ public class RecalculateWorkQueueTest {
                 .get()
                 .getMethodName();
         tm.begin();
-        long folderId = folderService.create(testName);
+        long folderId = folderService.create(testName).id();
         FolderEntity folder = folderService.read(folderId);
 
         assertNotNull(folder);
@@ -480,7 +480,7 @@ public class RecalculateWorkQueueTest {
         t.persist();
         tm.commit();
 
-        Upload uploaded = folderService.upload(testName,JqValues.parse(
+        Upload uploaded = folderService.upload(folderId,JqValues.parse(
                 """
                 { "a" : 1 }
                 """

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
@@ -26,7 +26,7 @@ public class TeamServiceTest extends FreshDb {
     void create_team() {
         long id = teamService.create("test-team");
         assertTrue(id > 0);
-        Team team = teamService.byName("test-team");
+        Team team = teamService.find("test-team");
         assertNotNull(team);
         assertEquals("test-team", team.name());
     }
@@ -42,9 +42,9 @@ public class TeamServiceTest extends FreshDb {
     @Test
     void delete_team() {
         long id = teamService.create("to-delete");
-        assertNotNull(teamService.byName("to-delete"));
+        assertNotNull(teamService.find("to-delete"));
         teamService.delete(id);
-        assertNull(teamService.byName("to-delete"));
+        assertNull(teamService.find("to-delete"));
     }
 
     @Test

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/ValueServiceTest.java
@@ -2003,12 +2003,13 @@ public class ValueServiceTest extends FreshDb {
         // 4, 21, and 62, then verifies getGroupedValues sorts by BUILD_ID numerically
         // (4, 21, 62) — not lexicographically ("21", "4", "62").
         folderService.importFolder(Path.of("src/test/resources/qvss/nodes.json"), false);
+        long qvssFolderId = folderService.find("quarkus-spring-boot-comparison").id();
 
         // Upload 3 runs with BUILD_IDs that differ in text vs numeric sort order
         for (String runFile : List.of("/qvss/15248.json", "/qvss/15769.json", "/qvss/16326.json")) {
             try (InputStream is = getClass().getResourceAsStream(runFile)) {
                 JqValue runData = JqValues.parse(is.readAllBytes());
-                folderService.upload("quarkus-spring-boot-comparison",  runData)
+                folderService.upload(qvssFolderId, runData)
                         .future.orTimeout(60, TimeUnit.SECONDS).join();
             }
         }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/WorkQueueRaceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/WorkQueueRaceTest.java
@@ -61,7 +61,7 @@ public class WorkQueueRaceTest extends FreshDb {
     @Test
     @Tag("postgresql-only")
     void rapidUploadsShouldProduceAllValues() throws Exception {
-        createThreeNodeTopology("rapid_test");
+        long folderId = createThreeNodeTopology("rapid_test");
 
         // Upload all files back-to-back without draining — maximizes contention.
         // try/finally ensures the queue drains before FreshDb's @AfterEach truncation,
@@ -69,7 +69,7 @@ public class WorkQueueRaceTest extends FreshDb {
         try {
             for (String fileName : TEST_FILES) {
                 JqValue data = loadQvssFile(fileName);
-                folderService.upload("rapid_test",  data);
+                folderService.upload(folderId, data);
             }
         } finally {
             awaitWorkQueue(30_000);
@@ -85,12 +85,12 @@ public class WorkQueueRaceTest extends FreshDb {
      */
     @Test
     void sequentialUploadsShouldProduceAllValues() throws Exception {
-        createThreeNodeTopology("sequential_test");
+        long folderId = createThreeNodeTopology("sequential_test");
 
         try {
             for (String fileName : TEST_FILES) {
                 JqValue data = loadQvssFile(fileName);
-                folderService.upload("sequential_test", data);
+                folderService.upload(folderId, data);
                 awaitWorkQueue(30_000);
             }
         } finally {
@@ -112,10 +112,10 @@ public class WorkQueueRaceTest extends FreshDb {
                 ". Missing values indicate the race condition silently dropped work. See #50");
     }
 
-    private void createThreeNodeTopology(String folderName) throws Exception {
+    private long createThreeNodeTopology(String folderName) throws Exception {
         tm.begin();
         try {
-            long folderId = folderService.create(folderName);
+            long folderId = folderService.create(folderName).id();
             FolderEntity folder = folderService.read(folderId);
             NodeGroupEntity group = folder.group;
             NodeEntity root = group.root;
@@ -133,6 +133,7 @@ public class WorkQueueRaceTest extends FreshDb {
             n3.persist();
 
             tm.commit();
+            return folderId;
         } catch (Exception e) {
             tm.rollback();
             throw e;


### PR DESCRIPTION
### Summary
 
  - Replace name-based path parameters with numeric IDs for folder, view, and notification sub-resources
  - Return full entity objects from create/delete endpoints instead of bare IDs
  - Rename `byName()` service methods to `find()` across all service interfaces
  - Update frontend components, CLI commands, and tests to match the new API
  
### Motivation
  Name-based resource identifiers in URL paths are fragile: they break if a resource is renamed, require URL-encoding for names with special characters, and couple clients to a mutable attribute instead of a stable surrogate key. Using numeric IDs as path parameters follows REST conventions where URIs identify resources by stable, opaque identifiers (RFC 7231). Names that serve as lookup criteria are better suited as query parameters, which is where folder creation now takes its name.

Returning full entities from mutating operations eliminates the need for clients to issue a follow-up GET after every create, reducing round-trips and making the API more self-contained (per the principle of "respond with the resource representation").