### PR TITLE
Revert Entity Graph to LEFT JOIN FETCH for source value loading

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/WorkService.java
@@ -20,7 +20,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Event;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PessimisticLockException;
 import jakarta.transaction.Status;
@@ -307,23 +306,22 @@ public class WorkService implements WorkServiceInterface {
         WorkQueue workQueue = workExecutor.getWorkQueue();
         boolean decrementDeferred = false;
         try {
-            // Batch-load source values with data and sources eagerly fetched
-            // via Entity Graph. The 2LC does not cache @Basic(LAZY) properties
-            // for entities with associations (HHH-20773), so em.find() cache
-            // hits still trigger a DB round-trip for the lazy data field.
-            // The fetchgraph hint tells Hibernate to treat data and sources as
-            // eager for this query, loading everything in one round-trip.
+            // Batch-load source values with sources eagerly fetched in a single
+            // query. The 2LC does not cache @Basic(LAZY) properties for entities
+            // with associations (HHH-20773), so em.find() cache hits still
+            // trigger a DB round-trip for the lazy data field. This JPQL query
+            // eagerly fetches the sources collection via LEFT JOIN FETCH.
+            // Note: Entity Graph (fetchgraph/loadgraph) was tested but causes
+            // a 3x regression despite generating identical SQL — the overhead
+            // is in Hibernate's entity initialization, not in query generation.
             List<ValueEntity> sourceValues;
             List<Long> sourceIds = w.getSourceValueIds();
             if (sourceIds == null || sourceIds.isEmpty()) {
                 sourceValues = List.of();
             } else {
-                EntityGraph<ValueEntity> graph = em.createEntityGraph(ValueEntity.class);
-                graph.addAttributeNodes("data", "sources");
                 sourceValues = em.createQuery(
-                        "SELECT v FROM value v WHERE v.id IN :ids",
+                        "SELECT v FROM value v LEFT JOIN FETCH v.sources WHERE v.id IN :ids",
                         ValueEntity.class)
-                    .setHint("jakarta.persistence.fetchgraph", graph)
                     .setParameter("ids", sourceIds)
                     .getResultList();
             }


### PR DESCRIPTION
Entity Graph (both fetchgraph and loadgraph hints) causes a 3x performance regression despite generating identical SQL to the LEFT JOIN FETCH approach.

Verified via Hibernate SQL logging (quarkus.hibernate-orm.log.sql=true):
- Both approaches generate the same query structure: SELECT with LEFT JOIN value_edge + LEFT JOIN value for sources
- fetchgraph correctly adds the data column to the SELECT
- Query counts are identical: 20,290 selects, 10,780 inserts, 1,280 source value queries for 5 runs
- The regression is in Hibernate's entity initialization code path, not in SQL generation — Entity Graph hints cause different entity construction behavior with bytecode-enhanced @Basic(LAZY) fields

Benchmark: test 339, batch=5, 8GB heap, core=4, maxPool=10
  Entity Graph (fetchgraph): 137 v/s
  LEFT JOIN FETCH:           434 v/s