### PR TITLE
add NodeConfiguration interface for typed detection config

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/FixedThresholdConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/FixedThresholdConfig.java
@@ -1,4 +1,0 @@
-package io.hyperfoil.tools.h5m.api;
-
-public record FixedThresholdConfig(Double min, Double max, Boolean minInclusive, Boolean maxInclusive, String fingerprintFilter) {
-}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/RelativeDifferenceConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/RelativeDifferenceConfig.java
@@ -1,4 +1,0 @@
-package io.hyperfoil.tools.h5m.api;
-
-public record RelativeDifferenceConfig(String filter, double threshold, int window, int minPrevious, String fingerprintFilter) {
-}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/EDivisiveConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/EDivisiveConfig.java
@@ -1,4 +1,6 @@
-package io.hyperfoil.tools.h5m.api;
+package io.hyperfoil.tools.h5m.api.node;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * Configuration for the E-Divisive (Hunter) change detection algorithm.
@@ -26,4 +28,5 @@ package io.hyperfoil.tools.h5m.api;
  *                        Bounds computation time for long-running tests.
  * @param fingerprintFilter optional jq filter to select specific fingerprint values
  */
-public record EDivisiveConfig(int windowLen, double maxPvalue, double minMagnitude, int maxSeriesLength, String fingerprintFilter) {}
+@Schema(description = "Configuration for the E-Divisive (Hunter) change detection algorithm")
+public record EDivisiveConfig(int windowLen, double maxPvalue, double minMagnitude, int maxSeriesLength, String fingerprintFilter) implements NodeConfiguration {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/FixedThresholdConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/FixedThresholdConfig.java
@@ -1,0 +1,7 @@
+package io.hyperfoil.tools.h5m.api.node;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Configuration for the Fixed Threshold detection algorithm")
+public record FixedThresholdConfig(Double min, Double max, Boolean minInclusive, Boolean maxInclusive, String fingerprintFilter) implements NodeConfiguration {
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/NodeConfiguration.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/NodeConfiguration.java
@@ -1,0 +1,37 @@
+package io.hyperfoil.tools.h5m.api.node;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.bind.annotation.JsonbTypeDeserializer;
+import jakarta.json.bind.serializer.DeserializationContext;
+import jakarta.json.bind.serializer.JsonbDeserializer;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParserFactory;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.lang.reflect.Type;
+
+@JsonbTypeDeserializer(NodeConfiguration.Deserializer.class)
+@Schema(oneOf = {FixedThresholdConfig.class, RelativeDifferenceConfig.class, StdDevAnomalyConfig.class, EDivisiveConfig.class})
+public sealed interface NodeConfiguration permits FixedThresholdConfig, RelativeDifferenceConfig, StdDevAnomalyConfig, EDivisiveConfig {
+
+    class Deserializer implements JsonbDeserializer<NodeConfiguration> {
+        private static final JsonParserFactory PARSER_FACTORY = Json.createParserFactory(null);
+
+        @Override
+        public NodeConfiguration deserialize(JsonParser parser, DeserializationContext ctx, Type rtType) {
+            JsonObject obj = parser.getObject();
+            Class<? extends NodeConfiguration> type;
+            if (obj.containsKey("windowLen")) {
+                type = EDivisiveConfig.class;
+            } else if (obj.containsKey("windowSize")) {
+                type = StdDevAnomalyConfig.class;
+            } else if (obj.containsKey("threshold")) {
+                type = RelativeDifferenceConfig.class;
+            } else {
+                type = FixedThresholdConfig.class;
+            }
+            return ctx.deserialize(type, PARSER_FACTORY.createParser(obj));
+        }
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/RelativeDifferenceConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/RelativeDifferenceConfig.java
@@ -1,0 +1,7 @@
+package io.hyperfoil.tools.h5m.api.node;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Configuration for the Relative Difference detection algorithm")
+public record RelativeDifferenceConfig(String filter, double threshold, int window, int minPrevious, String fingerprintFilter) implements NodeConfiguration {
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/StdDevAnomalyConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/StdDevAnomalyConfig.java
@@ -1,12 +1,15 @@
-package io.hyperfoil.tools.h5m.api;
+package io.hyperfoil.tools.h5m.api.node;
 
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(description = "Configuration for the StdDev Anomaly detection algorithm")
 public record StdDevAnomalyConfig(
         int windowSize,
         double deviations,
         Direction direction,
         int minDataPoints,
         String fingerprintFilter
-) {
+) implements NodeConfiguration {
     public enum Direction {
         UPPER,
         LOWER,

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/NodeServiceInterface.java
@@ -2,6 +2,7 @@ package io.hyperfoil.tools.h5m.api.svc;
 
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.node.NodeConfiguration;
 
 import java.util.List;
 
@@ -32,7 +33,7 @@ public interface NodeServiceInterface {
      * @return The created node.
      * @throws IllegalArgumentException If the configuration is invalid for the given node type.
      */
-    Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration);
+    Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, NodeConfiguration configuration);
 
     /**
      * Deletes a node by its ID.

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddEDivisive.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.cli;
 
-import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
+import io.hyperfoil.tools.h5m.api.node.EDivisiveConfig;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeGroup;
 import io.hyperfoil.tools.h5m.api.NodeType;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddFixedThreshold.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.cli;
 
-import io.hyperfoil.tools.h5m.api.FixedThresholdConfig;
+import io.hyperfoil.tools.h5m.api.node.FixedThresholdConfig;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeGroup;
 import io.hyperfoil.tools.h5m.api.NodeType;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
@@ -3,7 +3,7 @@ package io.hyperfoil.tools.h5m.cli;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeGroup;
 import io.hyperfoil.tools.h5m.api.NodeType;
-import io.hyperfoil.tools.h5m.api.RelativeDifferenceConfig;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig;
 import io.hyperfoil.tools.h5m.api.svc.NodeGroupServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.node.RelativeDifference;

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddStdDevAnomaly.java
@@ -3,7 +3,7 @@ package io.hyperfoil.tools.h5m.cli;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeGroup;
 import io.hyperfoil.tools.h5m.api.NodeType;
-import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.node.StdDevAnomalyConfig;
 import io.hyperfoil.tools.h5m.api.svc.NodeGroupServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.node.StdDevAnomaly;

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/EDivisive.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/EDivisive.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.node.EDivisiveConfig;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.yaup.json.Json;
 import jakarta.persistence.DiscriminatorValue;
@@ -39,6 +40,17 @@ public class EDivisive extends NodeEntity implements DetectionNode {
         } else {
             config = new Json();
         }
+    }
+
+    public EDivisive(String name, EDivisiveConfig ed) {
+        super(name, "");
+        config = new Json();
+        config.set(WINDOW_LEN, ed.windowLen());
+        config.set(MAX_PVALUE, ed.maxPvalue());
+        config.set(MIN_MAGNITUDE, ed.minMagnitude());
+        config.set(MAX_SERIES_LENGTH, ed.maxSeriesLength());
+        if (ed.fingerprintFilter() != null) config.set(FINGERPRINT_FILTER, ed.fingerprintFilter());
+        operation = config.toString();
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/FixedThreshold.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.node.FixedThresholdConfig;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.jjq.value.JqObject;
 import io.hyperfoil.tools.jjq.value.JqValue;
@@ -48,6 +49,18 @@ public class FixedThreshold extends NodeEntity implements DetectionNode {
     public FixedThreshold(String name, String operation) {
         super(name, operation);
         config = JqObject.EMPTY;
+    }
+
+    public FixedThreshold(String name, FixedThresholdConfig ft) {
+        super(name, "");
+        JqObject.Builder b = JqObject.builder();
+        if (ft.min() != null) b.put("min", ft.min());
+        if (ft.max() != null) b.put("max", ft.max());
+        if (ft.minInclusive() != null) b.put("minInclusive", ft.minInclusive());
+        if (ft.maxInclusive() != null) b.put("maxInclusive", ft.maxInclusive());
+        if (ft.fingerprintFilter() != null) b.put("fingerprintFilter", ft.fingerprintFilter());
+        config = b.build();
+        operation = config.toJsonString();
     }
 
     @PostLoad

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.jjq.value.*;
 import jakarta.persistence.DiscriminatorValue;
@@ -35,6 +36,18 @@ public class RelativeDifference extends NodeEntity implements DetectionNode {
     public RelativeDifference(String name, String operation) {
         super(name,operation);
         config = JqObject.EMPTY;
+    }
+
+    public RelativeDifference(String name, RelativeDifferenceConfig rd) {
+        super(name, "");
+        JqObject.Builder b = JqObject.builder();
+        if (rd.filter() != null) b.put("filter", rd.filter());
+        b.put("threshold", rd.threshold());
+        b.put("window", (long) rd.window());
+        b.put("minPrevious", (long) rd.minPrevious());
+        if (rd.fingerprintFilter() != null) b.put("fingerprintFilter", rd.fingerprintFilter());
+        config = b.build();
+        operation = config.toJsonString();
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/StdDevAnomaly.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/StdDevAnomaly.java
@@ -1,7 +1,7 @@
 package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
-import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.node.StdDevAnomalyConfig;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.yaup.json.Json;
 import jakarta.persistence.DiscriminatorValue;
@@ -48,6 +48,17 @@ public class StdDevAnomaly extends NodeEntity implements DetectionNode {
     public StdDevAnomaly(String name, String operation) {
         super(name, operation);
         config = new Json();
+    }
+
+    public StdDevAnomaly(String name, StdDevAnomalyConfig sd) {
+        super(name, "");
+        config = new Json();
+        config.set(WINDOW_SIZE, sd.windowSize());
+        config.set(DEVIATIONS, sd.deviations());
+        if (sd.direction() != null) config.set(DIRECTION, sd.direction().name());
+        config.set(MIN_DATA_POINTS, sd.minDataPoints());
+        if (sd.fingerprintFilter() != null) config.set(FINGERPRINT_FILTER, sd.fingerprintFilter());
+        operation = config.toString();
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -4,6 +4,7 @@ import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.RecalculationStatus;
+import io.hyperfoil.tools.h5m.api.node.NodeConfiguration;
 import io.hyperfoil.tools.h5m.api.svc.FolderServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.NodeServiceInterface;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
@@ -22,6 +23,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
@@ -64,7 +66,7 @@ public class NodeResource {
             @QueryParam("groupId") @NotNull Long groupId,
             @QueryParam("type") @NotNull NodeType type,
             @QueryParam("sources") @NotNull @NotEmpty List<Long> sources,
-            Object configuration) {
+            @RequestBody(required = false) NodeConfiguration configuration) {
         try {
             return nodeService.createConfigured(name, groupId, type, sources, configuration);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -3,12 +3,13 @@ package io.hyperfoil.tools.h5m.svc;
 import io.hyperfoil.tools.jjq.jsonata.JsonataCompiler;
 import io.hyperfoil.tools.jjq.jsonata.JsonataException;
 import io.hyperfoil.tools.jjq.value.*;
-import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
-import io.hyperfoil.tools.h5m.api.FixedThresholdConfig;
+import io.hyperfoil.tools.h5m.api.node.EDivisiveConfig;
+import io.hyperfoil.tools.h5m.api.node.FixedThresholdConfig;
 import io.hyperfoil.tools.h5m.api.Node;
 import io.hyperfoil.tools.h5m.api.NodeType;
-import io.hyperfoil.tools.h5m.api.RelativeDifferenceConfig;
-import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.node.NodeConfiguration;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig;
+import io.hyperfoil.tools.h5m.api.node.StdDevAnomalyConfig;
 import io.hyperfoil.tools.jhunter.Analysis;
 import io.hyperfoil.tools.jhunter.AnalysisOptions;
 import io.hyperfoil.tools.jhunter.ChangePoint;
@@ -116,13 +117,13 @@ public class NodeService implements NodeServiceInterface {
 
     @Override
     @Transactional
-    public Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, Object configuration) {
+    public Node createConfigured(String name, Long groupId, NodeType type, List<Long> sources, NodeConfiguration configuration) {
         NodeEntity node = switch (type) {
             case FINGERPRINT -> new FingerprintNode(name, "");
-            case FIXED_THRESHOLD -> new FixedThreshold(name, toFixedThresholdConfig(configuration).toJsonString());
-            case RELATIVE_DIFFERENCE -> new RelativeDifference(name, toRelativeDifferenceConfig(configuration).toJsonString());
-            case STDDEV_ANOMALY -> new StdDevAnomaly(name, toStdDevAnomalyConfig(configuration).toJsonString());
-            case EDIVISIVE -> new EDivisive(name, toEDivisiveConfig(configuration).toJsonString());
+            case FIXED_THRESHOLD -> new FixedThreshold(name, (FixedThresholdConfig) configuration);
+            case RELATIVE_DIFFERENCE -> new RelativeDifference(name, (RelativeDifferenceConfig) configuration);
+            case STDDEV_ANOMALY -> new StdDevAnomaly(name, (StdDevAnomalyConfig) configuration);
+            case EDIVISIVE -> new EDivisive(name, (EDivisiveConfig) configuration);
             default -> throw new IllegalArgumentException("Invalid node type " + type.display());
         };
         node.group = NodeGroupEntity.findById(groupId);
@@ -130,74 +131,6 @@ public class NodeService implements NodeServiceInterface {
 
         em.persist(node);
         return apiMapper.toNode(node, new CycleAvoidingContext());
-    }
-
-    /** Convert configuration (Map from REST or record from CLI) to JqObject for FixedThreshold. */
-    private static JqObject toFixedThresholdConfig(Object config) {
-        if (config instanceof FixedThresholdConfig ft) {
-            JqObject.Builder b = JqObject.builder();
-            if (ft.min() != null) b.put("min", ft.min());
-            if (ft.max() != null) b.put("max", ft.max());
-            if (ft.minInclusive() != null) b.put("minInclusive", ft.minInclusive());
-            if (ft.maxInclusive() != null) b.put("maxInclusive", ft.maxInclusive());
-            if (ft.fingerprintFilter() != null) b.put("fingerprintFilter", ft.fingerprintFilter());
-            return b.build();
-        } else if (config instanceof Map<?, ?>) {
-            JqValue v = JqValues.fromJavaObject(config);
-            if (v instanceof JqObject obj) return obj;
-        }
-        throw new IllegalArgumentException("Invalid FixedThreshold configuration: " + config);
-    }
-
-    /** Convert configuration (Map from REST or record from CLI) to JqObject for RelativeDifference. */
-    private static JqObject toRelativeDifferenceConfig(Object config) {
-        if (config instanceof RelativeDifferenceConfig rd) {
-            JqObject.Builder b = JqObject.builder();
-            if (rd.filter() != null) b.put("filter", rd.filter());
-            b.put("threshold", rd.threshold());
-            b.put("window", (long) rd.window());
-            b.put("minPrevious", (long) rd.minPrevious());
-            if (rd.fingerprintFilter() != null) b.put("fingerprintFilter", rd.fingerprintFilter());
-            return b.build();
-        } else if (config instanceof Map<?, ?>) {
-            JqValue v = JqValues.fromJavaObject(config);
-            if (v instanceof JqObject obj) return obj;
-        }
-        throw new IllegalArgumentException("Invalid RelativeDifference configuration: " + config);
-    }
-
-    /** Convert configuration to JqObject for StdDevAnomaly. */
-    private static JqObject toStdDevAnomalyConfig(Object config) {
-        if (config instanceof StdDevAnomalyConfig sd) {
-            JqObject.Builder b = JqObject.builder();
-            b.put("windowSize", (long) sd.windowSize());
-            b.put("deviations", sd.deviations());
-            if (sd.direction() != null) b.put("direction", sd.direction().name());
-            b.put("minDataPoints", (long) sd.minDataPoints());
-            if (sd.fingerprintFilter() != null) b.put("fingerprintFilter", sd.fingerprintFilter());
-            return b.build();
-        } else if (config instanceof Map<?, ?>) {
-            JqValue v = JqValues.fromJavaObject(config);
-            if (v instanceof JqObject obj) return obj;
-        }
-        throw new IllegalArgumentException("Invalid StdDevAnomaly configuration: " + config);
-    }
-
-    /** Convert configuration (Map from REST or record from CLI) to JqObject for EDivisive. */
-    private static JqObject toEDivisiveConfig(Object config) {
-        if (config instanceof EDivisiveConfig ed) {
-            JqObject.Builder b = JqObject.builder();
-            b.put("windowLen", (long) ed.windowLen());
-            b.put("maxPvalue", ed.maxPvalue());
-            b.put("minMagnitude", ed.minMagnitude());
-            b.put("maxSeriesLength", (long) ed.maxSeriesLength());
-            if (ed.fingerprintFilter() != null) b.put("fingerprintFilter", ed.fingerprintFilter());
-            return b.build();
-        } else if (config instanceof Map<?, ?>) {
-            JqValue v = JqValues.fromJavaObject(config);
-            if (v instanceof JqObject obj) return obj;
-        }
-        throw new IllegalArgumentException("Invalid EDivisive configuration: " + config);
     }
 
     @Transactional

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyCalculator.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyCalculator.java
@@ -1,6 +1,6 @@
 package io.hyperfoil.tools.h5m.svc;
 
-import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.node.StdDevAnomalyConfig;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
 /**

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/EDivisiveTest.java
@@ -3,7 +3,7 @@ package io.hyperfoil.tools.h5m.svc;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import io.hyperfoil.tools.jjq.value.JqValues;
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.api.EDivisiveConfig;
+import io.hyperfoil.tools.h5m.api.node.EDivisiveConfig;
 import io.hyperfoil.tools.h5m.api.EphemeralMode;
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/RecalculateTest.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.api.Folder;
+import io.hyperfoil.tools.h5m.api.node.FixedThresholdConfig;
 import io.hyperfoil.tools.jjq.value.JqValues;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.entity.FolderEntity;
@@ -171,7 +172,7 @@ public class RecalculateTest extends FreshDb {
         Long ftNodeId = nodeService.createConfigured("ft", groupId,
                 io.hyperfoil.tools.h5m.api.NodeType.FIXED_THRESHOLD,
                 List.of(fpNodeId, folder.group.root.id, rangeId),
-                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null)).id();
+                new FixedThresholdConfig(null, 50.0, false, true, null)).id();
 
         // Upload a value that exceeds the threshold
         eventObserver.clear();
@@ -303,7 +304,7 @@ public class RecalculateTest extends FreshDb {
         Long ftNodeId = nodeService.createConfigured("ft", groupId,
                 io.hyperfoil.tools.h5m.api.NodeType.FIXED_THRESHOLD,
                 List.of(fpNodeId, folder.group.root.id, rangeId),
-                new io.hyperfoil.tools.h5m.api.FixedThresholdConfig(null, 50.0, false, true, null)).id();
+                new FixedThresholdConfig(null, 50.0, false, true, null)).id();
 
         // Upload 3 values that all exceed the threshold
         for (int i = 0; i < 3; i++) {

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/StdDevAnomalyTest.java
@@ -3,7 +3,7 @@ package io.hyperfoil.tools.h5m.svc;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import io.hyperfoil.tools.jjq.value.JqValues;
 import io.hyperfoil.tools.h5m.FreshDb;
-import io.hyperfoil.tools.h5m.api.StdDevAnomalyConfig;
+import io.hyperfoil.tools.h5m.api.node.StdDevAnomalyConfig;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.entity.node.*;


### PR DESCRIPTION
Move detection config records into `api/node` package behind a sealed `NodeConfiguration` interface with JSON-B type deduction deserializer.

Entity constructors now accept config records directly, removing the Map/record dual-dispatch conversion methods from `NodeService`.
