### PR TITLE
render h5m site on the web-ui

### DIFF
--- a/docs/site/hugo.toml
+++ b/docs/site/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://h5m-docs.example.com/'
+baseURL = '/site/'
 title = 'h5m Documentation'
 
 contentDir = "content/en"
@@ -8,6 +8,7 @@ enableMissingTranslationPlaceholders = true
 
 enableRobotsTXT = true
 enableGitInfo = true
+canonifyURLs = true
 
 pygmentsCodeFences = true
 pygmentsUseClasses = false
@@ -37,6 +38,7 @@ pygmentsStyle = "tango"
 
 [params]
   github_repo = "https://github.com/hyperfoil/h5m"
+  github_subdir = "docs/site"
   github_project_repo = "https://github.com/hyperfoil/h5m"
   github_branch = "main"
   offlineSearch = true

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <build.build-helper-maven-plugin>3.6.1</build.build-helper-maven-plugin>
         <build.buildnumber-maven-plugin>3.2.1</build.buildnumber-maven-plugin>
         <build.exec-maven-plugin>3.6.2</build.exec-maven-plugin>
+        <build.hugo-maven-plugin>0.2.20</build.hugo-maven-plugin>
         <build.jandex-maven-plugin>3.1.6</build.jandex-maven-plugin>
         <build.maven-compiler-plugin>3.14.0</build.maven-compiler-plugin>
         <build.maven-enforcer-plugin>3.6.2</build.maven-enforcer-plugin>
