### PR TITLE
Convert simple JsNode calculations to JqNode during legacy import (is…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/cli/JsToJqPatterns.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/JsToJqPatterns.java
@@ -1,0 +1,207 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts simple JavaScript function patterns found in Horreum labels to
+ * equivalent jq expressions. This allows the import pipeline to create
+ * JqNode instances instead of JsNode instances, eliminating GraalVM Truffle
+ * interpreter overhead for these common patterns.
+ * <p>
+ * Only patterns that have been verified across real Horreum test data are
+ * supported. Unsupported patterns return {@code null} and fall back to JsNode.
+ *
+ * @see <a href="https://github.com/Hyperfoil/h5m/issues/247">Issue #247</a>
+ */
+public class JsToJqPatterns {
+
+    private JsToJqPatterns() {}
+
+    // --- Pattern 1: Simple division ---
+    // time => time / 1000000
+    // v => v / 1e+6;
+    // (v) => v / 1e+6
+    private static final Pattern SIMPLE_DIVISION = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*\\w+\\s*/\\s*([\\d.eE+]+)\\s*;?\\s*"
+    );
+
+    // --- Pattern 2: Division + rounding via parseFloat/toFixed ---
+    // value => parseFloat((value / 1000000).toFixed(2))
+    private static final Pattern DIVISION_TOFIXED = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*parseFloat\\(\\(\\w+\\s*/\\s*([\\d.eE+]+)\\)\\.toFixed\\((\\d+)\\)\\)\\s*;?\\s*"
+    );
+
+    // --- Pattern 3: Simple array mean ---
+    // fd => fd.reduce((a,b) => a+b) / fd.length
+    // (start) => start.reduce((a,b) => a+b) / start.length
+    private static final Pattern ARRAY_MEAN_SIMPLE = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*\\w+\\.reduce\\(\\(\\w+,\\s*\\w+\\)\\s*=>\\s*\\w+\\s*\\+\\s*\\w+\\)\\s*/\\s*\\w+\\.length\\s*;?\\s*"
+    );
+
+    // --- Pattern 4: Array mean with null guard + toFixed ---
+    // value => { if(!value) { return 0 } else { return parseFloat(((value.reduce((a,b) => a+b, 0))/value.length).toFixed(3)) || null }; }
+    // Also matches variant with *1000 before toFixed
+    private static final Pattern ARRAY_MEAN_GUARDED = Pattern.compile(
+            "\\s*\\w+\\s*=>\\s*\\{\\s*if\\s*\\(\\s*!\\s*\\w+\\s*\\)\\s*\\{\\s*return\\s+0\\s*;?\\s*\\}\\s*else\\s*\\{\\s*return\\s+parseFloat\\(\\(\\(\\w+\\.reduce\\(\\(\\w+,\\s*\\w+\\)\\s*=>\\s*\\w+\\s*\\+\\s*\\w+,\\s*0\\)\\)\\s*/\\s*\\w+\\.length(\\s*\\*\\s*([\\d.]+))?\\)\\.toFixed\\((\\d+)\\)\\)\\s*(\\|\\|\\s*null)?\\s*;?\\s*\\}\\s*;?\\s*\\}\\s*;?\\s*"
+    );
+
+    // --- Pattern 5: Conditional filter + array mean ---
+    // value => { if (value["workload"] != "autobench") { return null } if(!value["results"]) { return 0 } else { return parseFloat(...) } }
+    private static final Pattern CONDITIONAL_ARRAY_MEAN = Pattern.compile(
+            "\\s*\\w+\\s*=>\\s*\\{\\s*if\\s*\\(\\s*\\w+\\[\"(\\w+)\"\\]\\s*!=\\s*\"(\\w+)\"\\s*\\)\\s*\\{\\s*return\\s+null\\s*;?\\s*\\}\\s*;?\\s*if\\s*\\(\\s*!\\s*\\w+\\[\"(\\w+)\"\\]\\s*\\)\\s*\\{\\s*return\\s+0\\s*;?\\s*\\}\\s*else\\s*\\{\\s*return\\s+parseFloat\\(\\(\\(\\w+\\[\"\\3\"\\]\\.reduce\\(\\(\\w+,\\s*\\w+\\)\\s*=>\\s*\\w+\\s*\\+\\s*\\w+,\\s*0\\)\\)\\s*/\\s*\\w+\\[\"\\3\"\\]\\.length\\)\\.toFixed\\((\\d+)\\)\\).*\\}\\s*;?\\s*\\}\\s*;?\\s*"
+    );
+
+    // --- Pattern 6: Array max ---
+    // fd => Math.max(...fd)
+    private static final Pattern ARRAY_MAX = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*Math\\.max\\(\\.\\.\\.\\w+\\)\\s*;?\\s*"
+    );
+
+    // --- Pattern 7: Array min ---
+    // fd => Math.min(...fd)
+    private static final Pattern ARRAY_MIN = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*Math\\.min\\(\\.\\.\\.\\w+\\)\\s*;?\\s*"
+    );
+
+    // --- Pattern 8: Null guard (return "N/A" or value) ---
+    // value => { if (value == null) { return "N/A" } else { return value } }
+    private static final Pattern NULL_GUARD = Pattern.compile(
+            "\\s*\\w+\\s*=>\\s*\\{\\s*if\\s*\\(\\s*\\w+\\s*==\\s*null\\s*\\)\\s*\\{\\s*return\\s+\"([^\"]+)\"\\s*;?\\s*\\}\\s*else\\s*\\{\\s*return\\s+\\w+\\s*;?\\s*\\}\\s*\\}\\s*;?\\s*"
+    );
+
+    // --- Pattern 9: parseInt / Number.parseInt ---
+    // value => Number.parseInt(value)
+    // value => parseInt(value)
+    private static final Pattern PARSE_INT = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*(?:Number\\.)?parseInt\\(\\w+\\)\\s*;?\\s*"
+    );
+
+    // --- Pattern 10: Simple time division ---
+    // time => time / 1000000  (function keyword variant)
+    // Create Legume 50% Percentile ms: time => time / 1000000
+    // Already covered by SIMPLE_DIVISION
+
+    // --- Pattern 11: Array max of field with Math.round ---
+    // (value) => Math.round(value.reduce((curMax, result) => Math.max(curMax, result["throughput"]), 0))
+    private static final Pattern ARRAY_MAX_FIELD_ROUNDED = Pattern.compile(
+            "\\s*\\(?\\s*\\w+\\s*\\)?\\s*=>\\s*Math\\.round\\(\\w+\\.reduce\\(\\(\\w+,\\s*\\w+\\)\\s*=>\\s*Math\\.max\\(\\w+,\\s*\\w+\\[\"(\\w+)\"\\]\\),\\s*0\\)\\)\\s*;?\\s*"
+    );
+
+    /**
+     * Attempts to convert a JavaScript function string to an equivalent jq
+     * expression. Returns the jq expression string if a known pattern matches,
+     * or {@code null} if the function is not convertible.
+     *
+     * @param jsFunction the JavaScript function source code
+     * @return the equivalent jq expression, or {@code null}
+     */
+    public static String tryConvert(String jsFunction) {
+        if (jsFunction == null || jsFunction.isBlank()) {
+            return null;
+        }
+
+        // Normalize whitespace for matching (but keep original for backrefs)
+        String normalized = jsFunction.replaceAll("\\s+", " ").trim();
+
+        Matcher m;
+
+        // Pattern 2: Division + toFixed (check before simple division since it's more specific)
+        m = DIVISION_TOFIXED.matcher(normalized);
+        if (m.matches()) {
+            double divisor = parseNumber(m.group(1));
+            int decimals = Integer.parseInt(m.group(2));
+            long multiplier = (long) Math.pow(10, decimals);
+            return String.format(". / %s * %d | round / %d", formatNumber(divisor), multiplier, multiplier);
+        }
+
+        // Pattern 1: Simple division
+        m = SIMPLE_DIVISION.matcher(normalized);
+        if (m.matches()) {
+            double divisor = parseNumber(m.group(1));
+            return ". / " + formatNumber(divisor);
+        }
+
+        // Pattern 5: Conditional filter + array mean (check before guarded mean since it's more specific)
+        m = CONDITIONAL_ARRAY_MEAN.matcher(normalized);
+        if (m.matches()) {
+            String filterField = m.group(1);
+            String filterValue = m.group(2);
+            String arrayField = m.group(3);
+            int decimals = Integer.parseInt(m.group(4));
+            long multiplier = (long) Math.pow(10, decimals);
+            return String.format(
+                    "if .\"%s\" != \"%s\" then null elif (.\"%s\" == null or .\"%s\" == false) then 0 else (.\"%s\" | add / length * %d | round / %d) end",
+                    filterField, filterValue, arrayField, arrayField, arrayField, multiplier, multiplier);
+        }
+
+        // Pattern 4: Array mean with null guard + toFixed
+        m = ARRAY_MEAN_GUARDED.matcher(normalized);
+        if (m.matches()) {
+            String scaleStr = m.group(2); // optional multiplier (e.g., *1000)
+            int decimals = Integer.parseInt(m.group(3));
+            long multiplier = (long) Math.pow(10, decimals);
+            double scale = scaleStr != null ? Double.parseDouble(scaleStr) : 1.0;
+            if (scale != 1.0) {
+                return String.format(
+                        "if . == null or . == false then 0 elif length == 0 then null else (add / length * %s * %d | round / %d) end",
+                        formatNumber(scale), multiplier, multiplier);
+            }
+            return String.format(
+                    "if . == null or . == false then 0 elif length == 0 then null else (add / length * %d | round / %d) end",
+                    multiplier, multiplier);
+        }
+
+        // Pattern 3: Simple array mean
+        m = ARRAY_MEAN_SIMPLE.matcher(normalized);
+        if (m.matches()) {
+            return "add / length";
+        }
+
+        // Pattern 6: Array max
+        m = ARRAY_MAX.matcher(normalized);
+        if (m.matches()) {
+            return "max";
+        }
+
+        // Pattern 7: Array min
+        m = ARRAY_MIN.matcher(normalized);
+        if (m.matches()) {
+            return "min";
+        }
+
+        // Pattern 11: Array max of field with rounding
+        m = ARRAY_MAX_FIELD_ROUNDED.matcher(normalized);
+        if (m.matches()) {
+            String field = m.group(1);
+            return String.format("[.[] | .%s] | max | round", field);
+        }
+
+        // Pattern 8: Null guard
+        m = NULL_GUARD.matcher(normalized);
+        if (m.matches()) {
+            String fallback = m.group(1);
+            return String.format("if . == null then \"%s\" else . end", fallback);
+        }
+
+        // Pattern 9: parseInt
+        m = PARSE_INT.matcher(normalized);
+        if (m.matches()) {
+            return "tonumber | floor";
+        }
+
+        return null;
+    }
+
+    private static double parseNumber(String s) {
+        // Handle scientific notation like 1e+6, 1e6, 1E+6
+        return Double.parseDouble(s.replace("e+", "e").replace("E+", "E"));
+    }
+
+    private static String formatNumber(double d) {
+        if (d == (long) d) {
+            return Long.toString((long) d);
+        }
+        return Double.toString(d);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
@@ -313,7 +313,15 @@ public class LoadLegacyTests implements Callable<Integer> {
             // whether the function uses named property access (value["key"]) or positional.
             List<NodeEntity> sources = labelNodesByName.values().stream()
                     .flatMap(List::stream).collect(Collectors.toList());
-            rtrn = new JsNode(label.name, label.function, sources);
+            // Try converting simple JS patterns to jq to avoid GraalVM Truffle
+            // interpreter overhead (issue #247). Only single-source labels with
+            // known patterns are converted.
+            String jqEquivalent = sources.size() == 1 ? JsToJqPatterns.tryConvert(label.function) : null;
+            if (jqEquivalent != null) {
+                rtrn = new JqNode(label.name, jqEquivalent, sources);
+            } else {
+                rtrn = new JsNode(label.name, label.function, sources);
+            }
             if(rtrn!=null){
                 nodeTracking.addNode(rtrn);
                 group.addNode(rtrn);
@@ -496,7 +504,11 @@ public class LoadLegacyTests implements Callable<Integer> {
                         //missing
                     }
                 }
-                NodeEntity variableNode = new JsNode(variable.name(),variable.calculation(),sources);
+                // Try converting simple JS variable calculations to jq (issue #247)
+                String jqCalc = sources.size() == 1 ? JsToJqPatterns.tryConvert(variable.calculation()) : null;
+                NodeEntity variableNode = jqCalc != null
+                        ? new JqNode(variable.name(), jqCalc, sources)
+                        : new JsNode(variable.name(), variable.calculation(), sources);
                 folder.group.addNode(variableNode);
                 nodeTracking.addNode(variableNode);
                 variableIdToNode.put(variable.id(),variableNode);

--- a/src/test/java/io/hyperfoil/tools/h5m/cli/JsToJqPatternsTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/cli/JsToJqPatternsTest.java
@@ -1,0 +1,228 @@
+package io.hyperfoil.tools.h5m.cli;
+
+import io.hyperfoil.tools.jjq.JqProgram;
+import io.hyperfoil.tools.jjq.value.JqArray;
+import io.hyperfoil.tools.jjq.value.JqNull;
+import io.hyperfoil.tools.jjq.value.JqNumber;
+import io.hyperfoil.tools.jjq.value.JqString;
+import io.hyperfoil.tools.jjq.value.JqValue;
+import io.hyperfoil.tools.jjq.value.JqValues;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link JsToJqPatterns} JS→jq conversion.
+ * Each test verifies both the pattern matching (returns non-null jq expression)
+ * and the semantic correctness (jq produces the expected result).
+ */
+class JsToJqPatternsTest {
+
+    // --- Pattern 1: Simple division ---
+
+    @Test
+    void simpleDivision() {
+        String jq = JsToJqPatterns.tryConvert("time => time / 1000000");
+        assertNotNull(jq);
+        assertEquals(". / 1000000", jq);
+        assertJqResult(jq, JqNumber.of(5000000), JqNumber.of(5.0));
+    }
+
+    @Test
+    void simpleDivisionScientific() {
+        String jq = JsToJqPatterns.tryConvert("v => v / 1e+6;");
+        assertNotNull(jq);
+        assertEquals(". / 1000000", jq);
+    }
+
+    @Test
+    void simpleDivisionWithParens() {
+        String jq = JsToJqPatterns.tryConvert("(v) => v / 1e+6");
+        assertNotNull(jq);
+    }
+
+    // --- Pattern 2: Division + toFixed ---
+
+    @Test
+    void divisionToFixed() {
+        String jq = JsToJqPatterns.tryConvert("value => parseFloat((value / 1000000).toFixed(2))");
+        assertNotNull(jq);
+        assertJqResult(jq, JqNumber.of(5123456), JqNumber.of(5.12));
+    }
+
+    // --- Pattern 3: Simple array mean ---
+
+    @Test
+    void arrayMeanSimple() {
+        String jq = JsToJqPatterns.tryConvert("fd => fd.reduce((a,b) => a+b) / fd.length");
+        assertNotNull(jq);
+        assertEquals("add / length", jq);
+        JqArray input = JqArray.of(JqNumber.of(10), JqNumber.of(20), JqNumber.of(30));
+        assertJqResult(jq, input, JqNumber.of(20.0));
+    }
+
+    @Test
+    void arrayMeanSimpleWithParens() {
+        String jq = JsToJqPatterns.tryConvert("(start) => start.reduce((a,b) => a+b) / start.length");
+        assertNotNull(jq);
+        assertEquals("add / length", jq);
+    }
+
+    // --- Pattern 4: Array mean with null guard ---
+
+    @Test
+    void arrayMeanGuarded() {
+        String jq = JsToJqPatterns.tryConvert(
+                "value => { if(!value) { return 0 } else { return parseFloat(((value.reduce((a,b) => a+b, 0))/value.length).toFixed(3)) || null }; }");
+        assertNotNull(jq);
+        // Test with array input
+        JqArray input = JqArray.of(JqNumber.of(10), JqNumber.of(20), JqNumber.of(30));
+        assertJqResult(jq, input, JqNumber.of(20.0));
+        // Test with null input
+        assertJqResult(jq, JqNull.NULL, JqNumber.of(0));
+    }
+
+    @Test
+    void arrayMeanGuardedWithMultiplier() {
+        String jq = JsToJqPatterns.tryConvert(
+                "value => { if(!value) { return 0 } else { return parseFloat(((value.reduce((a,b) => a+b, 0))/value.length*1000).toFixed(3))} };");
+        assertNotNull(jq);
+        JqArray input = JqArray.of(JqNumber.of(1.5), JqNumber.of(2.5));
+        JqValue result = evalJq(jq, input);
+        assertNotNull(result);
+        // (1.5 + 2.5) / 2 * 1000 = 2000.0
+        assertEquals(2000.0, result.asDouble(0), 0.001);
+    }
+
+    // --- Pattern 5: Conditional filter + array mean ---
+
+    @Test
+    void conditionalArrayMean() {
+        String jq = JsToJqPatterns.tryConvert(
+                "value => { if (value[\"workload\"] != \"autobench\") { return null } if(!value[\"results\"]) { return 0 } " +
+                "else { return parseFloat(((value[\"results\"].reduce((a,b) => a+b, 0))/value[\"results\"].length).toFixed(3)) } }");
+        assertNotNull(jq);
+        // Test with matching workload
+        JqValue input = JqValues.parse("{\"workload\":\"autobench\",\"results\":[10,20,30]}");
+        assertJqResult(jq, input, JqNumber.of(20.0));
+        // Test with non-matching workload
+        JqValue nonMatch = JqValues.parse("{\"workload\":\"other\",\"results\":[10]}");
+        assertJqResult(jq, nonMatch, JqNull.NULL);
+    }
+
+    // --- Pattern 6: Array max ---
+
+    @Test
+    void arrayMax() {
+        String jq = JsToJqPatterns.tryConvert("fd => Math.max(...fd)");
+        assertNotNull(jq);
+        assertEquals("max", jq);
+        JqArray input = JqArray.of(JqNumber.of(3), JqNumber.of(7), JqNumber.of(1));
+        assertJqResult(jq, input, JqNumber.of(7));
+    }
+
+    // --- Pattern 7: Array min ---
+
+    @Test
+    void arrayMin() {
+        String jq = JsToJqPatterns.tryConvert("fd => Math.min(...fd)");
+        assertNotNull(jq);
+        assertEquals("min", jq);
+        JqArray input = JqArray.of(JqNumber.of(3), JqNumber.of(7), JqNumber.of(1));
+        assertJqResult(jq, input, JqNumber.of(1));
+    }
+
+    // --- Pattern 8: Null guard ---
+
+    @Test
+    void nullGuard() {
+        String jq = JsToJqPatterns.tryConvert(
+                "value => { if (value == null) { return \"N/A\" } else { return value } }");
+        assertNotNull(jq);
+        assertJqResult(jq, JqNull.NULL, JqString.of("N/A"));
+        assertJqResult(jq, JqNumber.of(42), JqNumber.of(42));
+    }
+
+    // --- Pattern 9: parseInt ---
+
+    @Test
+    void parseInt() {
+        String jq = JsToJqPatterns.tryConvert("value => Number.parseInt(value)");
+        assertNotNull(jq);
+        assertJqResult(jq, JqString.of("42"), JqNumber.of(42));
+    }
+
+    @Test
+    void parseIntWithoutNumber() {
+        String jq = JsToJqPatterns.tryConvert("value => parseInt(value)");
+        assertNotNull(jq);
+    }
+
+    // --- Pattern 10: Array max of field with rounding ---
+
+    @Test
+    void arrayMaxFieldRounded() {
+        String jq = JsToJqPatterns.tryConvert(
+                "(value) => Math.round(value.reduce((curMax, result) => Math.max(curMax, result[\"throughput\"]), 0))");
+        assertNotNull(jq);
+        JqValue input = JqValues.parse("[{\"throughput\":100.7},{\"throughput\":200.3},{\"throughput\":150.5}]");
+        assertJqResult(jq, input, JqNumber.of(200));
+    }
+
+    // --- Non-convertible patterns ---
+
+    @Test
+    void complexTransformerNotConverted() {
+        assertNull(JsToJqPatterns.tryConvert(
+                "({stressng_sample_uuid, fio_sample_uuid}) => { var sngmap = stressng_sample_uuid.map((value, i) => ({uuid: value})); return [...sngmap]; }"));
+    }
+
+    @Test
+    void dateManipulationNotConverted() {
+        assertNull(JsToJqPatterns.tryConvert(
+                "value => { var test_date = new Date(value[\"start_time\"]); return test_date.toDateString(); }"));
+    }
+
+    @Test
+    void objectKeysNotConverted() {
+        assertNull(JsToJqPatterns.tryConvert(
+                "value => { const workloads = []; for (const section of Object.keys(value[\"results\"])) { workloads.push(value[\"results\"][section]); }; return workloads; }"));
+    }
+
+    @Test
+    void generatorFunctionNotConverted() {
+        assertNull(JsToJqPatterns.tryConvert(
+                "function* dataset({foo, bar, biz}){ yield foo; yield bar; yield biz; }"));
+    }
+
+    @Test
+    void nullInputReturnsNull() {
+        assertNull(JsToJqPatterns.tryConvert(null));
+        assertNull(JsToJqPatterns.tryConvert(""));
+        assertNull(JsToJqPatterns.tryConvert("   "));
+    }
+
+    // --- Helpers ---
+
+    private static JqValue evalJq(String jqExpression, JqValue input) {
+        JqProgram program = JqProgram.compile(jqExpression);
+        JqValue result = program.apply(input);
+        // If the result is an array from multiple outputs, take the first
+        if (result instanceof JqArray arr && arr.length() > 0) {
+            return arr.get(0);
+        }
+        return result;
+    }
+
+    private static void assertJqResult(String jqExpression, JqValue input, JqValue expected) {
+        JqValue actual = evalJq(jqExpression, input);
+        if (expected instanceof JqNumber e && actual instanceof JqNumber a) {
+            assertEquals(e.asDouble(0), a.asDouble(0), 0.001,
+                    "jq expression: " + jqExpression);
+        } else {
+            assertEquals(expected, actual, "jq expression: " + jqExpression);
+        }
+    }
+}


### PR DESCRIPTION
…sue #247)

Add JsToJqPatterns utility that detects common JavaScript function patterns from Horreum labels and converts them to equivalent jq expressions. This eliminates GraalVM Truffle interpreter allocation overhead (~19% of total allocation) for converted nodes.

Supported patterns (11 total):
- Simple division: v => v / 1000000
- Division + rounding: parseFloat((v/N).toFixed(D))
- Array mean: fd.reduce((a,b) => a+b) / fd.length
- Array mean with null guard + toFixed (FIO nodes)
- Conditional filter + array mean (Autobench nodes)
- Array max/min: Math.max(...fd), Math.min(...fd)
- Null guard: if (value == null) return "N/A"
- parseInt/Number.parseInt
- Array max of field with rounding (techempower)

Conversion happens during load-legacy-tests import only. Labels with single-source extractors are checked against the pattern catalog; if a match is found, a JqNode is created instead of a JsNode. Complex JS functions (transformers, multi-schema combiners, Date manipulation) fall back to JsNode unchanged.