### PR TITLE
Upgrade jjq to 0.1.9 and fix JS proxy mutation for legacy Horreum fun…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <!-- dependencies -->
         <lib.jdbi>3.41.3</lib.jdbi>
         <lib.jhunter>0.1.0</lib.jhunter>
-        <lib.jjq>0.1.8</lib.jjq>
+        <lib.jjq>0.1.9</lib.jjq>
         <lib.jmh>1.37</lib.jmh>
 
         <lib.mapstruct>1.6.3</lib.mapstruct>

--- a/src/main/java/io/hyperfoil/tools/h5m/pasted/ProxyJqArray.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/pasted/ProxyJqArray.java
@@ -1,46 +1,131 @@
 package io.hyperfoil.tools.h5m.pasted;
 
 import io.hyperfoil.tools.jjq.value.JqArray;
+import io.hyperfoil.tools.jjq.value.JqNull;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import org.graalvm.polyglot.Value;
 import org.graalvm.polyglot.proxy.ProxyArray;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * GraalVM ProxyArray backed by JqArray.
- * Replaces ProxyJacksonArray — eliminates the JqValue→JsonNode conversion
- * for JavaScript interop.
+ * <p>
+ * Supports all standard JavaScript array operations. On first mutation
+ * ({@link #set} or {@link #remove}), the backing switches from the
+ * immutable {@link JqArray} to a mutable {@link ArrayList} that supports
+ * index-based set (including array growth), element removal with index
+ * shifting, and nested proxy caching for mutation propagation.
+ * <p>
+ * {@link #getJqArray()} rebuilds an immutable JqArray from the current
+ * mutable state, resolving any cached child proxies recursively.
  */
 public class ProxyJqArray implements ProxyArray {
 
-    private final JqArray node;
+    private final JqArray original;
+    // Mutable backing list, lazily created on first mutation.
+    // Contains a mix of JqValue (for scalars/unaccessed elements) and
+    // ProxyJqObject/ProxyJqArray (for cached child proxies).
+    private List<Object> mutable;
 
     public ProxyJqArray(JqArray node){
-        this.node = node;
+        this.original = node;
     }
 
-    public JqArray getJqArray(){ return node; }
+    /**
+     * Returns the current state as a JqArray, resolving any cached
+     * child proxies and mutable-list changes.
+     */
+    public JqArray getJqArray() {
+        if (mutable == null) {
+            return original;
+        }
+        JqValue[] elements = new JqValue[mutable.size()];
+        for (int i = 0; i < elements.length; i++) {
+            elements[i] = ProxyJqObject.resolveOverlayValue(mutable.get(i));
+        }
+        return JqArray.of(elements);
+    }
+
+    /**
+     * Lazily initialize the mutable list by copying from the original.
+     */
+    private List<Object> ensureMutable() {
+        if (mutable == null) {
+            mutable = new ArrayList<>(original.length());
+            for (int i = 0; i < original.length(); i++) {
+                mutable.add(original.get(i));
+            }
+        }
+        return mutable;
+    }
 
     @Override
     public Object get(long index){
-        JqValue value = node.get((int) index);
+        int idx = (int) index;
+        if (mutable != null) {
+            if (idx < 0 || idx >= mutable.size()) {
+                return null;
+            }
+            Object cached = mutable.get(idx);
+            if (cached instanceof ProxyJqObject || cached instanceof ProxyJqArray) {
+                return cached;
+            }
+            if (cached instanceof JqValue jqValue) {
+                if (jqValue.isNull()) {
+                    return null;
+                }
+                return wrapAndCache(idx, jqValue);
+            }
+            return cached;
+        }
+
+        JqValue value = original.get(idx);
         if (value == null || value.isNull()) {
             return null;
         }
-        return Util.convertFromJq(value);
+        return wrapAndCache(idx, value);
+    }
+
+    /**
+     * Wrap a JqValue for GraalVM and cache it in the mutable list if it's a
+     * proxy type (object/array) so nested mutations are visible.
+     */
+    private Object wrapAndCache(int index, JqValue value) {
+        Object wrapped = Util.convertFromJq(value);
+        if (wrapped instanceof ProxyJqObject || wrapped instanceof ProxyJqArray) {
+            ensureMutable().set(index, wrapped);
+        }
+        return wrapped;
     }
 
     @Override
     public void set(long index, Value value) {
-        // JqArray is immutable — set is a GraalVM contract requirement
-        // but h5m JS functions don't mutate input arrays
-        throw new UnsupportedOperationException("JqArray is immutable");
+        int idx = (int) index;
+        List<Object> list = ensureMutable();
+        JqValue jqValue = Util.convertToJqValue(value);
+        Object toStore = jqValue != null ? jqValue : JqNull.NULL;
+        // Support array growth: fill gaps with null if index is beyond current size
+        while (idx >= list.size()) {
+            list.add(JqNull.NULL);
+        }
+        list.set(idx, toStore);
     }
 
     @Override
     public boolean remove(long index){
-        throw new UnsupportedOperationException("JqArray is immutable");
+        int idx = (int) index;
+        List<Object> list = ensureMutable();
+        if (idx < 0 || idx >= list.size()) {
+            return false;
+        }
+        list.remove(idx);
+        return true;
     }
 
     @Override
-    public long getSize(){ return node.length(); }
+    public long getSize(){
+        return mutable != null ? mutable.size() : original.length();
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/pasted/ProxyJqObject.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/pasted/ProxyJqObject.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.pasted;
 
+import io.hyperfoil.tools.jjq.value.JqNull;
 import io.hyperfoil.tools.jjq.value.JqObject;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import org.graalvm.polyglot.Value;
@@ -8,12 +9,21 @@ import org.graalvm.polyglot.proxy.ProxyExecutable;
 import org.graalvm.polyglot.proxy.ProxyObject;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * GraalVM ProxyObject backed by JqObject.
- * Replaces ProxyJacksonObject — eliminates the JqValue→JsonNode conversion
- * for JavaScript interop.
+ * <p>
+ * Supports all standard JavaScript object operations via copy-on-write:
+ * {@link #putMember} and {@link #removeMember} store changes in an overlay
+ * map, and child proxy objects/arrays are cached so that nested mutations
+ * (e.g., {@code value["arr"][i].field = x}) are visible when the parent is
+ * later accessed. {@link #getJqObject()} rebuilds the JqObject from the
+ * overlay and cached children.
  */
 public class ProxyJqObject implements ProxyObject {
 
@@ -30,42 +40,162 @@ public class ProxyJqObject implements ProxyObject {
         }
     }
 
-    private final JqObject node;
+    private final JqObject original;
+    // Overlay for mutations and cached child proxies.
+    // Lazy-initialized on first mutation or child proxy creation.
+    private Map<String, Object> overlay;
+    // Keys removed via removeMember. Lazy-initialized.
+    private Set<String> removed;
 
     public ProxyJqObject(JqObject node){
-        this.node = node;
+        this.original = node;
     }
 
-    public JqObject getJqObject(){ return node; }
+    /**
+     * Returns the current state as a JqObject, merging any mutations
+     * from the overlay (including nested proxy mutations) with the original.
+     */
+    public JqObject getJqObject() {
+        if (overlay == null && removed == null) {
+            return original;
+        }
+        JqObject.Builder builder = JqObject.builder();
+        // Start with original keys, applying overlay and removals
+        for (String key : original.keys()) {
+            if (removed != null && removed.contains(key)) {
+                continue;
+            }
+            if (overlay != null && overlay.containsKey(key)) {
+                builder.put(key, resolveOverlayValue(overlay.get(key)));
+            } else {
+                builder.put(key, original.get(key));
+            }
+        }
+        // Add any keys that only exist in the overlay (new fields added by JS)
+        if (overlay != null) {
+            for (Map.Entry<String, Object> entry : overlay.entrySet()) {
+                if (!original.has(entry.getKey())) {
+                    builder.put(entry.getKey(), resolveOverlayValue(entry.getValue()));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Resolve an overlay value back to JqValue. If it's a cached child proxy,
+     * recursively get its current state.
+     */
+    static JqValue resolveOverlayValue(Object value) {
+        if (value instanceof ProxyJqObject proxyObj) {
+            return proxyObj.getJqObject();
+        } else if (value instanceof ProxyJqArray proxyArr) {
+            return proxyArr.getJqArray();
+        } else if (value instanceof JqValue jqValue) {
+            return jqValue;
+        } else {
+            return JqNull.NULL;
+        }
+    }
 
     @Override
     public Object getMember(String key) {
-        JqValue value = node.get(key);
+        // Removed keys return null
+        if (removed != null && removed.contains(key)) {
+            return null;
+        }
+        // Check overlay first (cached child proxies and putMember values)
+        if (overlay != null && overlay.containsKey(key)) {
+            Object cached = overlay.get(key);
+            if (cached instanceof ProxyJqObject || cached instanceof ProxyJqArray) {
+                return cached;
+            }
+            // It's a JqValue from putMember — convert to proxy/primitive
+            if (cached instanceof JqValue jqValue) {
+                return wrapAndCache(key, jqValue);
+            }
+            return cached;
+        }
+
+        JqValue value = original.get(key);
         if (value == null || value.isNull()) {
             return null;
         }
-        return Util.convertFromJq(value);
+        return wrapAndCache(key, value);
+    }
+
+    /**
+     * Wrap a JqValue for GraalVM and cache it in the overlay if it's a
+     * proxy type (object/array) so nested mutations are visible.
+     */
+    private Object wrapAndCache(String key, JqValue value) {
+        Object wrapped = Util.convertFromJq(value);
+        if (wrapped instanceof ProxyJqObject || wrapped instanceof ProxyJqArray) {
+            if (overlay == null) {
+                overlay = new LinkedHashMap<>();
+            }
+            overlay.put(key, wrapped);
+        }
+        return wrapped;
     }
 
     @Override
     public Object getMemberKeys() {
-        return ProxyArray.fromList(new ArrayList<>(node.keys()));
+        if (overlay == null && removed == null) {
+            return ProxyArray.fromList(new ArrayList<>(original.keys()));
+        }
+        // Merge original keys with overlay keys, excluding removed keys
+        List<Object> keys = new ArrayList<>();
+        for (String key : original.keys()) {
+            if (removed != null && removed.contains(key)) {
+                continue;
+            }
+            keys.add(key);
+        }
+        if (overlay != null) {
+            for (String key : overlay.keySet()) {
+                if (!original.has(key)) {
+                    keys.add(key);
+                }
+            }
+        }
+        return ProxyArray.fromList(keys);
     }
 
     @Override
     public boolean hasMember(String key) {
-        return node.has(key);
+        if (removed != null && removed.contains(key)) {
+            return false;
+        }
+        return original.has(key) || (overlay != null && overlay.containsKey(key));
     }
 
     @Override
     public void putMember(String key, Value value) {
-        // JqObject is immutable — putMember is a GraalVM contract requirement
-        // but h5m JS functions don't mutate input objects
-        throw new UnsupportedOperationException("JqObject is immutable");
+        if (overlay == null) {
+            overlay = new LinkedHashMap<>();
+        }
+        // If this key was previously removed, un-remove it
+        if (removed != null) {
+            removed.remove(key);
+        }
+        JqValue jqValue = Util.convertToJqValue(value);
+        overlay.put(key, jqValue != null ? jqValue : JqNull.NULL);
     }
 
     @Override
     public boolean removeMember(String key) {
-        throw new UnsupportedOperationException("JqObject is immutable");
+        boolean existed = hasMember(key);
+        if (existed) {
+            if (removed == null) {
+                removed = new HashSet<>();
+            }
+            removed.add(key);
+            // Also remove from overlay if present
+            if (overlay != null) {
+                overlay.remove(key);
+            }
+        }
+        return existed;
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/pasted/ProxyJqMutationTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/pasted/ProxyJqMutationTest.java
@@ -1,0 +1,479 @@
+package io.hyperfoil.tools.h5m.pasted;
+
+import io.hyperfoil.tools.jjq.value.*;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.Value;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for ProxyJqObject and ProxyJqArray mutation support.
+ * Legacy Horreum JS functions mutate input objects (e.g., adding fields
+ * to array elements). These tests verify that mutations are visible in
+ * the JS return value after conversion back to JqValue.
+ */
+public class ProxyJqMutationTest {
+
+    private static Engine engine;
+
+    @BeforeAll
+    static void setup() {
+        engine = Engine.newBuilder("js")
+                .option("engine.WarnInterpreterOnly", "false")
+                .build();
+    }
+
+    @AfterAll
+    static void teardown() {
+        if (engine != null) engine.close();
+    }
+
+    /**
+     * Evaluate JS with a single binding and assert on the result inside the context scope.
+     * The context must remain open while accessing the Value.
+     */
+    private void evalAndAssert(String js, String bindingName, JqValue input, Consumer<Value> assertions) {
+        try (Context context = Context.newBuilder("js")
+                .engine(engine)
+                .allowAllAccess(true)
+                .build()) {
+            context.getBindings("js").putMember(bindingName, ProxyJq.wrap(input));
+            Value result = context.eval("js", js);
+            assertions.accept(result);
+        }
+    }
+
+    /**
+     * Evaluate JS, convert result to JqValue, and assert.
+     */
+    private void evalAndAssertJq(String js, String bindingName, JqValue input, Consumer<JqValue> assertions) {
+        try (Context context = Context.newBuilder("js")
+                .engine(engine)
+                .allowAllAccess(true)
+                .build()) {
+            context.getBindings("js").putMember(bindingName, ProxyJq.wrap(input));
+            Value result = context.eval("js", js);
+            JqValue converted = Util.convertToJqValue(result);
+            assertions.accept(converted);
+        }
+    }
+
+    // --- ProxyJqObject.putMember ---
+
+    @Test
+    public void putMember_adds_new_field_to_object() {
+        JqObject input = JqObject.of("name", "test");
+        evalAndAssert("value.added = 42; value;", "value", input, result -> {
+            assertTrue(result.hasMember("name"), "original field should be preserved");
+            assertTrue(result.hasMember("added"), "new field should be visible");
+            assertEquals(42, result.getMember("added").asInt());
+        });
+    }
+
+    @Test
+    public void putMember_overwrites_existing_field() {
+        JqObject input = JqObject.builder()
+                .put("x", 1L)
+                .put("y", 2L)
+                .build();
+        evalAndAssert("value.x = 99; value;", "value", input, result -> {
+            assertEquals(99, result.getMember("x").asInt());
+            assertEquals(2, result.getMember("y").asInt());
+        });
+    }
+
+    @Test
+    public void putMember_result_converts_back_to_jqobject() {
+        JqObject input = JqObject.of("key", "hello");
+        evalAndAssertJq("value.extra = 'world'; value;", "value", input, converted -> {
+            assertInstanceOf(JqObject.class, converted);
+            JqObject obj = (JqObject) converted;
+            assertEquals("hello", obj.get("key").asString(""));
+            assertEquals("world", obj.get("extra").asString(""));
+        });
+    }
+
+    // --- ProxyJqArray.set ---
+
+    @Test
+    public void set_modifies_array_element() {
+        JqArray input = JqArray.of(JqNumber.of(10), JqNumber.of(20), JqNumber.of(30));
+        evalAndAssert("arr[1] = 99; arr;", "arr", input, result -> {
+            assertEquals(3, result.getArraySize());
+            assertEquals(10, result.getArrayElement(0).asInt());
+            assertEquals(99, result.getArrayElement(1).asInt());
+            assertEquals(30, result.getArrayElement(2).asInt());
+        });
+    }
+
+    @Test
+    public void set_result_converts_back_to_jqarray() {
+        JqArray input = JqArray.of(JqString.of("a"), JqString.of("b"));
+        evalAndAssertJq("arr[0] = 'replaced'; arr;", "arr", input, converted -> {
+            assertInstanceOf(JqArray.class, converted);
+            JqArray arr = (JqArray) converted;
+            assertEquals("replaced", arr.get(0).asString(""));
+            assertEquals("b", arr.get(1).asString(""));
+        });
+    }
+
+    // --- Nested mutation: object inside array ---
+
+    @Test
+    public void nested_mutation_object_in_array() {
+        // This is the PCP Time Series pattern:
+        // value["pcp_time_series"][i].elapsed_time = computed_value
+        JqArray timeSeries = JqArray.of(
+                JqObject.of("Time", "2024-01-01T00:00:00"),
+                JqObject.of("Time", "2024-01-01T00:01:00")
+        );
+        JqObject input = JqObject.builder()
+                .put("uuid", "test-uuid")
+                .put("pcp_time_series", timeSeries)
+                .build();
+
+        String js = """
+                (function(value) {
+                    for (var i = 0; i < value["pcp_time_series"].length; i++) {
+                        value["pcp_time_series"][i].elapsed_time = i * 60000;
+                        value["pcp_time_series"][i].uuid = value["uuid"];
+                    }
+                    return value["pcp_time_series"];
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasArrayElements(), "should return an array");
+            assertEquals(2, result.getArraySize());
+
+            Value first = result.getArrayElement(0);
+            assertTrue(first.hasMember("elapsed_time"),
+                    "elapsed_time should be set on first element");
+            assertEquals(0, first.getMember("elapsed_time").asInt());
+            assertTrue(first.hasMember("uuid"),
+                    "uuid should be set on first element");
+            assertEquals("test-uuid", first.getMember("uuid").asString());
+
+            Value second = result.getArrayElement(1);
+            assertEquals(60000, second.getMember("elapsed_time").asInt());
+            assertEquals("test-uuid", second.getMember("uuid").asString());
+        });
+    }
+
+    @Test
+    public void nested_mutation_converts_back_to_jqvalue() {
+        // Same as above but verify the full round-trip back to JqValue
+        JqArray timeSeries = JqArray.of(
+                JqObject.of("Time", "2024-01-01T00:00:00"),
+                JqObject.of("Time", "2024-01-01T00:01:00")
+        );
+        JqObject input = JqObject.builder()
+                .put("uuid", "test-uuid")
+                .put("pcp_time_series", timeSeries)
+                .build();
+
+        String js = """
+                (function(value) {
+                    for (var i = 0; i < value["pcp_time_series"].length; i++) {
+                        value["pcp_time_series"][i].elapsed_time = i * 60000;
+                        value["pcp_time_series"][i].uuid = value["uuid"];
+                    }
+                    return value["pcp_time_series"];
+                })(value)
+                """;
+
+        evalAndAssertJq(js, "value", input, converted -> {
+            assertInstanceOf(JqArray.class, converted);
+            JqArray arr = (JqArray) converted;
+            assertEquals(2, arr.length());
+
+            JqObject first = (JqObject) arr.get(0);
+            assertEquals(0L, first.get("elapsed_time").asLong(0));
+            assertEquals("test-uuid", first.get("uuid").asString(""));
+            assertEquals("2024-01-01T00:00:00", first.get("Time").asString(""));
+
+            JqObject second = (JqObject) arr.get(1);
+            assertEquals(60000L, second.get("elapsed_time").asLong(0));
+        });
+    }
+
+    // --- Nested mutation: Autobench Results pattern ---
+
+    @Test
+    public void nested_mutation_autobench_results_pattern() {
+        // Autobench Results:
+        // value["results"][section].test_name = section;
+        // value["results"][section].uuid = value["metadata"]["uuid"];
+        JqValue inputValue = JqValues.parse("""
+                {
+                    "metadata": {"uuid": "abc-123"},
+                    "results": {
+                        "workload_a": {"score": 100},
+                        "workload_b": {"score": 200}
+                    }
+                }
+                """);
+        assertInstanceOf(JqObject.class, inputValue);
+        JqObject input = (JqObject) inputValue;
+
+        String js = """
+                (function(value) {
+                    const workloads = [];
+                    for (const section of Object.keys(value["results"])) {
+                        value["results"][section].test_name = section;
+                        value["results"][section].uuid = value["metadata"]["uuid"];
+                        workloads.push(value["results"][section]);
+                    }
+                    return workloads;
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasArrayElements(), "should return an array");
+            assertEquals(2, result.getArraySize());
+
+            Value first = result.getArrayElement(0);
+            assertTrue(first.hasMember("test_name"), "test_name should be set");
+            assertTrue(first.hasMember("uuid"), "uuid should be set");
+            assertTrue(first.hasMember("score"), "original score should be preserved");
+        });
+    }
+
+    // --- Object.keys() on ProxyJqObject ---
+
+    @Test
+    public void object_keys_includes_added_fields() {
+        JqObject input = JqObject.of("a", 1L);
+
+        String js = """
+                (function(value) {
+                    value.b = 2;
+                    return Object.keys(value);
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasArrayElements());
+            boolean hasA = false, hasB = false;
+            for (int i = 0; i < result.getArraySize(); i++) {
+                String key = result.getArrayElement(i).asString();
+                if ("a".equals(key)) hasA = true;
+                if ("b".equals(key)) hasB = true;
+            }
+            assertTrue(hasA, "should include original key 'a'");
+            assertTrue(hasB, "should include added key 'b'");
+        });
+    }
+
+    // --- ProxyJqObject.removeMember ---
+
+    @Test
+    public void removeMember_deletes_field() {
+        JqObject input = JqObject.builder()
+                .put("keep", "yes")
+                .put("drop", "no")
+                .build();
+
+        String js = """
+                (function(value) {
+                    delete value.drop;
+                    return value;
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasMember("keep"), "keep should remain");
+            assertFalse(result.hasMember("drop"), "drop should be deleted");
+        });
+    }
+
+    @Test
+    public void removeMember_converts_back_without_removed_key() {
+        JqObject input = JqObject.builder()
+                .put("a", 1L)
+                .put("b", 2L)
+                .put("c", 3L)
+                .build();
+
+        evalAndAssertJq("delete value.b; value;", "value", input, converted -> {
+            assertInstanceOf(JqObject.class, converted);
+            JqObject obj = (JqObject) converted;
+            assertTrue(obj.has("a"));
+            assertFalse(obj.has("b"), "b should not be present after delete");
+            assertTrue(obj.has("c"));
+        });
+    }
+
+    @Test
+    public void removeMember_then_re_add() {
+        JqObject input = JqObject.of("key", "original");
+
+        String js = """
+                (function(value) {
+                    delete value.key;
+                    value.key = "replaced";
+                    return value;
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasMember("key"));
+            assertEquals("replaced", result.getMember("key").asString());
+        });
+    }
+
+    @Test
+    public void object_keys_excludes_removed_fields() {
+        JqObject input = JqObject.builder()
+                .put("a", 1L)
+                .put("b", 2L)
+                .put("c", 3L)
+                .build();
+
+        String js = """
+                (function(value) {
+                    delete value.b;
+                    return Object.keys(value);
+                })(value)
+                """;
+
+        evalAndAssert(js, "value", input, result -> {
+            assertTrue(result.hasArrayElements());
+            assertEquals(2, result.getArraySize());
+            List<String> keys = new ArrayList<>();
+            for (int i = 0; i < result.getArraySize(); i++) {
+                keys.add(result.getArrayElement(i).asString());
+            }
+            assertTrue(keys.contains("a"));
+            assertFalse(keys.contains("b"));
+            assertTrue(keys.contains("c"));
+        });
+    }
+
+    // --- ProxyJqArray.remove ---
+
+    @Test
+    public void array_splice_removes_element() {
+        JqArray input = JqArray.of(JqNumber.of(10), JqNumber.of(20), JqNumber.of(30));
+
+        String js = """
+                (function(arr) {
+                    arr.splice(1, 1);
+                    return arr;
+                })(arr)
+                """;
+
+        evalAndAssert(js, "arr", input, result -> {
+            assertEquals(2, result.getArraySize());
+            assertEquals(10, result.getArrayElement(0).asInt());
+            assertEquals(30, result.getArrayElement(1).asInt());
+        });
+    }
+
+    @Test
+    public void array_remove_converts_back() {
+        JqArray input = JqArray.of(JqString.of("a"), JqString.of("b"), JqString.of("c"));
+
+        evalAndAssertJq("arr.splice(0, 1); arr;", "arr", input, converted -> {
+            assertInstanceOf(JqArray.class, converted);
+            JqArray arr = (JqArray) converted;
+            assertEquals(2, arr.length());
+            assertEquals("b", arr.get(0).asString(""));
+            assertEquals("c", arr.get(1).asString(""));
+        });
+    }
+
+    // --- ProxyJqArray.set beyond bounds (array growth) ---
+
+    @Test
+    public void array_set_beyond_bounds_grows_array() {
+        JqArray input = JqArray.of(JqNumber.of(1), JqNumber.of(2), JqNumber.of(3));
+
+        String js = """
+                (function(arr) {
+                    arr[5] = 99;
+                    return arr;
+                })(arr)
+                """;
+
+        evalAndAssert(js, "arr", input, result -> {
+            assertEquals(6, result.getArraySize());
+            assertEquals(1, result.getArrayElement(0).asInt());
+            assertEquals(2, result.getArrayElement(1).asInt());
+            assertEquals(3, result.getArrayElement(2).asInt());
+            assertTrue(result.getArrayElement(3).isNull(), "gap should be null");
+            assertTrue(result.getArrayElement(4).isNull(), "gap should be null");
+            assertEquals(99, result.getArrayElement(5).asInt());
+        });
+    }
+
+    @Test
+    public void array_push_grows_array() {
+        JqArray input = JqArray.of(JqNumber.of(1));
+
+        String js = """
+                (function(arr) {
+                    arr.push(2);
+                    arr.push(3);
+                    return arr;
+                })(arr)
+                """;
+
+        evalAndAssert(js, "arr", input, result -> {
+            assertEquals(3, result.getArraySize());
+            assertEquals(1, result.getArrayElement(0).asInt());
+            assertEquals(2, result.getArrayElement(1).asInt());
+            assertEquals(3, result.getArrayElement(2).asInt());
+        });
+    }
+
+    @Test
+    public void array_growth_converts_back() {
+        JqArray input = JqArray.of(JqNumber.of(1));
+
+        evalAndAssertJq("arr[3] = 99; arr;", "arr", input, converted -> {
+            assertInstanceOf(JqArray.class, converted);
+            JqArray arr = (JqArray) converted;
+            assertEquals(4, arr.length());
+            assertEquals(1L, arr.get(0).asLong(0));
+            assertTrue(arr.get(1).isNull());
+            assertTrue(arr.get(2).isNull());
+            assertEquals(99L, arr.get(3).asLong(0));
+        });
+    }
+
+    // --- Creating new objects in JS (no mutation needed) ---
+
+    @Test
+    public void js_map_creates_new_objects_without_mutation() {
+        // This pattern doesn't mutate — it creates new objects via object literal
+        JqArray input = JqArray.of(
+                JqObject.builder().put("x", 1L).put("y", 2L).build(),
+                JqObject.builder().put("x", 3L).put("y", 4L).build()
+        );
+
+        String js = """
+                (function(arr) {
+                    var result = [];
+                    for (var i = 0; i < arr.length; i++) {
+                        result.push({x: arr[i].x, y: arr[i].y, sum: arr[i].x + arr[i].y});
+                    }
+                    return result;
+                })(arr)
+                """;
+
+        evalAndAssert(js, "arr", input, result -> {
+            assertEquals(2, result.getArraySize());
+            assertEquals(3, result.getArrayElement(0).getMember("sum").asInt());
+            assertEquals(7, result.getArrayElement(1).getMember("sum").asInt());
+        });
+    }
+}


### PR DESCRIPTION
…ctions

Upgrade jjq from 0.1.8 to 0.1.9, adding JqValue.estimatedSizeInBytes() and JqValues.serializeToByteOutput() for future weight-based 2LC cache eviction.

Fix ProxyJqObject and ProxyJqArray to support mutation through the GraalVM proxy chain. Legacy Horreum JS functions mutate nested objects (e.g., value["pcp_time_series"][i].elapsed_time = x), but the previous implementation threw UnsupportedOperationException, silently discarding mutations and causing fillInStackTrace overhead on every attempt.