### PR TITLE
Switch from uber-jar to fast-jar packaging (issue #244)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,11 @@
                                         <quarkus.native.enabled>${h5m.cli.native}</quarkus.native.enabled>
                                         <quarkus.profile>cli</quarkus.profile>
                                         <quarkus.package.output-directory>cli</quarkus.package.output-directory>
+                                        <!-- CLI uses uber-jar for single-file distribution.
+                                             Truffle Multi-Release check is disabled since uber-jar
+                                             merging loses the Multi-Release manifest attribute. -->
+                                        <quarkus.package.jar.type>uber-jar</quarkus.package.jar.type>
+                                        <quarkus.package.jar.add-runner-suffix>false</quarkus.package.jar.add-runner-suffix>
                                     </properties>
                                 </configuration>
                             </execution>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,8 +56,7 @@ quarkus.banner.enabled=false
 %dev.quarkus.http.cors.methods=GET,POST,PUT,DELETE,OPTIONS
 %dev.quarkus.http.cors.headers=content-type,authorization
 
-quarkus.package.jar.type=uber-jar
-quarkus.package.jar.add-runner-suffix=false
+quarkus.package.jar.type=fast-jar
 
 # open api
 quarkus.smallrye-openapi.operation-id-strategy=method


### PR DESCRIPTION
The Docker image crashed on startup with a GraalVM Truffle Multi-Release error because uber-jar merging loses the Multi-Release manifest attribute from Truffle's JARs.

Fix: switch quarkus.package.jar.type from uber-jar to fast-jar. Fast-jar keeps dependencies in their original JARs under quarkus-app/lib/, preserving Multi-Release attributes. This matches Horreum's packaging approach.

The Quarkus JIB extension (quarkus-container-image-jib) adapts automatically to fast-jar — no container configuration changes.

CLI profile keeps uber-jar for single-file distribution (quarkus.package.jar.type=uber-jar override in the cli Maven profile). CLI users running the uber-jar with JavaScript nodes need to add -Dpolyglotimpl.DisableMultiReleaseCheck=true to the java command line.