### PR TITLE
Import performance optimizations: 2.5x throughput improvement

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/ValueEntity.java
@@ -14,7 +14,9 @@ import io.hyperfoil.tools.jjq.jakarta.JqValueJavaType;
 import io.hyperfoil.tools.jjq.jakarta.JqValueJdbcType;
 import org.hibernate.annotations.JavaType;
 import org.hibernate.annotations.JdbcType;
+import org.hibernate.annotations.Mutability;
 import org.hibernate.annotations.NativeGenerator;
+import org.hibernate.type.descriptor.java.Immutability;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -38,6 +40,7 @@ public class ValueEntity extends PanacheEntityBase {
     @JdbcType(JqValueJdbcType.class)
     @JavaType(JqValueJavaType.class)
     @Basic(fetch = FetchType.LAZY)
+    @Mutability(Immutability.class)
     public JqValue data;
 
     //not yet used but the idea is to sort multiple values based on idx to preserve node output order for next nodes input
@@ -73,6 +76,7 @@ public class ValueEntity extends PanacheEntityBase {
             indexes = @Index(name = "idx_value_edge_parent", columnList = "parent_id")
     )
     @OrderColumn(name = "idx")
+    @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
     public List<ValueEntity> sources;
 
     public ValueEntity(){

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/work/Work.java
@@ -23,6 +23,12 @@ public class Work implements Runnable, Comparable<Work>{
 
     private Set<NodeEntity> activeNodes;
 
+    // Cached set of all transitive ancestor node IDs for activeNodes.
+    // Populated by precomputeAncestors() while the Hibernate session is open,
+    // then used by dependsOn() for O(1) lookups during WorkQueue sorting
+    // (which runs in afterCompletion, outside the session).
+    private Set<Long> ancestorNodeIds;
+
     /*
      * If the work should be performed after work for any dependent Nodes regardless of Values
      */
@@ -61,6 +67,7 @@ public class Work implements Runnable, Comparable<Work>{
 
     public void setActiveNodes(Set<NodeEntity> activeNodes) {
         this.activeNodes = activeNodes;
+        this.ancestorNodeIds = null; // invalidate cache — new active nodes need fresh ancestors
         if(activeNodes.stream().anyMatch(node -> node instanceof StdDevAnomaly || node instanceof EDivisive)){
             this.cumulative = true;
         }else{
@@ -68,6 +75,31 @@ public class Work implements Runnable, Comparable<Work>{
         }
     }
     public List<Long> getSourceValueIds(){return sourceValueIds;}
+
+    /**
+     * Pre-computes the transitive ancestor node IDs for all active nodes.
+     * Must be called while the Hibernate session is open (sources are lazy).
+     * After this, dependsOn() uses O(1) Set.contains() instead of traversing
+     * the NodeEntity.sources graph.
+     */
+    public void precomputeAncestors() {
+        if (activeNodes == null || activeNodes.isEmpty()) return;
+        ancestorNodeIds = new HashSet<>();
+        Queue<NodeEntity> queue = new ArrayDeque<>();
+        for (NodeEntity activeNode : activeNodes) {
+            if (activeNode.sources != null) {
+                queue.addAll(activeNode.sources);
+            }
+        }
+        while (!queue.isEmpty()) {
+            NodeEntity node = queue.poll();
+            if (node.id != null && ancestorNodeIds.add(node.id)) {
+                if (node.sources != null) {
+                    queue.addAll(node.sources);
+                }
+            }
+        }
+    }
 
     //work A depends on work B if A.activeNode depends on B.activeNode
     public boolean dependsOn(Work work){
@@ -78,17 +110,26 @@ public class Work implements Runnable, Comparable<Work>{
         if (this.activeNodes == null || this.activeNodes.isEmpty()) {
             return false;
         }
-        // Check node-level dependency: does any of this Work's active nodes
-        // depend on any of the other Work's active nodes?
+        // Fast path: use pre-computed ancestor IDs if available
         boolean hasNodeDependency = false;
-        for (NodeEntity thisNode : this.activeNodes) {
+        if (ancestorNodeIds != null) {
             for (NodeEntity otherNode : work.activeNodes) {
-                if (thisNode.dependsOn(otherNode)) {
+                if (otherNode.id != null && ancestorNodeIds.contains(otherNode.id)) {
                     hasNodeDependency = true;
                     break;
                 }
             }
-            if (hasNodeDependency) break;
+        } else {
+            // Fallback: traverse the source graph (requires active Hibernate session)
+            for (NodeEntity thisNode : this.activeNodes) {
+                for (NodeEntity otherNode : work.activeNodes) {
+                    if (thisNode.dependsOn(otherNode)) {
+                        hasNodeDependency = true;
+                        break;
+                    }
+                }
+                if (hasNodeDependency) break;
+            }
         }
         if (!hasNodeDependency) {
             return false;
@@ -192,6 +233,7 @@ public class Work implements Runnable, Comparable<Work>{
         sourceValueIds = null;
         sourceNodes = null;
         activeNodes = null;
+        ancestorNodeIds = null;
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -1265,7 +1265,7 @@ public class NodeService implements NodeServiceInterface {
                             newValue.sources = node.sources.stream().filter(n->sourceValues.containsKey(n.getId())).map(n -> sourceValues.get(n.getId())).collect(Collectors.toList());
                             rtrn.add(newValue);
                         }else{
-                            System.err.println("null data from value "+resolvedValue+" from node="+node.name);
+                            Log.debugf("null data from value %s from node=%s", resolvedValue, node.name);
                         }
                     }catch (PolyglotException pe){
                         System.err.println("exception jsNode "+node.name+" sourceValues="+sourceValues+"\n"+pe.getMessage());

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PessimisticLockException;
 import jakarta.transaction.Status;
@@ -30,7 +31,7 @@ import io.hyperfoil.tools.h5m.provided.DatabaseEngine;
 import static io.hyperfoil.tools.h5m.provided.DatabaseEngine.Kind.*;
 import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.hibernate.Hibernate;
+
 
 import java.time.Duration;
 import java.util.*;
@@ -38,6 +39,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -212,13 +214,10 @@ public class WorkService implements WorkServiceInterface {
         if (!newWorks.isEmpty()) {
             List<Work> toQueue = List.copyOf(newWorks);
             for (Work work : toQueue) {
-                // Pre-compute ancestor caches while session is open — needed by
-                // WorkQueue.sort() → dependsOn() which runs in afterCompletion
-                // outside the session. Without this, dependsOn() would try to
-                // lazily traverse NodeEntity.sources and fail.
-                if (work.getActiveNodes() != null) {
-                    work.dependsOn(work);
-                }
+                // Pre-compute ancestor node IDs while the Hibernate session is
+                // open. WorkQueue.sort() → dependsOn() runs in afterCompletion
+                // (outside the session) and needs these for O(1) dependency checks.
+                work.precomputeAncestors();
                 // Increment trackers for each work item (before afterCompletion decrement)
                 incrementTrackers(work, 1);
             }
@@ -308,16 +307,25 @@ public class WorkService implements WorkServiceInterface {
         WorkQueue workQueue = workExecutor.getWorkQueue();
         boolean decrementDeferred = false;
         try {
-            // Load source values by ID from the database (or 2LC cache).
-            // Work only carries value IDs — full entities are loaded here in
-            // the transaction that needs them.
-            List<ValueEntity> sourceValues = new ArrayList<>();
-            for (Long valueId : w.getSourceValueIds()) {
-                ValueEntity managed = em.find(ValueEntity.class, valueId);
-                if (managed != null) {
-                    Hibernate.initialize(managed.data);
-                    sourceValues.add(managed);
-                }
+            // Batch-load source values with data and sources eagerly fetched
+            // via Entity Graph. The 2LC does not cache @Basic(LAZY) properties
+            // for entities with associations (HHH-20773), so em.find() cache
+            // hits still trigger a DB round-trip for the lazy data field.
+            // The fetchgraph hint tells Hibernate to treat data and sources as
+            // eager for this query, loading everything in one round-trip.
+            List<ValueEntity> sourceValues;
+            List<Long> sourceIds = w.getSourceValueIds();
+            if (sourceIds == null || sourceIds.isEmpty()) {
+                sourceValues = List.of();
+            } else {
+                EntityGraph<ValueEntity> graph = em.createEntityGraph(ValueEntity.class);
+                graph.addAttributeNodes("data", "sources");
+                sourceValues = em.createQuery(
+                        "SELECT v FROM value v WHERE v.id IN :ids",
+                        ValueEntity.class)
+                    .setHint("jakarta.persistence.fetchgraph", graph)
+                    .setParameter("ids", sourceIds)
+                    .getResultList();
             }
 
             // Reload active nodes in this transaction's persistence context —


### PR DESCRIPTION
Three optimizations for the bulk import pipeline, verified with async-profiler CPU and allocation profiling on test 339 (rhivos-perf-comprehensive, 1,327 runs, 129 nodes):

1. Cache ValueEntity.sources collection in 2LC (ValueEntity.java)
   - Add @Cache(READ_ONLY) on the sources @ManyToMany collection
   - Eliminates N+1 collection loading when entities are served from the Hibernate second-level cache
   - Restore @Mutability(Immutability.class) on data field, accidentally removed in PR #182. Tells Hibernate the JqValue is immutable, reducing deep-copy overhead during cache entry construction (~6% throughput improvement)

2. Batch JPQL for source value loading in WorkService (WorkService.java)
   - Replace N separate em.find() + Hibernate.initialize(data) calls with a single JPQL query that eagerly loads source values with their data and sources collections in one round-trip
   - The 2LC does not cache @Basic(LAZY) BYTEA properties for entities with associations (filed as HHH-20773), so em.find() cache hits still triggered a DB round-trip for every lazy data access
   - The JPQL query bypasses this limitation entirely

3. Pre-compute ancestor node IDs for Work dependency checks (Work.java)
   - Add precomputeAncestors() that collects all transitive ancestor node IDs into a HashSet while the Hibernate session is open
   - dependsOn() uses O(1) Set.contains() instead of O(n) graph traversal through NodeEntity.dependsOn() which triggered Hibernate bytecode interceptor overhead on every getId() call
   - Called in WorkService.create() replacing the work.dependsOn(work) hack that only initialized lazy sources without caching results
   - Eliminates ~16% CPU from KahnDagSort during WorkQueue.addWorks()

Benchmark: test 339, 100 runs, batch=5, 8GB heap, 4 core / 10 max pool
  Before: 176 values/sec (baseline main branch)
  After:  434 values/sec (+147%)
  Steady-state peaks: 500-535 values/sec