### PR TITLE
initial authentication infrastructure 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <quarkiverse.http-problem>3.38.2</quarkiverse.http-problem>
         <quarkiverse.jdbc-sqlite>3.0.11</quarkiverse.jdbc-sqlite>
         <quarkiverse.mapstruct>1.1.0</quarkiverse.mapstruct>
+        <quarkiverse.oidc-proxy>0.7.0</quarkiverse.oidc-proxy>
         <quarkiverse.quinoa>2.8.1</quarkiverse.quinoa>
 
         <!-- quarkus -->
@@ -267,6 +268,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-aesh</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-oidc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -634,6 +640,13 @@
                     <name>web</name>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkiverse.oidc-proxy</groupId>
+                    <artifactId>quarkus-oidc-proxy</artifactId>
+                    <version>${quarkiverse.oidc-proxy}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
@@ -9,7 +9,11 @@ public interface UserServiceInterface {
 
     long create(String username, Role role);
 
+    long create(String sub, String iss, String username, Role role);
+
     User byUsername(String username);
+
+    User bySub(String sub, String iss);
 
     List<User> list();
 

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
@@ -10,16 +10,23 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity(name = "h5m_user")
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"sub", "iss"}))
 public class UserEntity extends PanacheEntityBase {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     public Long id;
+
+    public String sub;
+
+    public String iss;
 
     @Column(unique = true)
     public String username;
@@ -33,6 +40,13 @@ public class UserEntity extends PanacheEntityBase {
     public UserEntity() {}
 
     public UserEntity(String username, Role role) {
+        this.username = username;
+        this.role = role;
+    }
+
+    public UserEntity(String sub, String iss, String username, Role role) {
+        this.sub = sub;
+        this.iss = iss;
         this.username = username;
         this.role = role;
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
@@ -1,0 +1,41 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.User;
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+@Path("/api/user")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "User", description = "User and role information")
+public class UserResource {
+
+    @Inject
+    UserServiceInterface userService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @GET
+    @Path("role")
+    @Authenticated
+    @Operation(description = "Get the role of the authenticated user")
+    @APIResponse(responseCode = "200", description = "User role")
+    public Role role() {
+        User user = switch (identity.getPrincipal()) {
+            case JsonWebToken jwt -> userService.bySub(jwt.getSubject(), jwt.getIssuer());
+            default -> userService.byUsername(identity.getPrincipal().getName());
+        };
+        return user != null ? user.role() : Role.USER;
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
@@ -11,6 +11,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 @ApplicationScoped
 public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
@@ -27,8 +28,10 @@ public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
     }
 
     private SecurityIdentity addRoles(SecurityIdentity identity) {
-        String username = identity.getPrincipal().getName();
-        User user = userService.byUsername(username);
+        User user = switch (identity.getPrincipal()) {
+            case JsonWebToken jwt -> userService.bySub(jwt.getSubject(), jwt.getIssuer());
+            default -> userService.byUsername(identity.getPrincipal().getName());
+        };
         if (user == null) {
             return identity;
         }

--- a/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/OidcUserProvisioner.java
@@ -11,6 +11,7 @@ import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 @ApplicationScoped
 @Priority(1)
@@ -28,6 +29,32 @@ public class OidcUserProvisioner implements SecurityIdentityAugmentor {
     }
 
     private SecurityIdentity provisionIfNeeded(SecurityIdentity identity) {
+        return switch (identity.getPrincipal()) {
+            case JsonWebToken jwt -> provisionOidc(identity, jwt);
+            default -> provisionByUsername(identity);
+        };
+    }
+
+    private SecurityIdentity provisionOidc(SecurityIdentity identity, JsonWebToken jwt) {
+        String sub = jwt.getSubject();
+        String iss = jwt.getIssuer();
+        if (userService.bySub(sub, iss) != null) {
+            return identity;
+        }
+        String username = jwt.getClaim("preferred_username");
+        if (username == null) {
+            username = jwt.getClaim("upn");
+        }
+        if (username == null) {
+            username = sub;
+        }
+        Role role = userService.count() == 0 ? Role.ADMIN : Role.USER;
+        userService.create(sub, iss, username, role);
+        Log.infof("Auto-provisioned OIDC user %s with role %s", username, role);
+        return identity;
+    }
+
+    private SecurityIdentity provisionByUsername(SecurityIdentity identity) {
         String username = identity.getPrincipal().getName();
         if (userService.byUsername(username) != null) {
             return identity;

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
@@ -27,8 +27,23 @@ public class UserService implements UserServiceInterface {
 
     @Override
     @Transactional
+    public long create(String sub, String iss, String username, Role role) {
+        UserEntity user = new UserEntity(sub, iss, username, role);
+        user.persist();
+        return user.id;
+    }
+
+    @Override
+    @Transactional
     public User byUsername(String username) {
         UserEntity entity = UserEntity.find("username", username).firstResult();
+        return apiMapper.toUser(entity);
+    }
+
+    @Override
+    @Transactional
+    public User bySub(String sub, String iss) {
+        UserEntity entity = UserEntity.find("sub = ?1 and iss = ?2", sub, iss).firstResult();
         return apiMapper.toUser(entity);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,6 +51,9 @@ quarkus.banner.enabled=false
 %cli.quarkus.datasource.jdbc.url=jdbc:sqlite:${H5M_PATH:${user.home}/h5m.db}
 %cli.quarkus.datasource.devservices.enabled=false
 %cli.quarkus.quinoa=false
+# disable OIDC
+%cli.quarkus.oidc.tenant-enabled=false
+%cli.quarkus.oidc-proxy.enabled=false
 # CLI uses uber-jar for single-file distribution. Truffle Multi-Release check is disabled since uber-jar merging loses the Multi-Release manifest attribute.
 %cli.quarkus.package.jar.type=uber-jar
 %cli.quarkus.package.jar.add-runner-suffix=false
@@ -93,20 +96,21 @@ quarkus.hibernate-orm.log.queries-slower-than-ms=100
 #10m timeout
 quarkus.transaction-manager.default-transaction-timeout=PT10m
 
-# Security - disabled by default (local/CLI mode)
-h5m.security.enabled=false
+# ApiKey Security
 h5m.api-key.expiration-days=365
 
 # Disable proactive auth so unauthenticated requests can reach @PermitAll endpoints
 quarkus.http.auth.proactive=false
 
-# OIDC - disabled by default (enable via environment for service deployments)
-quarkus.oidc.tenant-enabled=false
-quarkus.oidc.auth-server-url=${OIDC_AUTH_SERVER_URL:}
-quarkus.oidc.client-id=${OIDC_CLIENT_ID:h5m}
-quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:}
-quarkus.oidc.application-type=service
-quarkus.oidc.token.principal-claim=preferred_username
+# OIDC
+quarkus.oidc.tenant-enabled=true
+quarkus.oidc.client-id=h5m
+quarkus.oidc.application-type=hybrid
+quarkus.oidc-proxy.external-client-id=h5m-webui
+quarkus.oidc-proxy.external-client-secret=public
+
+# Dev mode: enable lightweight OIDC server
+%dev.quarkus.oidc.devservices.enabled=true
 
 # Mailer - configure via environment for service deployments
 quarkus.mailer.from=${MAILER_FROM:h5m@localhost}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -71,6 +71,7 @@ quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
 
 # quinoa
 quarkus.quinoa.enable-spa-routing=true
+quarkus.quinoa.ignored-path-prefixes=/_
 
 # aesh configuration: runtime for commands, console for REPL
 quarkus.aesh.start-console=false

--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -50,6 +50,7 @@
         "rolldown": "^1.0",
         "rolldown-vite": "^7.3",
         "typescript-eslint": "^8.59",
+        "vite-plugin-devtools-json": "^1.1",
         "vitest": "^4.1"
       }
     },
@@ -9509,6 +9510,20 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.12",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
@@ -9585,6 +9600,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-devtools-json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-devtools-json/-/vite-plugin-devtools-json-1.1.0.tgz",
+      "integrity": "sha512-Fy9nMgMudGzDtUh1tGL7v0WAH0gsnZcZu2LFr/+1YxvYaJnxgbqRqv4jLU2tn5L9oqSaETHVCdDo9f8mSCQEZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^14.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/vite/node_modules/@oxc-project/types": {

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -56,6 +56,7 @@
     "rolldown": "^1.0",
     "rolldown-vite": "^7.3",
     "typescript-eslint": "^8.59",
+    "vite-plugin-devtools-json": "^1.1",
     "vitest": "^4.1"
   }
 }

--- a/src/main/webui/src/app/App.tsx
+++ b/src/main/webui/src/app/App.tsx
@@ -1,3 +1,5 @@
+import { AuthorizationProvider } from '@app/context/AuthorizationProvider.tsx';
+import { navigateSigninLocation, navigateSignoutLocation } from '@app/context/navigation.tsx';
 import { NotificationProvider } from '@app/context/NotificationProvider.tsx';
 import router from '@app/routes.ts';
 import { GlobalTheme } from '@carbon/react';
@@ -30,6 +32,7 @@ const oidcConfig: AuthProviderProps = {
   monitorSession: true,
   post_logout_redirect_uri: `${window.location.origin}/`,
   redirect_uri: `${window.location.origin}/`,
+  scope: 'openid',
   silent_redirect_uri: `${window.location.origin}/oidc-silent-renew.html`,
 };
 
@@ -44,14 +47,16 @@ export const App: FunctionComponent = () => {
     <GlobalTheme theme={carbonTheme}>
       <QueryClientProvider client={queryClient}>
         <NotificationProvider>
-          <AuthProvider {...oidcConfig}>
-            <RouterProvider router={router} />
-            <TanStackDevtools
+          <AuthProvider {...oidcConfig} onRemoveUser={navigateSignoutLocation} onSigninCallback={navigateSigninLocation}>
+            <AuthorizationProvider>
+              <RouterProvider router={router} />
+              <TanStackDevtools
               plugins={[
                 formDevtoolsPlugin(),
                 { name: 'TanStack Query', render: <ReactQueryDevtoolsPanel /> },
               ]}
             />
+            </AuthorizationProvider>
           </AuthProvider>
         </NotificationProvider>
       </QueryClientProvider>

--- a/src/main/webui/src/app/context/AuthorizationContext.tsx
+++ b/src/main/webui/src/app/context/AuthorizationContext.tsx
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+
+export interface AuthorizationContextInterface {
+  isAdmin: boolean;
+  isAuthenticated: boolean;
+}
+
+export const AuthorizationContext = createContext<AuthorizationContextInterface>({
+  isAdmin: false,
+  isAuthenticated: false,
+});

--- a/src/main/webui/src/app/context/AuthorizationProvider.tsx
+++ b/src/main/webui/src/app/context/AuthorizationProvider.tsx
@@ -1,0 +1,34 @@
+import { AuthorizationContext } from '@app/context/AuthorizationContext.tsx';
+import { roleOptions } from '@client/@tanstack/react-query.gen.ts';
+import { client } from '@client/client.gen.ts';
+import { useQuery } from '@tanstack/react-query';
+import { ReactNode, useEffect } from 'react';
+import { useAuth } from 'react-oidc-context';
+
+export const AuthorizationProvider = ({ children }: { children: ReactNode }) => {
+  const auth = useAuth();
+
+  const token = auth.user?.access_token;
+  const isAuthenticated = !!(auth.isAuthenticated && token);
+
+  useEffect(() => {
+    client.setConfig({ auth: isAuthenticated ? token : undefined });
+  }, [token, isAuthenticated]);
+
+  const { data: role } = useQuery({
+    ...roleOptions(),
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000,
+  });
+
+  return (
+    <AuthorizationContext.Provider
+      value={{
+        isAdmin: isAuthenticated && role === 'ADMIN',
+        isAuthenticated,
+      }}
+    >
+      {children}
+    </AuthorizationContext.Provider>
+  );
+};

--- a/src/main/webui/src/app/context/navigation.tsx
+++ b/src/main/webui/src/app/context/navigation.tsx
@@ -1,0 +1,27 @@
+import { User } from 'oidc-client-ts';
+import { NavigateFunction } from 'react-router-dom';
+
+let appNavigator: NavigateFunction | undefined = undefined;
+
+export const setAppNavigator = (nav?: NavigateFunction) => {
+  appNavigator = nav;
+};
+
+export const navigateSigninLocation = (user: undefined | User) => {
+  const targetPath = (user?.state as { path?: string } | undefined)?.path;
+  if (targetPath) {
+    if (appNavigator) {
+      return appNavigator(targetPath);
+    } else {
+      window.history.replaceState({}, document.title, targetPath);
+    }
+  }
+};
+
+export const navigateSignoutLocation = () => {
+  if (appNavigator) {
+    return appNavigator('/');
+  } else {
+    window.history.replaceState({}, document.title, '/');
+  }
+};

--- a/src/main/webui/src/app/context/useRoles.tsx
+++ b/src/main/webui/src/app/context/useRoles.tsx
@@ -1,0 +1,4 @@
+import { AuthorizationContext } from '@app/context/AuthorizationContext.tsx';
+import { useContext } from 'react';
+
+export const useRoles = () => useContext(AuthorizationContext);

--- a/src/main/webui/src/app/layout/AppHeader.tsx
+++ b/src/main/webui/src/app/layout/AppHeader.tsx
@@ -1,3 +1,4 @@
+import { AuthActions } from '@app/layout/AuthActions.tsx';
 import {
   ErrorBoundary,
   Header,
@@ -45,7 +46,9 @@ export const AppHeader = () => {
           <SkipToContent />
           <HeaderMenuButton aria-label="Hamburger menu" onClick={toggleSideNav} isActive={sideNavOpen} isCollapsible={true} />
           <HeaderName href="/" prefix="h5m">Horreum</HeaderName>
-          <HeaderGlobalBar />
+          <HeaderGlobalBar>
+            <AuthActions />
+          </HeaderGlobalBar>
         </Header>
         <SideNav aria-label="Side navigation" expanded={sideNavOpen} isPersistent={false} isFixedNav={false}>
           <ErrorBoundary

--- a/src/main/webui/src/app/layout/AuthActions.tsx
+++ b/src/main/webui/src/app/layout/AuthActions.tsx
@@ -1,0 +1,89 @@
+import { setAppNavigator } from '@app/context/navigation.tsx';
+import { useNotification } from '@app/context/useNotification.tsx';
+import { Login, Logout, UserAvatar } from '@carbon/icons-react';
+import { HeaderGlobalAction, HeaderPanel, SideNavDivider, SideNavItems, SideNavLink, SideNavMenuItem } from '@carbon/react';
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth } from 'react-oidc-context';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export const AuthActions = () => {
+  const auth = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { warning, handleError } = useNotification();
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  useEffect(() => {
+    setAppNavigator(navigate);
+  }, [navigate]);
+
+  const handleLogout = useCallback(() => {
+    auth
+      .signoutRedirect()
+      .then(() => auth.removeUser())
+      .catch((error: unknown) => {
+        handleError('Logout failed', error);
+      });
+  }, [auth, handleError]);
+
+  useEffect(() => {
+    const handleAccessTokenExpiring = () => {
+      auth.signinSilent({ extraQueryParams: { login_hint: auth.user?.profile.sub ?? '' } }).catch((error: unknown) => {
+        handleError('Token renewal failed', error);
+        handleLogout();
+      });
+    };
+    const handleSilentRenewError = (error: unknown) => {
+      warning('Session expired');
+      handleError('Silent renewal failed', error);
+      handleLogout();
+    };
+    auth.events.addAccessTokenExpiring(handleAccessTokenExpiring);
+    auth.events.addSilentRenewError(handleSilentRenewError);
+    return () => {
+      auth.events.removeAccessTokenExpiring(handleAccessTokenExpiring);
+      auth.events.removeSilentRenewError(handleSilentRenewError);
+    };
+  }, [auth, handleLogout, handleError, warning]);
+
+  const handleLogin = useCallback(() => {
+    const loginHintParam = auth.user ? { login_hint: auth.user.profile.sub } : undefined;
+    auth.signinRedirect({ ...loginHintParam, state: { path: `${location.pathname}${location.search}` } }).catch((error: unknown) => {
+      handleError('Login failed', error);
+    });
+  }, [auth, location, handleError]);
+
+  const username = auth.user?.profile.name ?? auth.user?.profile.preferred_username ?? auth.user?.profile.upn?.toString() ?? 'Anonymous';
+
+  if (!auth.isAuthenticated) {
+    return (
+      <HeaderGlobalAction aria-label="Login" onClick={handleLogin} tooltipAlignment="end">
+        <Login size={24} />
+      </HeaderGlobalAction>
+    );
+  }
+
+  return (
+    <>
+      <HeaderGlobalAction
+        aria-label={username}
+        isActive={panelOpen}
+        tooltipAlignment="end"
+        onClick={() => {
+          setPanelOpen((prev) => !prev);
+        }}
+      >
+        <UserAvatar size={24} />
+      </HeaderGlobalAction>
+      <HeaderPanel aria-label="User panel" expanded={panelOpen}>
+        <SideNavItems>
+          <SideNavMenuItem>{username}</SideNavMenuItem>
+          <SideNavDivider />
+          <SideNavLink renderIcon={Logout} onClick={handleLogout}>
+            Logout
+          </SideNavLink>
+        </SideNavItems>
+      </HeaderPanel>
+    </>
+  );
+};

--- a/src/main/webui/vite.config.ts
+++ b/src/main/webui/vite.config.ts
@@ -1,6 +1,7 @@
 import { devtools } from '@tanstack/devtools-vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
+import devtoolsJson from 'vite-plugin-devtools-json';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -25,7 +26,7 @@ export default defineConfig({
       },
     },
   },
-  plugins: [devtools(), react()],
+  plugins: [devtools({ consolePiping: { enabled: false } }), devtoolsJson(), react()],
   resolve: {
     alias: [
       {

--- a/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/server/AutoProvisioningTest.java
@@ -12,9 +12,13 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -22,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @QuarkusTest
 @TestProfile(SecurityEnabledProfile.class)
 public class AutoProvisioningTest extends FreshDb {
+
+    private static final String TEST_ISS = "https://test-issuer";
 
     @Inject
     OidcUserProvisioner provisioner;
@@ -42,11 +48,17 @@ public class AutoProvisioningTest extends FreshDb {
                 .build();
     }
 
+    private SecurityIdentity oidcIdentity(String sub, String username) {
+        return QuarkusSecurityIdentity.builder()
+                .setPrincipal(new TestJwt(sub, TEST_ISS, username))
+                .build();
+    }
+
     @Test
     void first_user_gets_admin_role() {
         assertEquals(0, userService.count());
         provisioner.augment(identityFor("first-user"), testContext)
-                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem();
 
         User user = userService.byUsername("first-user");
@@ -59,7 +71,7 @@ public class AutoProvisioningTest extends FreshDb {
         userService.create("existing-admin", Role.ADMIN);
 
         provisioner.augment(identityFor("new-user"), testContext)
-                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem();
 
         User user = userService.byUsername("new-user");
@@ -73,9 +85,47 @@ public class AutoProvisioningTest extends FreshDb {
         assertEquals(1, userService.count());
 
         provisioner.augment(identityFor("alice"), testContext)
-                .subscribe().withSubscriber(io.smallrye.mutiny.helpers.test.UniAssertSubscriber.create())
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
                 .awaitItem();
 
         assertEquals(1, userService.count());
+    }
+
+    @Test
+    void oidc_user_gets_provisioned_with_sub_and_iss() {
+        userService.create("existing-admin", Role.ADMIN);
+
+        provisioner.augment(oidcIdentity("sub-oidc", "oidc-user"), testContext)
+                .subscribe().withSubscriber(UniAssertSubscriber.create())
+                .awaitItem();
+
+        User user = userService.bySub("sub-oidc", TEST_ISS);
+        assertNotNull(user);
+        assertEquals("oidc-user", user.username());
+        assertEquals(Role.USER, user.role());
+    }
+
+    private record TestJwt(String sub, String iss, String preferredUsername) implements JsonWebToken {
+
+        @Override
+        public String getName() {
+            return sub;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T getClaim(String claimName) {
+            return (T) switch (claimName) {
+                case "sub" -> sub;
+                case "iss" -> iss;
+                case "preferred_username" -> preferredUsername;
+                default -> null;
+            };
+        }
+
+        @Override
+        public Set<String> getClaimNames() {
+            return Set.of("sub", "iss", "preferred_username");
+        }
     }
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/SecurityEnabledProfile.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/SecurityEnabledProfile.java
@@ -7,6 +7,10 @@ import java.util.Map;
 public class SecurityEnabledProfile implements QuarkusTestProfile {
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of("h5m.security.enabled", "true");
+        return Map.of(
+                "h5m.security.enabled", "true",
+                "quarkus.oidc.tenant-enabled", "false", // disables the start of a oidc server. we're testing API keys, no need for OIDC
+                "quarkus.oidc-proxy.enabled", "false" // oidc-proxy disabled in tests: no frontend needs the /q/oidc discovery endpoint
+        );
     }
 }


### PR DESCRIPTION
Summary

- Add `quarkus-oidc-proxy` extension to expose a `/q/oidc` discovery endpoint, allowing the frontend OIDC client to discover the identity provider through the backend. Dev profile auto-starts an OIDC server with test users (roles are assigned by h5m on first login).
- Store OIDC `sub` and `iss` claims in `UserEntity` as stable identity. The provisioner and roles augmentor pattern-match on principal type (`JsonWebToken` vs plain principal) to dispatch user lookup accordingly.
- Wire up frontend auth: `AuthorizationContext`/`Provider` injects OIDC tokens into Axios via interceptor, fetches the user role from `/api/user/role`, and exposes `isAdmin`/`isAuthenticated`. `AuthActions` component provides login/logout with token renewal and notifications.

Test plan

- [x] Start dev mode — OIDC server launches automatically with test users
- [x] Login via OIDC — username displays in the header (not "Anonymous")
- [x] First user gets `ADMIN` role, subsequent users get `USER` role
- [x] `AutoProvisioningTest` covers OIDC provisioning with `sub`/`iss` and the username-based path
- [x] API key auth remains functional with OIDC enabled
- [x] Create folder using CLI does not require authentication