### PR TITLE
wire Zod validation from backend annotations to TanStack Form

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/EDivisiveConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/EDivisiveConfig.java
@@ -1,5 +1,9 @@
 package io.hyperfoil.tools.h5m.api.node;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -29,4 +33,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
  * @param fingerprintFilter optional jq filter to select specific fingerprint values
  */
 @Schema(description = "Configuration for the E-Divisive (Hunter) change detection algorithm")
-public record EDivisiveConfig(int windowLen, double maxPvalue, double minMagnitude, int maxSeriesLength, String fingerprintFilter) implements NodeConfiguration {}
+public record EDivisiveConfig(
+        @Min(3) int windowLen,
+        @DecimalMin("0") @DecimalMax("1") double maxPvalue,
+        @DecimalMin("0") double minMagnitude,
+        @Positive int maxSeriesLength,
+        String fingerprintFilter) implements NodeConfiguration {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/FixedThresholdConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/FixedThresholdConfig.java
@@ -1,7 +1,13 @@
 package io.hyperfoil.tools.h5m.api.node;
 
+import jakarta.validation.constraints.AssertTrue;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Configuration for the Fixed Threshold detection algorithm")
 public record FixedThresholdConfig(Double min, Double max, Boolean minInclusive, Boolean maxInclusive, String fingerprintFilter) implements NodeConfiguration {
+
+    @AssertTrue(message = "min must be less than or equal to max")
+    boolean isMinLessThanOrEqualToMax() {
+        return min == null || max == null || min <= max;
+    }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/RelativeDifferenceConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/RelativeDifferenceConfig.java
@@ -1,7 +1,15 @@
 package io.hyperfoil.tools.h5m.api.node;
 
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Positive;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Configuration for the Relative Difference detection algorithm")
-public record RelativeDifferenceConfig(String filter, double threshold, int window, int minPrevious, String fingerprintFilter) implements NodeConfiguration {
+public record RelativeDifferenceConfig(
+        Filter filter,
+        @DecimalMin("0") double threshold,
+        @Positive int window,
+        @Positive int minPrevious,
+        String fingerprintFilter) implements NodeConfiguration {
+    public enum Filter { MEAN, MIN, MAX }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/node/StdDevAnomalyConfig.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/node/StdDevAnomalyConfig.java
@@ -1,13 +1,16 @@
 package io.hyperfoil.tools.h5m.api.node;
 
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(description = "Configuration for the StdDev Anomaly detection algorithm")
 public record StdDevAnomalyConfig(
-        int windowSize,
-        double deviations,
+        @Min(2) int windowSize,
+        @DecimalMin(value = "0", inclusive = false) double deviations,
         Direction direction,
-        int minDataPoints,
+        @Positive int minDataPoints,
         String fingerprintFilter
 ) implements NodeConfiguration {
     public enum Direction {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AddRelativeDifference.java
@@ -36,8 +36,8 @@ public class AddRelativeDifference extends AddDetectionNode {
 
     @Option(name = "filter", acceptNameWithoutDashes = true,
             description = "Function used to aggregate datapoints from the floating window.",
-            defaultValue = {RelativeDifference.DEFAULT_FILTER})
-    String filter;
+            defaultValue = {"MEAN"})
+    RelativeDifferenceConfig.Filter filter;
 
     @Override
     public CommandResult execute(H5mCommandInvocation invocation) throws InterruptedException {

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/LoadLegacyTests.java
@@ -13,6 +13,7 @@ import io.hyperfoil.tools.h5m.entity.NodeGroupEntity;
 import io.hyperfoil.tools.h5m.entity.node.*;
 import io.hyperfoil.tools.h5m.api.View;
 import io.hyperfoil.tools.h5m.api.ViewComponent;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig;
 import io.hyperfoil.tools.h5m.api.svc.ViewServiceInterface;
 import io.hyperfoil.tools.h5m.svc.FolderService;
 import io.hyperfoil.tools.h5m.svc.NodeService;
@@ -575,7 +576,12 @@ public class LoadLegacyTests implements Command<H5mCommandInvocation> {
                 case "relativeDifference"-> {
                     RelativeDifference difference = new RelativeDifference();
                     difference.name="rd."+variableNode.name+"."+changeDetection.id();
-                    difference.setFilter(changeDetection.config().get("filter").asString(RelativeDifference.DEFAULT_FILTER));
+                    try {
+                        String filterStr = changeDetection.config().get("filter").asString(RelativeDifference.DEFAULT_FILTER.name());
+                        difference.setFilter(RelativeDifferenceConfig.Filter.valueOf(filterStr.toUpperCase()));
+                    } catch (IllegalArgumentException ignored) {
+                        difference.setFilter(RelativeDifference.DEFAULT_FILTER);
+                    }
                     difference.setWindow(changeDetection.config().get("window").asInt(RelativeDifference.DEFAULT_WINDOW));
                     difference.setThreshold(changeDetection.config().get("threshold").asDouble(RelativeDifference.DEFAULT_THRESHOLD));
                     difference.setMinPrevious(changeDetection.config().get("minPrevious").asInt(RelativeDifference.DEFAULT_MIN_PREVIOUS));

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/node/RelativeDifference.java
@@ -2,6 +2,7 @@ package io.hyperfoil.tools.h5m.entity.node;
 
 import io.hyperfoil.tools.h5m.api.NodeType;
 import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig.Filter;
 import io.hyperfoil.tools.h5m.entity.NodeEntity;
 import io.hyperfoil.tools.jjq.value.*;
 import jakarta.persistence.DiscriminatorValue;
@@ -23,7 +24,7 @@ public class RelativeDifference extends NodeEntity implements DetectionNode {
     private static final String MIN_PREVIOUS = "minPrevious";
     public static final int DEFAULT_MIN_PREVIOUS = 5;
     private static final String FILTER =  "filter";
-    public static final String DEFAULT_FILTER = "mean";//attribute value must be a constant
+    public static final Filter DEFAULT_FILTER = Filter.MEAN;
     private static final String FINGERPRINT_FILTER = "fingerprintFilter";
 
     @Transient
@@ -41,7 +42,7 @@ public class RelativeDifference extends NodeEntity implements DetectionNode {
     public RelativeDifference(String name, RelativeDifferenceConfig rd) {
         super(name, "");
         JqObject.Builder b = JqObject.builder();
-        if (rd.filter() != null) b.put("filter", rd.filter());
+        if (rd.filter() != null) b.put("filter", rd.filter().name());
         b.put("threshold", rd.threshold());
         b.put("window", (long) rd.window());
         b.put("minPrevious", (long) rd.minPrevious());
@@ -128,11 +129,15 @@ public class RelativeDifference extends NodeEntity implements DetectionNode {
         operation = config.toJsonString();
     }
     @Transient
-    public String getFilter(){
-        return config.get(FILTER).asString(DEFAULT_FILTER);
+    public Filter getFilter(){
+        try {
+            return Filter.valueOf(config.get(FILTER).asString(DEFAULT_FILTER.name()).toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return DEFAULT_FILTER;
+        }
     }
-    public void setFilter(String filter){
-        config = config.with(FILTER, JqString.of(filter));
+    public void setFilter(Filter filter){
+        config = config.with(FILTER, JqString.of(filter.name()));
         operation = config.toJsonString();
     }
     @Transient

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -18,8 +18,10 @@ import io.quarkus.security.Authenticated;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.UniqueElements;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -57,7 +59,7 @@ public class NodeResource {
             @QueryParam("name") @NotEmpty String name,
             @QueryParam("groupId") @NotNull Long groupId,
             @QueryParam("type") @NotNull NodeType type,
-            @QueryParam("operation") String operation) {
+            @QueryParam("operation") @NotEmpty String operation) {
         return nodeService.create(name, groupId, type, operation);
     }
 
@@ -70,8 +72,8 @@ public class NodeResource {
             @QueryParam("name") @NotEmpty String name,
             @QueryParam("groupId") @NotNull Long groupId,
             @QueryParam("type") @NotNull NodeType type,
-            @QueryParam("sources") @NotNull @NotEmpty List<Long> sources,
-            @RequestBody(required = false) NodeConfiguration configuration) {
+            @QueryParam("sources") @NotNull @NotEmpty @UniqueElements(message = "Duplicate source nodes are not allowed: each source node must serve a unique role") List<Long> sources,
+            @RequestBody(required = false) @Valid NodeConfiguration configuration) {
         try {
             return nodeService.createConfigured(name, groupId, type, sources, configuration);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/NodeService.java
@@ -562,10 +562,9 @@ public class NodeService implements NodeServiceInterface {
                                 System.err.println("insufficient samples to calculate " + relDiff.name + " need " + (relDiff.getWindow() + minPrevious) + " have " + converted.size());
                             } else {
                                 DoubleBinaryOperator op = switch (relDiff.getFilter()) {
-                                    case "min" -> Double::min;
-                                    case "max" -> Double::max;
-                                    case "mean" -> Double::sum;
-                                    default -> Double::sum;
+                                    case MIN -> Double::min;
+                                    case MAX -> Double::max;
+                                    case MEAN -> Double::sum;
                                 };
                                 SummaryStatistics previousStats = new SummaryStatistics();
                                 converted
@@ -581,7 +580,7 @@ public class NodeService implements NodeServiceInterface {
                                         .mapToDouble(Double::doubleValue)
                                         .reduce(op)
                                         .getAsDouble();
-                                if (relDiff.getFilter().equals("mean")) {
+                                if (relDiff.getFilter() == RelativeDifferenceConfig.Filter.MEAN) {
                                     value = value / (converted.size() - minPrevious);
                                 }
                                 double ratio = value / previousStats.getMean();

--- a/src/main/webui/src/app/components/CreateNodeModal.tsx
+++ b/src/main/webui/src/app/components/CreateNodeModal.tsx
@@ -1,7 +1,8 @@
-import type { Direction, Node as ApiNode, NodeType } from '@client/types.gen.ts';
+import type { Direction, Filter, Node as ApiNode, NodeType } from '@client/types.gen.ts';
 
 import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
 import { useNotification } from '@app/context/useNotification.tsx';
+import { fieldError } from '@app/validation.ts';
 import {
   Button,
   ComposedModal,
@@ -21,9 +22,11 @@ import {
   TextInput,
 } from '@carbon/react';
 import { byIdOptions, createConfiguredMutation, createNodeMutation } from '@client/@tanstack/react-query.gen.ts';
+import { zCreateNodeQuery } from '@client/zod.gen.ts';
 import { useForm, useSelector } from '@tanstack/react-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { z } from 'zod';
 
 import { DETECTION_SOURCES, DetectionConfigStep, buildConfig } from './DetectionConfigStep';
 
@@ -85,10 +88,16 @@ export interface FormValues {
   srcGroupBy: string;
   srcRange: string;
   srcDomain: string;
-  ftConfig: { min: string; max: string; minInclusive: boolean; maxInclusive: boolean; fingerprintFilter: string };
-  rdConfig: { filter: string; threshold: string; window: string; minPrevious: string; fingerprintFilter: string };
-  sdConfig: { windowSize: string; deviations: string; direction: Direction; minDataPoints: string; fingerprintFilter: string };
-  edConfig: { windowLen: string; maxPvalue: string; minMagnitude: string; maxSeriesLength: string; fingerprintFilter: string };
+  ftConfig: { min: number | string; max: number | string; minInclusive: boolean; maxInclusive: boolean; fingerprintFilter: string };
+  rdConfig: { filter: Filter; threshold: number | string; window: number | string; minPrevious: number | string; fingerprintFilter: string };
+  sdConfig: { windowSize: number | string; deviations: number | string; direction: Direction; minDataPoints: number | string; fingerprintFilter: string };
+  edConfig: {
+    windowLen: number | string;
+    maxPvalue: number | string;
+    minMagnitude: number | string;
+    maxSeriesLength: number | string;
+    fingerprintFilter: string;
+  };
 }
 
 const DEFAULT_VALUES: FormValues = {
@@ -102,9 +111,9 @@ const DEFAULT_VALUES: FormValues = {
   srcRange: '',
   srcDomain: '',
   ftConfig: { min: '', minInclusive: true, max: '', maxInclusive: true, fingerprintFilter: '' },
-  rdConfig: { filter: 'mean', threshold: '0.2', window: '1', minPrevious: '5', fingerprintFilter: '' },
-  sdConfig: { windowSize: '10', deviations: '2.0', direction: 'BOTH', minDataPoints: '5', fingerprintFilter: '' },
-  edConfig: { windowLen: '50', maxPvalue: '0.001', minMagnitude: '0.0', maxSeriesLength: '500', fingerprintFilter: '' },
+  rdConfig: { filter: 'MEAN', threshold: 0.2, window: 1, minPrevious: 5, fingerprintFilter: '' },
+  sdConfig: { windowSize: 10, deviations: 2.0, direction: 'BOTH', minDataPoints: 5, fingerprintFilter: '' },
+  edConfig: { windowLen: 50, maxPvalue: 0.001, minMagnitude: 0.0, maxSeriesLength: 500, fingerprintFilter: '' },
 };
 
 export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps) => {
@@ -194,34 +203,12 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
   const nodeEntry = NODE_TYPES.find((t) => t.value === nodeType);
   const steps: StepKey[] = ['type', ...(nodeEntry?.extraSteps ?? [])];
 
-  const validateStep = (stepKey: StepKey): boolean => {
-    const values = form.state.values;
-    if (stepKey === 'type') {
-      void form.validateField('name', 'submit');
-      if (!values.name.trim()) return false;
-    }
-    if (stepKey === 'sources') {
-      if (nodeType === 'FINGERPRINT') {
-        void form.validateField('fpSources', 'submit');
-        if (values.fpSources.length === 0) return false;
-      }
-      if (steps.includes('detection')) {
-        let hasError = false;
-        for (const src of DETECTION_SOURCES) {
-          void form.validateField(src.name, 'submit');
-          if (!values[src.name]) hasError = true;
-        }
-        if (hasError) return false;
-      }
-    }
-    return true;
-  };
-
   const handleNext = () => {
-    const step = steps[currentStep];
-    if (step && validateStep(step)) {
-      setCurrentStep((s) => s + 1);
-    }
+    void form.validateAllFields('submit').then(() => {
+      if (form.state.isFieldsValid) {
+        setCurrentStep((s) => s + 1);
+      }
+    });
   };
 
   return (
@@ -241,14 +228,11 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                   setCurrentStep(stepIndex);
                   return;
                 }
-                for (let i = currentStep; i < stepIndex; i++) {
-                  const step = steps[i];
-                  if (!step || !validateStep(step)) {
-                    setCurrentStep(i);
-                    return;
+                void form.validateAllFields('submit').then(() => {
+                  if (form.state.isFieldsValid) {
+                    setCurrentStep(stepIndex);
                   }
-                }
-                setCurrentStep(stepIndex);
+                });
               }}
               spaceEqually
             >
@@ -262,8 +246,8 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                 <form.Field
                   name="name"
                   validators={{
-                    onBlur: ({ value }) => (value.trim() === '' ? 'Node name is required' : undefined),
-                    onSubmit: ({ value }) => (value.trim() === '' ? 'Node name is required' : undefined),
+                    onBlur: zCreateNodeQuery.shape.name,
+                    onSubmit: zCreateNodeQuery.shape.name,
                   }}
                 >
                   {(field) => (
@@ -277,7 +261,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                       }}
                       onBlur={field.handleBlur}
                       invalid={field.state.meta.errors.length > 0}
-                      invalidText={field.state.meta.errors[0]}
+                      invalidText={fieldError(field.state.meta.errors)}
                     />
                   )}
                 </form.Field>
@@ -360,7 +344,8 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                 {nodeType === 'FINGERPRINT' && (
                   <form.Field
                     name="fpSources"
-                    validators={{ onSubmit: ({ value }) => (value.length === 0 ? 'At least one source node is required' : undefined) }}
+                    // workaround for hey-api/hey-api#1802: Zod plugin generates bigint for int64 despite bigInt:false
+                    validators={{ onSubmit: z.array(z.number()).min(1) }}
                   >
                     {(field) => (
                       <MultiSelect
@@ -373,7 +358,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                           .map((n) => ({ id: String(n.id), label: `${n.name ?? '?'} (${n.type ?? '?'})`, nodeId: n.id }))}
                         itemToString={(item) => item.label}
                         invalid={field.state.meta.errors.length > 0}
-                        invalidText={field.state.meta.errors[0]}
+                        invalidText={fieldError(field.state.meta.errors)}
                         onChange={({ selectedItems }) => {
                           field.handleChange((selectedItems ?? []).map((i) => i.nodeId));
                         }}
@@ -385,7 +370,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                 {steps.includes('detection') && (
                   <Stack gap={6}>
                     {DETECTION_SOURCES.map((src) => (
-                      <form.Field key={src.name} name={src.name} validators={{ onSubmit: ({ value }) => (!value ? `${src.label} is required` : undefined) }}>
+                      <form.Field key={src.name} name={src.name} validators={{ onSubmit: src.schema }}>
                         {(field) => (
                           <Select
                             id={src.name}
@@ -396,7 +381,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                             }}
                             disabled={nodesLoading}
                             invalid={field.state.meta.errors.length > 0}
-                            invalidText={field.state.meta.errors[0]}
+                            invalidText={fieldError(field.state.meta.errors)}
                           >
                             <SelectItem value="" text={`Select ${src.label.toLowerCase()}`} />
                             {availableNodes
@@ -436,7 +421,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
             )}
 
             {steps[currentStep] === 'operation' && (
-              <form.Field name="operation" validators={{ onSubmit: ({ value }) => (value.trim() === '' ? 'Operation is required' : undefined) }}>
+              <form.Field name="operation" validators={{ onSubmit: zCreateNodeQuery.shape.operation }}>
                 {(field) => (
                   <TextArea
                     id="node-operation"
@@ -450,7 +435,7 @@ export const CreateNodeModal = ({ open, onClose, groupId }: CreateNodeModalProps
                     }}
                     className="type-code"
                     invalid={field.state.meta.errors.length > 0}
-                    invalidText={field.state.meta.errors[0]}
+                    invalidText={fieldError(field.state.meta.errors)}
                   />
                 )}
               </form.Field>

--- a/src/main/webui/src/app/components/DetectionConfigStep.tsx
+++ b/src/main/webui/src/app/components/DetectionConfigStep.tsx
@@ -2,14 +2,23 @@ import type { EDivisiveConfig, FixedThresholdConfig, NodeConfiguration, NodeType
 import type { FormAsyncValidateOrFn, FormValidateOrFn } from '@tanstack/form-core';
 import type { ReactFormExtendedApi } from '@tanstack/react-form';
 
-import { Checkbox, Select, SelectItem, Stack, TextInput } from '@carbon/react';
+import { fieldError, groupValidator } from '@app/validation.ts';
+import { Checkbox, NumberInput, Select, SelectItem, Stack } from '@carbon/react';
+import { zDirection, zEDivisiveConfig, zFilter, zFixedThresholdConfig, zRelativeDifferenceConfig, zStdDevAnomalyConfig } from '@client/zod.gen.ts';
+import { z, type ZodType } from 'zod';
 
 import type { FormValues } from './CreateNodeModal';
 
-export const DETECTION_SOURCES: { name: 'srcFingerprint' | 'srcGroupBy' | 'srcRange'; label: string; allowedTypes: NodeType[] }[] = [
-  { name: 'srcFingerprint', label: 'Fingerprint node', allowedTypes: ['FINGERPRINT'] },
-  { name: 'srcGroupBy', label: 'GroupBy node', allowedTypes: ['JQ', 'JS', 'JSONATA', 'SPLIT'] },
-  { name: 'srcRange', label: 'Range node', allowedTypes: ['JQ', 'JS', 'JSONATA', 'SPLIT'] },
+export const DETECTION_SOURCES: {
+  name: 'srcFingerprint' | 'srcGroupBy' | 'srcRange';
+  label: string;
+  allowedTypes: NodeType[];
+  // frontend-only: the API takes a flat sources array, not individual source-role parameters, so per-select validation can't flow from the backend
+  schema: ZodType<string, string>;
+}[] = [
+  { name: 'srcFingerprint', label: 'Fingerprint node', allowedTypes: ['FINGERPRINT'], schema: z.string().min(1) },
+  { name: 'srcGroupBy', label: 'GroupBy node', allowedTypes: ['ROOT', 'JQ', 'JS', 'JSONATA', 'SPLIT'], schema: z.string().min(1) },
+  { name: 'srcRange', label: 'Range node', allowedTypes: ['JQ', 'JS', 'JSONATA', 'SPLIT'], schema: z.string().min(1) },
 ];
 
 type NumericConfigField =
@@ -27,15 +36,15 @@ type NumericConfigField =
   | 'edConfig.windowLen';
 
 type DetectionFieldDef =
-  | { kind: 'number'; name: NumericConfigField; id: string; label: string; placeholder: string; helperText?: string }
+  | { kind: 'number'; name: NumericConfigField; id: string; label: string; helperText?: string; allowEmpty?: boolean }
   | { kind: 'select'; name: 'rdConfig.filter' | 'sdConfig.direction'; id: string; label: string; options: { value: string; text: string }[] }
   | { kind: 'checkbox'; name: 'ftConfig.minInclusive' | 'ftConfig.maxInclusive'; id: string; label: string };
 
 const DETECTION_FIELDS: Partial<Record<NodeType, DetectionFieldDef[]>> = {
   FIXED_THRESHOLD: [
-    { kind: 'number', name: 'ftConfig.min', id: 'ft-min', label: 'Min', placeholder: '0' },
+    { kind: 'number', name: 'ftConfig.min', id: 'ft-min', label: 'Min', allowEmpty: true },
     { kind: 'checkbox', name: 'ftConfig.minInclusive', id: 'ft-min-inclusive', label: 'Min inclusive' },
-    { kind: 'number', name: 'ftConfig.max', id: 'ft-max', label: 'Max', placeholder: '100' },
+    { kind: 'number', name: 'ftConfig.max', id: 'ft-max', label: 'Max', allowEmpty: true },
     { kind: 'checkbox', name: 'ftConfig.maxInclusive', id: 'ft-max-inclusive', label: 'Max inclusive' },
   ],
   RELATIVE_DIFFERENCE: [
@@ -44,48 +53,37 @@ const DETECTION_FIELDS: Partial<Record<NodeType, DetectionFieldDef[]>> = {
       name: 'rdConfig.filter',
       id: 'rd-filter',
       label: 'Aggregation filter',
-      options: ['mean', 'median', 'min', 'max'].map((f) => ({ value: f, text: f })),
+      options: zFilter.options.map((f) => ({ value: f, text: f.charAt(0) + f.slice(1).toLowerCase() })),
     },
-    { kind: 'number', name: 'rdConfig.threshold', id: 'rd-threshold', label: 'Threshold (fraction)', placeholder: '0.2', helperText: 'e.g. 0.2 = 20%' },
-    { kind: 'number', name: 'rdConfig.window', id: 'rd-window', label: 'Window', placeholder: '1', helperText: 'Recent values to compare' },
-    { kind: 'number', name: 'rdConfig.minPrevious', id: 'rd-min-previous', label: 'Min previous', placeholder: '5', helperText: 'History required' },
+    { kind: 'number', name: 'rdConfig.threshold', id: 'rd-threshold', label: 'Threshold (fraction)', helperText: 'e.g. 0.2 = 20%' },
+    { kind: 'number', name: 'rdConfig.window', id: 'rd-window', label: 'Window', helperText: 'Recent values to compare' },
+    { kind: 'number', name: 'rdConfig.minPrevious', id: 'rd-min-previous', label: 'Min previous', helperText: 'History required' },
   ],
   STDDEV_ANOMALY: [
-    { kind: 'number', name: 'sdConfig.windowSize', id: 'sd-window', label: 'Window size', placeholder: '10' },
-    { kind: 'number', name: 'sdConfig.deviations', id: 'sd-deviations', label: 'Deviations', placeholder: '2.0' },
-    { kind: 'number', name: 'sdConfig.minDataPoints', id: 'sd-min-dp', label: 'Min data points', placeholder: '5' },
+    { kind: 'number', name: 'sdConfig.windowSize', id: 'sd-window', label: 'Window size' },
+    { kind: 'number', name: 'sdConfig.deviations', id: 'sd-deviations', label: 'Deviations' },
+    { kind: 'number', name: 'sdConfig.minDataPoints', id: 'sd-min-dp', label: 'Min data points' },
     {
       kind: 'select',
       name: 'sdConfig.direction',
       id: 'sd-direction',
       label: 'Direction',
-      options: [
-        { value: 'BOTH', text: 'Both' },
-        { value: 'UPPER', text: 'Upper' },
-        { value: 'LOWER', text: 'Lower' },
-      ],
+      options: zDirection.options.map((d) => ({ value: d, text: d.charAt(0) + d.slice(1).toLowerCase() })),
     },
   ],
   EDIVISIVE: [
-    {
-      kind: 'number',
-      name: 'edConfig.windowLen',
-      id: 'ed-window',
-      label: 'Window length',
-      placeholder: '50',
-      helperText: 'Min 3; ≥100 data points recommended',
-    },
-    { kind: 'number', name: 'edConfig.maxPvalue', id: 'ed-pvalue', label: 'Max p-value', placeholder: '0.001', helperText: 'Significance threshold' },
-    { kind: 'number', name: 'edConfig.minMagnitude', id: 'ed-magnitude', label: 'Min magnitude', placeholder: '0.0', helperText: 'e.g. 0.1 = 10% change' },
-    {
-      kind: 'number',
-      name: 'edConfig.maxSeriesLength',
-      id: 'ed-max-series',
-      label: 'Max series length',
-      placeholder: '500',
-      helperText: 'Most recent N points to analyze',
-    },
+    { kind: 'number', name: 'edConfig.windowLen', id: 'ed-window', label: 'Window length', helperText: 'Min 3; ≥100 data points recommended' },
+    { kind: 'number', name: 'edConfig.maxPvalue', id: 'ed-pvalue', label: 'Max p-value', helperText: 'Significance threshold' },
+    { kind: 'number', name: 'edConfig.minMagnitude', id: 'ed-magnitude', label: 'Min magnitude', helperText: 'e.g. 0.1 = 10% change' },
+    { kind: 'number', name: 'edConfig.maxSeriesLength', id: 'ed-max-series', label: 'Max series length', helperText: 'Most recent N points to analyze' },
   ],
+};
+
+const GROUP_SCHEMAS: Partial<Record<NodeType, ZodType>> = {
+  FIXED_THRESHOLD: zFixedThresholdConfig,
+  RELATIVE_DIFFERENCE: zRelativeDifferenceConfig,
+  STDDEV_ANOMALY: zStdDevAnomalyConfig,
+  EDIVISIVE: zEDivisiveConfig,
 };
 
 export function buildConfig(v: FormValues): NodeConfiguration | undefined {
@@ -141,68 +139,76 @@ interface DetectionConfigStepProps {
   nodeType: NodeType;
 }
 
+function renderField(form: NodeFormApi, f: DetectionFieldDef) {
+  switch (f.kind) {
+    case 'number':
+      return (
+        <form.Field key={f.id} name={f.name}>
+          {(field) => (
+            <NumberInput
+              id={f.id}
+              label={f.label}
+              value={field.state.value}
+              onChange={(_, { value }) => {
+                field.handleChange(value);
+              }}
+              onBlur={field.handleBlur}
+              helperText={f.helperText}
+              allowEmpty={f.allowEmpty}
+              hideSteppers
+              invalid={field.state.meta.errors.length > 0}
+              invalidText={fieldError(field.state.meta.errors)}
+            />
+          )}
+        </form.Field>
+      );
+    case 'checkbox':
+      return (
+        <form.Field key={f.id} name={f.name}>
+          {(field) => (
+            <Checkbox
+              id={f.id}
+              labelText={f.label}
+              checked={field.state.value}
+              onChange={(_, { checked }) => {
+                field.handleChange(checked);
+              }}
+            />
+          )}
+        </form.Field>
+      );
+    case 'select':
+      return (
+        <form.Field key={f.id} name={f.name}>
+          {(field) => (
+            <Select
+              id={f.id}
+              labelText={f.label}
+              value={field.state.value}
+              onChange={(e) => {
+                field.handleChange(e.target.value as typeof field.state.value);
+              }}
+            >
+              {f.options.map((o) => (
+                <SelectItem key={o.value} value={o.value} text={o.text} />
+              ))}
+            </Select>
+          )}
+        </form.Field>
+      );
+  }
+}
+
 export const DetectionConfigStep = ({ form, nodeType }: DetectionConfigStepProps) => {
   const fields = DETECTION_FIELDS[nodeType];
-  if (!fields) return null;
+  const schema = GROUP_SCHEMAS[nodeType];
+  if (!fields || !schema) return null;
 
+  const configName = fields[0]?.name.split('.')[0] as 'ftConfig' | 'rdConfig' | 'sdConfig' | 'edConfig';
+  const validator = groupValidator(schema);
   return (
-    <Stack gap={6}>
-      {fields.map((f) => {
-        switch (f.kind) {
-          case 'number':
-            return (
-              <form.Field key={f.id} name={f.name}>
-                {(field) => (
-                  <TextInput
-                    id={f.id}
-                    labelText={f.label}
-                    placeholder={f.placeholder}
-                    type="number"
-                    value={field.state.value}
-                    onChange={(e) => {
-                      field.handleChange(e.target.value);
-                    }}
-                    helperText={f.helperText}
-                  />
-                )}
-              </form.Field>
-            );
-          case 'checkbox':
-            return (
-              <form.Field key={f.id} name={f.name}>
-                {(field) => (
-                  <Checkbox
-                    id={f.id}
-                    labelText={f.label}
-                    checked={field.state.value}
-                    onChange={(_, { checked }) => {
-                      field.handleChange(checked);
-                    }}
-                  />
-                )}
-              </form.Field>
-            );
-          case 'select':
-            return (
-              <form.Field key={f.id} name={f.name}>
-                {(field) => (
-                  <Select
-                    id={f.id}
-                    labelText={f.label}
-                    value={field.state.value}
-                    onChange={(e) => {
-                      field.handleChange(e.target.value);
-                    }}
-                  >
-                    {f.options.map((o) => (
-                      <SelectItem key={o.value} value={o.value} text={o.text} />
-                    ))}
-                  </Select>
-                )}
-              </form.Field>
-            );
-        }
-      })}
-    </Stack>
+    <form.FormGroup name={configName} validators={{ onBlur: validator, onSubmit: validator }}>
+      {() => <Stack gap={6}>{fields.map((f) => renderField(form, f))}</Stack>}
+    </form.FormGroup>
   );
 };

--- a/src/main/webui/src/app/context/NotificationProvider.tsx
+++ b/src/main/webui/src/app/context/NotificationProvider.tsx
@@ -32,7 +32,11 @@ export function extractErrorMessage(reason: unknown): string | undefined {
     if (typeof data === 'object' && data !== null) {
       const body = data as Record<string, unknown>;
       if (typeof body.detail === 'string') return body.detail;
+      if (Array.isArray(body.violations)) {
+        return body.violations.map((v: { field?: string; message?: string }) => `${v.field}: ${v.message}`).join('; ');
+      }
       if (typeof body.message === 'string') return body.message;
+      if (typeof body.title === 'string') return body.title;
     }
   }
 

--- a/src/main/webui/src/app/validation.ts
+++ b/src/main/webui/src/app/validation.ts
@@ -1,0 +1,22 @@
+import type { ZodType } from 'zod';
+
+export const fieldError = (errors: unknown[]): string | undefined => {
+  const e = errors[0];
+  if (!e) return undefined;
+  if (typeof e === 'string') return e;
+  if (typeof e === 'object' && 'message' in e) return (e as { message: string }).message;
+  return undefined;
+};
+
+export const groupValidator = (schema: ZodType) => ({ value }: { value: unknown }) => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    const fields: Record<string, string> = {};
+    for (const issue of result.error.issues) {
+      const key = issue.path.join('.');
+      if (key && !fields[key]) fields[key] = issue.message;
+    }
+    return { fields };
+  }
+  return undefined;
+};

--- a/src/test/java/io/hyperfoil/tools/h5m/api/node/DetectionConfigValidationTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/api/node/DetectionConfigValidationTest.java
@@ -1,0 +1,453 @@
+package io.hyperfoil.tools.h5m.api.node;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class DetectionConfigValidationTest {
+
+    @Inject
+    Validator validator;
+
+    // ---- EDivisiveConfig @Min(3) on windowLen ----
+
+    @Test
+    public void eDivisive_windowLen_at_minimum_boundary() {
+        EDivisiveConfig config = new EDivisiveConfig(3, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "windowLen=3 should pass @Min(3)");
+    }
+
+    @Test
+    public void eDivisive_windowLen_below_minimum() {
+        EDivisiveConfig config = new EDivisiveConfig(2, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowLen=2 should fail @Min(3)");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().contains("windowLen")));
+    }
+
+    @Test
+    public void eDivisive_windowLen_zero() {
+        EDivisiveConfig config = new EDivisiveConfig(0, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowLen=0 should fail @Min(3)");
+    }
+
+    @Test
+    public void eDivisive_windowLen_negative() {
+        EDivisiveConfig config = new EDivisiveConfig(-5, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowLen=-5 should fail @Min(3)");
+    }
+
+    // ---- EDivisiveConfig @DecimalMin("0") @DecimalMax("1") on maxPvalue ----
+
+    @Test
+    public void eDivisive_maxPvalue_at_min_boundary() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.0, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "maxPvalue=0.0 should pass @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void eDivisive_maxPvalue_at_max_boundary() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 1.0, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "maxPvalue=1.0 should pass @DecimalMax(\"1\")");
+    }
+
+    @Test
+    public void eDivisive_maxPvalue_within_range() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.05, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "maxPvalue=0.05 should pass both constraints");
+    }
+
+    @Test
+    public void eDivisive_maxPvalue_below_minimum() {
+        EDivisiveConfig config = new EDivisiveConfig(50, -0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "maxPvalue=-0.001 should fail @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void eDivisive_maxPvalue_exceeds_maximum() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 1.1, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "maxPvalue=1.1 should fail @DecimalMax(\"1\")");
+    }
+
+    @Test
+    public void eDivisive_maxPvalue_far_exceeds_maximum() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 2.0, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "maxPvalue=2.0 should fail @DecimalMax(\"1\")");
+    }
+
+    // ---- EDivisiveConfig @DecimalMin("0") on minMagnitude ----
+
+    @Test
+    public void eDivisive_minMagnitude_at_boundary() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minMagnitude=0.0 should pass @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void eDivisive_minMagnitude_positive_value() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.5, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minMagnitude=0.5 should pass @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void eDivisive_minMagnitude_negative() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, -0.1, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "minMagnitude=-0.1 should fail @DecimalMin(\"0\")");
+    }
+
+    // ---- EDivisiveConfig @Positive on maxSeriesLength ----
+
+    @Test
+    public void eDivisive_maxSeriesLength_valid() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.0, 500, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "maxSeriesLength=500 should pass @Positive");
+    }
+
+    @Test
+    public void eDivisive_maxSeriesLength_one() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.0, 1, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "maxSeriesLength=1 should pass @Positive");
+    }
+
+    @Test
+    public void eDivisive_maxSeriesLength_zero() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.0, 0, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "maxSeriesLength=0 should fail @Positive");
+        assertTrue(violations.stream().anyMatch(v -> v.getPropertyPath().toString().contains("maxSeriesLength")));
+    }
+
+    @Test
+    public void eDivisive_maxSeriesLength_negative() {
+        EDivisiveConfig config = new EDivisiveConfig(50, 0.001, 0.0, -100, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "maxSeriesLength=-100 should fail @Positive");
+    }
+
+    // ---- RelativeDifferenceConfig @DecimalMin("0") on threshold ----
+
+    @Test
+    public void relativeDiff_threshold_at_boundary() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.0, 10, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "threshold=0.0 should pass @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void relativeDiff_threshold_positive() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.5, 10, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "threshold=0.5 should pass @DecimalMin(\"0\")");
+    }
+
+    @Test
+    public void relativeDiff_threshold_negative() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, -0.1, 10, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "threshold=-0.1 should fail @DecimalMin(\"0\")");
+    }
+
+    // ---- RelativeDifferenceConfig @Positive on window ----
+
+    @Test
+    public void relativeDiff_window_valid() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.1, 10, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "window=10 should pass @Positive");
+    }
+
+    @Test
+    public void relativeDiff_window_one() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MEAN, 0.1, 1, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "window=1 should pass @Positive");
+    }
+
+    @Test
+    public void relativeDiff_window_zero() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.1, 0, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "window=0 should fail @Positive");
+    }
+
+    @Test
+    public void relativeDiff_window_negative() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MIN, 0.1, -5, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "window=-5 should fail @Positive");
+    }
+
+    // ---- RelativeDifferenceConfig @Positive on minPrevious ----
+
+    @Test
+    public void relativeDiff_minPrevious_valid() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.1, 10, 5, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minPrevious=5 should pass @Positive");
+    }
+
+    @Test
+    public void relativeDiff_minPrevious_one() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MEAN, 0.1, 10, 1, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minPrevious=1 should pass @Positive");
+    }
+
+    @Test
+    public void relativeDiff_minPrevious_zero() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX, 0.1, 10, 0, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "minPrevious=0 should fail @Positive");
+    }
+
+    @Test
+    public void relativeDiff_minPrevious_negative() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MIN, 0.1, 10, -1, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "minPrevious=-1 should fail @Positive");
+    }
+
+    // ---- StdDevAnomalyConfig @Min(2) on windowSize ----
+
+    @Test
+    public void stdDev_windowSize_at_minimum_boundary() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(2, 1.0, StdDevAnomalyConfig.Direction.BOTH, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "windowSize=2 should pass @Min(2)");
+    }
+
+    @Test
+    public void stdDev_windowSize_below_minimum() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(1, 1.0, StdDevAnomalyConfig.Direction.BOTH, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowSize=1 should fail @Min(2)");
+    }
+
+    @Test
+    public void stdDev_windowSize_zero() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(0, 1.0, StdDevAnomalyConfig.Direction.UPPER, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowSize=0 should fail @Min(2)");
+    }
+
+    @Test
+    public void stdDev_windowSize_negative() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(-5, 1.0, StdDevAnomalyConfig.Direction.LOWER, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "windowSize=-5 should fail @Min(2)");
+    }
+
+    // ---- StdDevAnomalyConfig @DecimalMin("0", inclusive = false) on deviations ----
+
+    @Test
+    public void stdDev_deviations_above_zero() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(10, 0.1, StdDevAnomalyConfig.Direction.BOTH, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "deviations=0.1 should pass @DecimalMin(\"0\", inclusive=false)");
+    }
+
+    @Test
+    public void stdDev_deviations_positive() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, 3.0, StdDevAnomalyConfig.Direction.BOTH, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "deviations=3.0 should pass constraint");
+    }
+
+    @Test
+    public void stdDev_deviations_exactly_zero() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, 0.0, StdDevAnomalyConfig.Direction.UPPER, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "deviations=0.0 should fail @DecimalMin(\"0\", inclusive=false)");
+    }
+
+    @Test
+    public void stdDev_deviations_negative() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, -1.0, StdDevAnomalyConfig.Direction.LOWER, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "deviations=-1.0 should fail @DecimalMin");
+    }
+
+    // ---- StdDevAnomalyConfig @Positive on minDataPoints ----
+
+    @Test
+    public void stdDev_minDataPoints_valid() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, 2.0, StdDevAnomalyConfig.Direction.BOTH, 100, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minDataPoints=100 should pass @Positive");
+    }
+
+    @Test
+    public void stdDev_minDataPoints_one() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(2, 1.0, StdDevAnomalyConfig.Direction.UPPER, 1, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "minDataPoints=1 should pass @Positive");
+    }
+
+    @Test
+    public void stdDev_minDataPoints_zero() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, 2.0, StdDevAnomalyConfig.Direction.LOWER, 0, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "minDataPoints=0 should fail @Positive");
+    }
+
+    @Test
+    public void stdDev_minDataPoints_negative() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(5, 2.0, StdDevAnomalyConfig.Direction.BOTH, -50, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "minDataPoints=-50 should fail @Positive");
+    }
+
+    // ---- Multiple violations in single config ----
+
+    @Test
+    public void eDivisive_multiple_violations_all_fields() {
+        EDivisiveConfig config = new EDivisiveConfig(
+            2,      // Fails @Min(3)
+            1.5,    // Fails @DecimalMax("1")
+            -0.1,   // Fails @DecimalMin("0")
+            -1,     // Fails @Positive
+            null
+        );
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertEquals(4, violations.size(), "should have 4 violations for 4 invalid fields");
+    }
+
+    @Test
+    public void relativeDiff_multiple_violations() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MAX,
+            -0.1,  // Fails @DecimalMin("0")
+            0,     // Fails @Positive
+            -5,    // Fails @Positive
+            null
+        );
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertEquals(3, violations.size(), "should have 3 violations for threshold, window, and minPrevious");
+    }
+
+    // ---- Boundary and edge cases ----
+
+    @Test
+    public void eDivisive_all_minimum_valid_values() {
+        EDivisiveConfig config = new EDivisiveConfig(3, 0.0, 0.0, 1, null);
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "all minimum valid values should pass");
+    }
+
+    @Test
+    public void relativeDiff_all_minimum_valid_values() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MIN, 0.0, 1, 1, null);
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "all minimum valid values should pass");
+    }
+
+    @Test
+    public void stdDev_all_minimum_valid_values() {
+        StdDevAnomalyConfig config = new StdDevAnomalyConfig(2, 0.001, StdDevAnomalyConfig.Direction.BOTH, 1, null);
+        Set<ConstraintViolation<StdDevAnomalyConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "all minimum valid values should pass");
+    }
+
+    @Test
+    public void eDivisive_very_small_valid_decimals() {
+        EDivisiveConfig config = new EDivisiveConfig(
+            50,
+            0.00001,  // Very small valid p-value
+            0.00001,  // Very small valid magnitude
+            1000,
+            null
+        );
+        Set<ConstraintViolation<EDivisiveConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "very small fractional values within valid ranges should pass");
+    }
+
+    @Test
+    public void relativeDiff_very_large_valid_values() {
+        RelativeDifferenceConfig config = new RelativeDifferenceConfig(
+            RelativeDifferenceConfig.Filter.MEAN,
+            999999.99,  // Very large valid threshold
+            10000,      // Very large valid window
+            5000,       // Very large valid minPrevious
+            null
+        );
+        Set<ConstraintViolation<RelativeDifferenceConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "very large values within valid ranges should pass");
+    }
+
+    // ---- FixedThresholdConfig cross-field validation ----
+
+    @Test
+    public void fixedThreshold_min_less_than_max() {
+        FixedThresholdConfig config = new FixedThresholdConfig(5.0, 10.0, true, true, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "min < max should pass");
+    }
+
+    @Test
+    public void fixedThreshold_min_equals_max() {
+        FixedThresholdConfig config = new FixedThresholdConfig(5.0, 5.0, true, true, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "min == max should pass");
+    }
+
+    @Test
+    public void fixedThreshold_min_greater_than_max() {
+        FixedThresholdConfig config = new FixedThresholdConfig(10.0, 5.0, true, true, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertFalse(violations.isEmpty(), "min > max should fail");
+    }
+
+    @Test
+    public void fixedThreshold_only_min_set() {
+        FixedThresholdConfig config = new FixedThresholdConfig(10.0, null, true, null, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "only min set should pass (one-sided threshold)");
+    }
+
+    @Test
+    public void fixedThreshold_only_max_set() {
+        FixedThresholdConfig config = new FixedThresholdConfig(null, 10.0, null, true, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "only max set should pass (one-sided threshold)");
+    }
+
+    @Test
+    public void fixedThreshold_neither_set() {
+        FixedThresholdConfig config = new FixedThresholdConfig(null, null, null, null, null);
+        Set<ConstraintViolation<FixedThresholdConfig>> violations = validator.validate(config);
+        assertTrue(violations.isEmpty(), "neither min nor max set should pass");
+    }
+}

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -377,7 +377,7 @@ public class RestEndpointTest extends FreshDb {
         Long nodeId = createConfiguredNode(groupId, "reldiff", NodeType.RELATIVE_DIFFERENCE.name(),
                 List.of(fpNodeId, rangeNodeId),
                 """
-                {"filter": "max", "threshold": 0.2, "window": 5, "minPrevious": 3, "fingerprintFilter": null}
+                {"filter": "MAX", "threshold": 0.2, "window": 5, "minPrevious": 3, "fingerprintFilter": null}
                 """);
 
         assertTrue(nodeId > 0, "should return a valid node ID");

--- a/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/rest/RestEndpointTest.java
@@ -1292,4 +1292,60 @@ public class RestEndpointTest extends FreshDb {
         fail("Upload " + uploadId + " did not complete within 30 seconds");
     }
 
+    // -- Validation tests for detection config constraints --
+
+    @Test
+    public void node_eDivisive_invalid_windowLen_below_minimum() {
+        createFolder("eDivisive-test");
+        Long groupId = getGroupId("eDivisive-test");
+        Long sourceId = createNode(groupId, "source", ".data");
+
+        String invalidConfig = JqObject.builder()
+                .put("windowLen", JqNumber.of(2))  // Fails @Min(3)
+                .put("maxPvalue", JqNumber.of(0.001))
+                .put("minMagnitude", JqNumber.of(0.0))
+                .put("maxSeriesLength", JqNumber.of(500))
+                .build().toJsonString();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .queryParam("name", "eDivisive-invalid")
+                .queryParam("groupId", groupId)
+                .queryParam("type", "EDIVISIVE")
+                .queryParam("sources", sourceId)
+                .body(invalidConfig)
+                .when().post("/api/node/configured")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    public void node_relativeDifference_non_unique_sources() {
+        createFolder("relDiff-nonunique");
+        Long groupId = getGroupId("relDiff-nonunique");
+        Long source1 = createNode(groupId, "source1", ".data");
+        Long source2 = createNode(groupId, "source2", ".domain");
+
+        String validConfig = JqObject.builder()
+                .put("filter", JqString.of("MAX"))
+                .put("threshold", JqNumber.of(0.1))
+                .put("window", JqNumber.of(10))
+                .put("minPrevious", JqNumber.of(5))
+                .build().toJsonString();
+
+        // Try to create with duplicate source (source1 twice) - should fail @UniqueElements
+        given()
+                .contentType(MediaType.APPLICATION_JSON)
+                .queryParam("name", "relDiff-nonunique")
+                .queryParam("groupId", groupId)
+                .queryParam("type", "RELATIVE_DIFFERENCE")
+                .queryParam("sources", source1)
+                .queryParam("sources", source2)
+                .queryParam("sources", source1)  // Duplicate
+                .body(validConfig)
+                .when().post("/api/node/configured")
+                .then()
+                .statusCode(400);
+    }
+
 }

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/NodeServiceTest.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.api.EphemeralMode;
+import io.hyperfoil.tools.h5m.api.node.RelativeDifferenceConfig.Filter;
 import io.hyperfoil.tools.jjq.value.*;
 import io.hyperfoil.tools.h5m.FreshDb;
 import io.hyperfoil.tools.h5m.api.Node;
@@ -725,7 +726,7 @@ public class NodeServiceTest extends FreshDb {
 
         RelativeDifference relDifference = new RelativeDifference();
         //relDifference.name="max.y";
-        relDifference.setFilter("max");
+        relDifference.setFilter(Filter.MAX);
         relDifference.setWindow(1);
         relDifference.setMinPrevious(1);
         relDifference.setNodes(fingerprintNode,rootNode,rangeNode,domainNode);
@@ -803,7 +804,7 @@ public class NodeServiceTest extends FreshDb {
         assertEquals(1,found.size());
 
         assertEquals(RelativeDifference.DEFAULT_FILTER, relDifference.getFilter(),
-                "getFilter() should return DEFAULT_FILTER ('mean') when no filter is configured");
+                "getFilter() should return default (MEAN) when no filter is configured");
     }
 
     @Test
@@ -1804,7 +1805,7 @@ public class NodeServiceTest extends FreshDb {
 
         // set up RelativeDifference with fingerprintFilter that only matches x86
         RelativeDifference relDifference = new RelativeDifference();
-        relDifference.setFilter("max");
+        relDifference.setFilter(Filter.MAX);
         relDifference.setWindow(1);
         relDifference.setMinPrevious(1);
         relDifference.setFingerprintFilter("(fp) => fp.platform === \"x86\"");
@@ -1826,7 +1827,7 @@ public class NodeServiceTest extends FreshDb {
 
         // run from an arm root WITHOUT filter to prove arm data produces results
         RelativeDifference relDiffNoFilter = new RelativeDifference();
-        relDiffNoFilter.setFilter("max");
+        relDiffNoFilter.setFilter(Filter.MAX);
         relDiffNoFilter.setWindow(1);
         relDiffNoFilter.setMinPrevious(1);
         relDiffNoFilter.setNodes(fingerprintNode,rootNode,rangeNode,domainNode);
@@ -1843,7 +1844,7 @@ public class NodeServiceTest extends FreshDb {
 
         // run from an arm root WITH x86 filter — filter should exclude the arm fingerprint
         RelativeDifference relDiffArmWithX86Filter = new RelativeDifference();
-        relDiffArmWithX86Filter.setFilter("max");
+        relDiffArmWithX86Filter.setFilter(Filter.MAX);
         relDiffArmWithX86Filter.setWindow(1);
         relDiffArmWithX86Filter.setMinPrevious(1);
         relDiffArmWithX86Filter.setFingerprintFilter("(fp) => fp.platform === \"x86\"");
@@ -2105,7 +2106,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         ValueEntity root1 = new ValueEntity(null, rootNode, JqObject.EMPTY);
@@ -2323,7 +2324,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         ValueEntity root1 = new ValueEntity(null, rootNode, JqObject.EMPTY);
@@ -2483,7 +2484,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         
@@ -2627,7 +2628,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         
@@ -2767,7 +2768,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         
@@ -2916,7 +2917,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
         tm.commit();
 
@@ -2953,7 +2954,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         
@@ -3121,7 +3122,7 @@ public class NodeServiceTest extends FreshDb {
         relDiff.setNodes(fingerprintNode, splitNode, rangeNode, domainNode);
         relDiff.setWindow(1);
         relDiff.setMinPrevious(1);
-        relDiff.setFilter("mean");
+        relDiff.setFilter(Filter.MEAN);
         relDiff.persist();
 
         


### PR DESCRIPTION
Summary

- Zod-based form validation: replaced all inline function validators in `CreateNodeModal` with generated Zod schemas (from OpenAPI/Jakarta Bean Validation), removing the manual `validateStep` method entirely
- Validation utilities: added `fieldError` and `groupValidator` in `validation.ts` to bridge Zod schemas with TanStack Form's Standard Schema support and Carbon's error display
- Backend-driven enums: `Filter` (Relative Difference) and `Direction` (StdDev Anomaly) flow as Java enums through OpenAPI to generated Zod schemas, replacing hardcoded frontend option arrays
- Detection config group validation: detection config fields are wrapped in `FormGroup` with generated Zod schemas (`zRelativeDifferenceConfig`, `zEDivisiveConfig`, etc.) as group validators
- Carbon `NumberInput`: switched numeric config fields from `TextInput` to `NumberInput` with proper `number | string` form value types