### PR TITLE
use http-problem quarkus extension to send errors in rest responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <h5m.benchmark.warmup>5</h5m.benchmark.warmup>
 
         <h5m.cli.native>true</h5m.cli.native>
+
         <!-- dependencies -->
         <lib.jdbi>3.41.3</lib.jdbi>
         <lib.jhunter>0.1.0</lib.jhunter>
@@ -71,6 +72,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- quarkiverse -->
+        <quarkiverse.http-problem>3.38.2</quarkiverse.http-problem>
         <quarkiverse.jdbc-sqlite>3.0.11</quarkiverse.jdbc-sqlite>
         <quarkiverse.mapstruct>1.1.0</quarkiverse.mapstruct>
         <quarkiverse.quinoa>2.8.1</quarkiverse.quinoa>
@@ -129,6 +131,11 @@
             <groupId>io.hyperfoil.tools</groupId>
             <artifactId>yaup-core</artifactId>
             <version>${lib.yaup}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.httpproblem</groupId>
+            <artifactId>quarkus-http-problem</artifactId>
+            <version>${quarkiverse.http-problem}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.jdbc</groupId>

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/FolderService.java
@@ -70,7 +70,7 @@ public class FolderService implements FolderServiceInterface {
     @Transactional
     public Folder create(String name){
         if(FolderEntity.find("name",name).firstResult() !=null){
-            throw new WebApplicationException("Folder already exists:" + name, 409);
+            throw new WebApplicationException("Folder already exists: " + name, 409);
         }
         FolderEntity entity = new FolderEntity();
         entity.name = name;

--- a/src/main/webui/src/app/components/CreateFolderModal.tsx
+++ b/src/main/webui/src/app/components/CreateFolderModal.tsx
@@ -7,9 +7,9 @@ import {
   TextInput,
 } from '@carbon/react';
 import { createFolderMutation } from '@client/@tanstack/react-query.gen.ts';
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { AxiosError } from 'axios';
 
 interface CreateFolderModalProps {
   open: boolean;
@@ -29,12 +29,8 @@ export const CreateFolderModal = ({ open, onClose }: CreateFolderModalProps) => 
       setError(null);
       onClose();
     },
-    onError: (e: AxiosError<Error>) => {
-      if (e.response?.status === 409) {
-        setError('A folder with same name already exists');
-      } else {
-        setError(e.message ?? 'Failed to create folder');
-      }
+    onError: (e) => {
+      setError(extractErrorMessage(e) ?? 'Failed to create folder');
     },
   });
 

--- a/src/main/webui/src/app/components/CreateNodeModal.tsx
+++ b/src/main/webui/src/app/components/CreateNodeModal.tsx
@@ -1,5 +1,6 @@
 import type { Direction, Node as ApiNode, NodeType } from '@client/types.gen.ts';
 
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useNotification } from '@app/context/useNotification.tsx';
 import {
   Button,
@@ -124,8 +125,8 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
     notifications.success('Node created');
     handleClose();
   };