@@ -664,6 +665,46 @@
                                 <configuration>
                                     <attachRunnerAsMainArtifact>true</attachRunnerAsMainArtifact>
                                     <attachSboms>true</attachSboms>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${build.exec-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>docs-npm-install</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <executable>npm</executable>
+                                    <workingDirectory>${project.basedir}/docs/site</workingDirectory>
+                                    <arguments>
+                                        <argument>install</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.echocat.maven.plugins</groupId>
+                        <artifactId>hugo-maven-plugin</artifactId>
+                        <version>${build.hugo-maven-plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>generate-hugo-site</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <workingDirectory>${project.basedir}/docs/site</workingDirectory>
+                                    <config>${project.basedir}/docs/site/hugo.toml</config>
+                                    <output>${project.basedir}/src/main/webui/public/site</output>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -74,7 +74,8 @@ quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
 
 # quinoa
 quarkus.quinoa.enable-spa-routing=true
-quarkus.quinoa.ignored-path-prefixes=/_
+quarkus.quinoa.ignored-path-prefixes=/api
+quarkus.quinoa.dev-server.direct-forwarding=true
 
 # aesh configuration: runtime for commands, console for REPL
 quarkus.aesh.start-console=false

--- a/src/main/webui/.gitignore
+++ b/src/main/webui/.gitignore
@@ -27,3 +27,6 @@ chunks-report.html
 *.njsproj
 *.sln
 *.sw?
+
+# generated static site
+/public/site/

--- a/src/main/webui/src/app/layout/AppHeader.tsx
+++ b/src/main/webui/src/app/layout/AppHeader.tsx
@@ -1,7 +1,10 @@
 import { AuthActions } from '@app/layout/AuthActions.tsx';
+import { Help } from '@carbon/icons-react';
 import {
+  Content,
   ErrorBoundary,
   Header,
+  HeaderGlobalAction,
   HeaderGlobalBar,
   HeaderMenuButton,
   HeaderName,
@@ -16,7 +19,7 @@ import {
 import { listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Suspense, useCallback, useState } from 'react';
-import { Outlet, useParams } from 'react-router-dom';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
 
 const NavFolders = () => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
@@ -35,6 +38,7 @@ const NavFolders = () => {
 
 export const AppHeader = () => {
   const { folderId } = useParams<{ folderId: string }>();
+  const navigate = useNavigate();
   const [sideNavOpen, setSideNavOpen] = useState(!folderId);
   const toggleSideNav = useCallback(() => {
     setSideNavOpen((prev) => !prev);
@@ -45,8 +49,13 @@ export const AppHeader = () => {
         <Header aria-label="Carbon App">
           <SkipToContent />
           <HeaderMenuButton aria-label="Hamburger menu" onClick={toggleSideNav} isActive={sideNavOpen} isCollapsible={true} />
-          <HeaderName href="/" prefix="h5m">Horreum</HeaderName>
+          <HeaderName href="/" prefix="h5m">
+            Horreum
+          </HeaderName>
           <HeaderGlobalBar>
+            <HeaderGlobalAction aria-label="Documentation" onClick={() => void navigate('/help')} tooltipAlignment="end">
+              <Help size={24} />
+            </HeaderGlobalAction>
             <AuthActions />
           </HeaderGlobalBar>
         </Header>
@@ -70,7 +79,9 @@ export const AppHeader = () => {
           </ErrorBoundary>
         </SideNav>
       </Theme>
-      <Outlet />
+      <Content style={{ padding: 0 }}>
+        <Outlet />
+      </Content>
     </>
   );
 };

--- a/src/main/webui/src/app/pages/DashboardPage.tsx
+++ b/src/main/webui/src/app/pages/DashboardPage.tsx
@@ -218,7 +218,7 @@ const DashboardContent = () => {
 
 export const DashboardPage = () => {
   return (
-    <div style={{ padding: 'var(--cds-spacing-05)', marginTop: 'var(--cds-spacing-09)' }}>
+    <div style={{ padding: 'var(--cds-spacing-05)' }}>
       <h2 style={{ marginBottom: 'var(--cds-spacing-05)' }}>Dashboard</h2>
       <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load dashboard" />}>
         <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -211,7 +211,7 @@ export const FolderPage = () => {
     return null;
   }
   return (
-    <div style={{ padding: 'var(--cds-spacing-05)', marginTop: 'var(--cds-spacing-09)' }}>
+    <div style={{ padding: 'var(--cds-spacing-05)' }}>
       <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load folder" />}>
         <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
           <FolderContent folderId={id} />

--- a/src/main/webui/src/app/routes.ts
+++ b/src/main/webui/src/app/routes.ts
@@ -1,6 +1,7 @@
 import { AppHeader } from '@app/layout/AppHeader';
 import { DashboardPage } from '@app/pages/DashboardPage';
 import { FolderPage } from '@app/pages/FolderPage';
+import { createElement } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 const router = createBrowserRouter([
@@ -11,6 +12,15 @@ const router = createBrowserRouter([
       {
         Component: DashboardPage,
         index: true,
+      },
+      {
+        Component: () =>
+          createElement('iframe', {
+            src: '/site/docs/',
+            title: 'Documentation',
+            style: { display: 'block', border: 'none', width: '100%', height: 'calc(100vh - 3rem)' },
+          }),
+        path: 'help',
       },
       {
         Component: FolderPage,


### PR DESCRIPTION
Integrate Hugo documentation site into the web UI

Build the Hugo/Docsy documentation site during the Maven build and display it in the React app via a Help icon in the header.

Changes

Build pipeline (`pom.xml`)
- Add `exec-maven-plugin` to run `npm install` in `docs/site` (installs PostCSS, required by Docsy's SCSS pipeline)
- Add `hugo-maven-plugin` to build the Hugo site from `docs/site` into `src/main/webui/public/site`
- Both run during `generate-resources` in the `web` profile

Hugo configuration (`docs/site/hugo.toml`)
- Set `baseURL` to `/site/` so generated links resolve correctly when served under the app
- Add `github_subdir = "docs/site"` so "View page source" links point to the correct path in the repo
- Enable `canonifyURLs` in Hugo, which rewrites all absolute URLs to include the `baseURL` prefix, ir order to correctly display images (because they're written as absolute paths in markdown).

Web UI
- Add a Help icon (question mark) to `HeaderGlobalBar` in `AppHeader`, navig
- Add `/help` route that renders the Hugo site in an `<iframe/>`
- Wrap `<Outlet />` in Carbon's `Content` component for proper header offset (hacks from `DashboardPage` and `FolderPage`)

Quinoa (`application.properties`)
- Enable `dev-server.direct-forwarding` so Vite handles directory-to-index.html resolution and SPA fallback in `dev` mode, matching production behavior

Other
- Add `/public/site/` to webui `.gitignore` (build artifact)