-  const onError = (e: Error) => {
-    setSubmitError(e.message || 'Failed to create node');
+  const onError = (e: unknown) => {
+    setSubmitError(extractErrorMessage(e) ?? 'Failed to create node');
   };
 
   const createNode = useMutation({ ...createNodeMutation(), onSuccess, onError });

--- a/src/main/webui/src/app/components/DeleteNodeModal.tsx
+++ b/src/main/webui/src/app/components/DeleteNodeModal.tsx
@@ -1,9 +1,9 @@
 import { Modal } from '@carbon/react';
 import { deleteNodeMutation } from '@client/@tanstack/react-query.gen.ts';
 import type { Node as ApiNode } from '@client/types.gen.ts';
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { AxiosError } from 'axios';
 
 interface DeleteNodeModalProps {
   node: ApiNode | null;
@@ -20,13 +20,9 @@ export const DeleteNodeModal = ({ node, onClose }: DeleteNodeModalProps) => {
       void queryClient.invalidateQueries();
       onClose();
     },
-    onError: (e: AxiosError<Error>) => {
-        if (e.response?.status === 500) {
-          setError('Cannot delete node');
-        } else {
-          setError(e.message ?? 'Failed to Delete Node');
-        }
-      },
+    onError: (e) => {
+      setError(extractErrorMessage(e) ?? 'Failed to delete node');
+    },
   });
 
   const handleSubmit = () => {

--- a/src/main/webui/src/app/components/EditNodeModal.tsx
+++ b/src/main/webui/src/app/components/EditNodeModal.tsx
@@ -11,8 +11,8 @@ import {
 } from '@carbon/react';
 import { setEphemeralMutation, updateMutation } from '@client/@tanstack/react-query.gen.ts';
 import type { EphemeralMode, Node as ApiNode } from '@client/types.gen.ts';
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 
 interface EditNodeModalProps {
@@ -49,8 +49,8 @@ export const EditNodeModal = ({ node, onClose, onRecalculation }: EditNodeModalP
       }
       onClose();
     },
-    onError: (e: AxiosError<Error>) => {
-      setError(e.message ?? 'Failed to update node');
+    onError: (e) => {
+      setError(extractErrorMessage(e) ?? 'Failed to update node');
     },
   });
 
@@ -60,8 +60,8 @@ export const EditNodeModal = ({ node, onClose, onRecalculation }: EditNodeModalP
       void queryClient.invalidateQueries();
       onClose();
     },
-    onError: (e: AxiosError<Error>) => {
-      setError(e.message ?? 'Failed to update ephemeral mode');
+    onError: (e) => {
+      setError(extractErrorMessage(e) ?? 'Failed to update ephemeral mode');
     },
   });
 

--- a/src/main/webui/src/app/components/ViewConfigModal.tsx
+++ b/src/main/webui/src/app/components/ViewConfigModal.tsx
@@ -12,6 +12,7 @@ import {
 import { ArrowUp, ArrowDown, Close } from '@carbon/icons-react';
 import { byIdOptions } from '@client/@tanstack/react-query.gen.ts';
 import { ViewService } from '@client/sdk.gen.ts';
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 
@@ -106,8 +107,8 @@ export const ViewConfigModal = ({ open, onClose, folderId, groupId, view }: View
       }});
       onClose();
     },
-    onError: (e: Error) => {
-      setSaveError(e.message ?? 'Failed to create view');
+    onError: (e) => {
+      setSaveError(extractErrorMessage(e) ?? 'Failed to create view');
     },
   });
 
@@ -126,8 +127,8 @@ export const ViewConfigModal = ({ open, onClose, folderId, groupId, view }: View
       }});
       onClose();
     },
-    onError: (e: Error) => {
-      setSaveError(e.message ?? 'Failed to update view');
+    onError: (e) => {
+      setSaveError(extractErrorMessage(e) ?? 'Failed to update view');
     },
   });
 

--- a/src/main/webui/src/app/context/NotificationProvider.tsx
+++ b/src/main/webui/src/app/context/NotificationProvider.tsx
@@ -21,8 +21,8 @@ function reducer(state: Notification[], action: Action): Notification[] {
   }
 }
 
-// extracts message from Axios-like errors (response.data.detail, response.data.message) without coupling to Axios
-function extractErrorMessage(reason: unknown): string | undefined {
+// extracts message from HTTP-Problems and Axios-like errors (response.data.detail for RFC 9457 Problem details, response.data.message) without coupling to Axios
+export function extractErrorMessage(reason: unknown): string | undefined {
   if (typeof reason === 'string') return reason;
   if (typeof reason !== 'object' || reason === null) return undefined;
 


### PR DESCRIPTION
with this PR the backend returns structured error responses following RFC 9457 (Problem Details for HTTP APIs) via `quarkus-http-problem` [extension](https://github.com/quarkiverse/quarkus-http-problem). Instead of frontend components switching on HTTP status codes to guess user-facing messages, they read the detail field from the problem response — the server sends the actual error message. This removes the coupling between frontend error display and specific status codes, and gives users meaningful messages ("Folder already exists: benchmarks") rather than generic ones ("A folder with same name already exists").