### PR TITLE
initial Team management

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/api/Role.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Role.java
@@ -1,6 +1,9 @@
 package io.hyperfoil.tools.h5m.api;
 
 public enum Role {
-    ADMIN,
-    USER
+
+    ADMIN, USER;
+
+    public static final String ADMIN_ROLE = "ADMIN", USER_ROLE = "USER";
+
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/Team.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/Team.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.api;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 
 /**
@@ -7,5 +8,5 @@ import jakarta.validation.constraints.Pattern;
  */
 public record Team(long id,
         // Input hint only: the backend may still send reserved 'h5m.' names.
-        @Pattern(regexp = ReservedNamespace.ALLOWED_NAME_PATTERN, message = "names starting with 'h5m.' are reserved for internal use") String name,
+        @Pattern(regexp = ReservedNamespace.ALLOWED_NAME_PATTERN, message = "names starting with 'h5m.' are reserved for internal use") @NotEmpty String name,
         int memberCount) {}

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/TeamServiceInterface.java
@@ -1,20 +1,27 @@
 package io.hyperfoil.tools.h5m.api.svc;
 
 import io.hyperfoil.tools.h5m.api.Team;
+import io.hyperfoil.tools.h5m.api.User;
 
 import java.util.List;
 
 public interface TeamServiceInterface {
 
-    long create(String name);
+    Team create(String name);
 
     void delete(long teamId);
+
+    Team renameTeam(long teamId, String name);
 
     Team find(String name);
 
     List<Team> list();
 
-    void addMember(long teamId, long userId);
+    List<Team> listByUsername(String username);
 
-    void removeMember(long teamId, long userId);
+    List<User> listMembers(long teamId);
+
+    List<User> addMember(long teamId, long userId);
+
+    List<User> removeMember(long teamId, long userId);
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/api/svc/UserServiceInterface.java
@@ -11,11 +11,13 @@ public interface UserServiceInterface {
 
     long create(String sub, String iss, String username, Role role);
 
+    User resolveUser();
+
     User byUsername(String username);
 
-    User bySub(String sub, String iss);
-
     List<User> list();
+
+    boolean isMemberOf(long teamId);
 
     void setRole(long userId, Role role);
 

--- a/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateTeam.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/cli/AdminCreateTeam.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.tools.h5m.cli;
 
+import io.hyperfoil.tools.h5m.api.Team;
 import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
 import jakarta.inject.Inject;
 
@@ -19,8 +20,8 @@ public class AdminCreateTeam implements Command<H5mCommandInvocation> {
 
     @Override
     public CommandResult execute(H5mCommandInvocation invocation) throws InterruptedException {
-        long id = teamService.create(name);
-        invocation.println("Created team: " + name + " (id=" + id + ")");
+        Team team = teamService.create(name);
+        invocation.println("Created team: " + name + " (id=" + team.id() + ")");
         return CommandResult.SUCCESS;
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/TeamEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/TeamEntity.java
@@ -10,8 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity(name = "team")
 public class TeamEntity extends PanacheEntityBase {
@@ -29,7 +29,7 @@ public class TeamEntity extends PanacheEntityBase {
             joinColumns = @JoinColumn(name = "team_id"),
             inverseJoinColumns = @JoinColumn(name = "user_id")
     )
-    public List<UserEntity> members = new ArrayList<>();
+    public Set<UserEntity> members = new HashSet<>();
 
     public TeamEntity() {}
 
@@ -39,15 +39,20 @@ public class TeamEntity extends PanacheEntityBase {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof TeamEntity that)) {
             return false;
         }
-        return name.equals(that.name);
+        return id != null && id.equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        // Deliberately constant: hashCode must stay stable across the entity lifecycle while this instance sits in a HashSet.
+        // Basing it on id (null until persisted) or name (mutable) would change the hash and turn the entity into an unreachable "ghost" in its collection.
+        return getClass().hashCode();
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/entity/UserEntity.java
@@ -13,8 +13,8 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity(name = "h5m_user")
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"sub", "iss"}))
@@ -35,7 +35,7 @@ public class UserEntity extends PanacheEntityBase {
     public Role role;
 
     @ManyToMany(mappedBy = "members")
-    public List<TeamEntity> teams = new ArrayList<>();
+    public Set<TeamEntity> teams = new HashSet<>();
 
     public UserEntity() {}
 
@@ -53,15 +53,20 @@ public class UserEntity extends PanacheEntityBase {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof UserEntity that)) {
             return false;
         }
-        return username.equals(that.username);
+        return id != null && id.equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return username.hashCode();
+        // Deliberately constant: hashCode must stay stable across the entity lifecycle while this instance sits in a HashSet.
+        // Basing it on id (null until persisted) or username (mutable) would change the hash and turn the entity into an unreachable "ghost" in its collection.
+        return getClass().hashCode();
     }
 
     @Override

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
@@ -17,6 +17,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
+import static io.hyperfoil.tools.h5m.api.Role.ADMIN_ROLE;
+
 @Path("/apikey")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "API Key", description = "Manage API keys for authentication")
@@ -61,7 +63,7 @@ public class ApiKeyResource {
             throw new NotFoundException("API key not found: " + keyId);
         }
         String username = identity.getPrincipal().getName();
-        if (!key.owner().equals(username) && !identity.hasRole("admin")) {
+        if (!key.owner().equals(username) && !identity.hasRole(ADMIN_ROLE)) {
             throw new ForbiddenException("Cannot revoke another user's API key");
         }
         apiKeyService.revoke(keyId);

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/TeamResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/TeamResource.java
@@ -1,0 +1,98 @@
+package io.hyperfoil.tools.h5m.rest;
+
+import io.hyperfoil.tools.h5m.api.Team;
+import io.hyperfoil.tools.h5m.api.User;
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
+import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.List;
+
+import static io.hyperfoil.tools.h5m.api.Role.ADMIN_ROLE;
+
+@Path("/team")
+@Produces(MediaType.APPLICATION_JSON)
+@Tag(name = "Team", description = "Manage teams and team membership")
+public class TeamResource {
+
+    @Inject
+    TeamServiceInterface teamService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    UserServiceInterface userService;
+
+    @GET
+    @PermitAll
+    @Operation(description = "Retrieve the list of all teams")
+    public List<Team> listTeams() {
+        return teamService.list();
+    }
+
+    @POST
+    @RolesAllowed(ADMIN_ROLE)
+    @Operation(description = "Create a new team")
+    public Team createTeam(@Valid Team team) {
+        return teamService.create(team.name());
+    }
+
+    @PUT
+    @Path("{id}")
+    @RolesAllowed(ADMIN_ROLE)
+    @Operation(description = "Rename a team")
+    public Team renameTeam(@PathParam("id") long id, @Valid Team team) {
+        return teamService.renameTeam(id, team.name());
+    }
+
+    @DELETE
+    @Path("{id}")
+    @RolesAllowed(ADMIN_ROLE)
+    @Operation(description = "Delete a team by its ID")
+    public void deleteTeam(@PathParam("id") long id) {
+        teamService.delete(id);
+    }
+
+    @GET
+    @Path("{id}/members")
+    @Authenticated
+    @Operation(description = "List the members of a team")
+    public List<User> listMembers(@PathParam("id") long id) {
+        if (!identity.getRoles().contains(ADMIN_ROLE) && !userService.isMemberOf(id)) {
+            throw new ForbiddenException("You are not allowed to perform this action");
+        }
+        return teamService.listMembers(id);
+    }
+
+    @PUT
+    @Path("{id}/members/{userId}")
+    @Authenticated
+    @Operation(description = "Add a user to a team")
+    public List<User> addMember(@PathParam("id") long id, @PathParam("userId") long userId) {
+        if (!identity.getRoles().contains(ADMIN_ROLE) && !userService.isMemberOf(id)) {
+            throw new ForbiddenException("You are not allowed to perform this action");
+        }
+        return teamService.addMember(id, userId);
+    }
+
+    @DELETE
+    @Path("{id}/members/{userId}")
+    @Authenticated
+    @Operation(description = "Remove a user from a team")
+    public List<User> removeMember(@PathParam("id") long id, @PathParam("userId") long userId) {
+        if (!identity.getRoles().contains(ADMIN_ROLE) && !userService.isMemberOf(id)) {
+            throw new ForbiddenException("You are not allowed to perform this action");
+        }
+        return teamService.removeMember(id, userId);
+    }
+}

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
@@ -1,19 +1,21 @@
 package io.hyperfoil.tools.h5m.rest;
 
-import io.hyperfoil.tools.h5m.api.Role;
+import io.hyperfoil.tools.h5m.api.Team;
 import io.hyperfoil.tools.h5m.api.User;
+import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+
+import java.util.List;
 
 @Path("/user")
 @Produces(MediaType.APPLICATION_JSON)
@@ -24,18 +26,39 @@ public class UserResource {
     UserServiceInterface userService;
 
     @Inject
+    TeamServiceInterface teamService;
+
+    @Inject
     SecurityIdentity identity;
 
     @GET
-    @Path("role")
-    @Authenticated
-    @Operation(description = "Get the role of the authenticated user")
-    @APIResponse(responseCode = "200", description = "User role")
-    public Role role() {
-        User user = switch (identity.getPrincipal()) {
-            case JsonWebToken jwt -> userService.bySub(jwt.getSubject(), jwt.getIssuer());
-            default -> userService.byUsername(identity.getPrincipal().getName());
-        };
-        return user != null ? user.role() : Role.USER;
+    @Operation(description = "List all users")
+    public List<User> listUsers() {
+        return identity.isAnonymous() ? List.of() : userService.list();
     }
+
+    @GET
+    @Path("me")
+    @Authenticated
+    @Operation(description = "Get the authenticated user")
+    public User currentUser() {
+        User user = userService.resolveUser();
+        if (user == null) {
+            throw new InternalServerErrorException("The authenticated user is not present in the database");
+        }
+        return user;
+    }
+
+    @GET
+    @Path("teams")
+    @Authenticated
+    @Operation(description = "Get the teams of the authenticated user")
+    public List<Team> userTeams() {
+        User user = userService.resolveUser();
+        if (user == null) {
+            throw new InternalServerErrorException("The authenticated user is not present in the database");
+        }
+        return teamService.listByUsername(user.username());
+    }
+
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
@@ -3,7 +3,6 @@ package io.hyperfoil.tools.h5m.rest;
 import io.hyperfoil.tools.jjq.value.JqValue;
 import io.hyperfoil.tools.h5m.api.Value;
 import io.hyperfoil.tools.h5m.api.svc.ValueServiceInterface;
-import io.hyperfoil.tools.h5m.entity.ValueEntity;
 import io.hyperfoil.tools.h5m.svc.ValueService;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
@@ -14,6 +13,8 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
+
+import static io.hyperfoil.tools.h5m.api.Role.ADMIN_ROLE;
 
 @Path("/value")
 @Produces(MediaType.APPLICATION_JSON)
@@ -27,7 +28,7 @@ public class ValueResource {
     ValueService valueServiceImpl;
 
     @DELETE
-    @RolesAllowed("admin")
+    @RolesAllowed(ADMIN_ROLE)
     @Operation(description = "Purge all values")
     public void purgeValues() {
         valueService.purgeValues();

--- a/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyAuthenticationMechanism.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/ApiKeyAuthenticationMechanism.java
@@ -19,6 +19,9 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import static io.hyperfoil.tools.h5m.api.Role.ADMIN_ROLE;
+import static io.hyperfoil.tools.h5m.api.Role.USER_ROLE;
+
 @ApplicationScoped
 public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanism {
 
@@ -32,9 +35,9 @@ public class ApiKeyAuthenticationMechanism implements HttpAuthenticationMechanis
     public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
         if (!securityEnabled) {
             SecurityIdentity localAdmin = QuarkusSecurityIdentity.builder()
-                    .setPrincipal(new QuarkusPrincipal("local"))
-                    .addRole("admin")
-                    .addRole("user")
+                    .setPrincipal(new QuarkusPrincipal("h5m.local"))
+                    .addRole(ADMIN_ROLE)
+                    .addRole(USER_ROLE)
                     .build();
             return Uni.createFrom().item(localAdmin);
         }

--- a/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/server/H5mRolesAugmentor.java
@@ -13,6 +13,9 @@ import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
+import static io.hyperfoil.tools.h5m.api.Role.ADMIN_ROLE;
+import static io.hyperfoil.tools.h5m.api.Role.USER_ROLE;
+
 @ApplicationScoped
 public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
 
@@ -36,9 +39,9 @@ public class H5mRolesAugmentor implements SecurityIdentityAugmentor {
             return identity;
         }
         QuarkusSecurityIdentity.Builder builder = QuarkusSecurityIdentity.builder(identity);
-        builder.addRole("user");
+        builder.addRole(USER_ROLE);
         if (user.role() == Role.ADMIN) {
-            builder.addRole("admin");
+            builder.addRole(ADMIN_ROLE);
         }
         return builder.build();
     }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/TeamService.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.tools.h5m.svc;
 
 import io.hyperfoil.tools.h5m.api.Team;
+import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.api.svc.TeamServiceInterface;
 import io.hyperfoil.tools.h5m.entity.TeamEntity;
 import io.hyperfoil.tools.h5m.entity.UserEntity;
@@ -8,8 +9,11 @@ import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
 
 import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
 
 @ApplicationScoped
 public class TeamService implements TeamServiceInterface {
@@ -19,16 +23,27 @@ public class TeamService implements TeamServiceInterface {
 
     @Override
     @Transactional
-    public long create(String name) {
+    public Team create(String name) {
         TeamEntity team = new TeamEntity(name);
         team.persist();
-        return team.id;
+        return apiMapper.toTeam(team);
     }
 
     @Override
     @Transactional
     public void delete(long teamId) {
         TeamEntity.deleteById(teamId);
+    }
+
+    @Override
+    @Transactional
+    public Team renameTeam(long teamId, String name) {
+        TeamEntity team = TeamEntity.findById(teamId);
+        if (team == null) {
+            throw new NotFoundException("Team not found" + teamId);
+        }
+        team.name = name;
+        return apiMapper.toTeam(team);
     }
 
     @Override
@@ -47,21 +62,40 @@ public class TeamService implements TeamServiceInterface {
 
     @Override
     @Transactional
-    public void addMember(long teamId, long userId) {
-        TeamEntity team = TeamEntity.findById(teamId);
-        UserEntity user = UserEntity.findById(userId);
-        if (team != null && user != null && !team.members.contains(user)) {
-            team.members.add(user);
-        }
+    public List<Team> listByUsername(String username) {
+        UserEntity user = UserEntity.find("username", username).firstResult();
+        return user == null ? List.of() : user.teams.stream().map(apiMapper::toTeam).toList();
     }
 
     @Override
     @Transactional
-    public void removeMember(long teamId, long userId) {
+    public List<User> listMembers(long teamId) {
         TeamEntity team = TeamEntity.findById(teamId);
-        UserEntity user = UserEntity.findById(userId);
-        if (team != null && user != null) {
-            team.members.remove(user);
+        return team == null ? List.of() : team.members.stream().map(apiMapper::toUser).toList();
+    }
+
+    @Override
+    @Transactional
+    public List<User> addMember(long teamId, long userId) {
+        return modifyMembers(teamId, userId, Set::add);
+    }
+
+    @Override
+    @Transactional
+    public List<User> removeMember(long teamId, long userId) {
+        return modifyMembers(teamId, userId, Set::remove);
+    }
+
+    private List<User> modifyMembers(long teamId, long userId, BiConsumer<Set<UserEntity>, UserEntity> action) {
+        TeamEntity team = TeamEntity.findById(teamId);
+        if (team == null) {
+            throw new NotFoundException("Team not found" + teamId);
         }
+        UserEntity user = UserEntity.findById(userId);
+        if (user == null) {
+            throw new NotFoundException("User not found" + userId);
+        }
+        action.accept(team.members, user);
+        return team.members.stream().map(apiMapper::toUser).toList();
     }
 }

--- a/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/svc/UserService.java
@@ -5,9 +5,11 @@ import io.hyperfoil.tools.h5m.api.User;
 import io.hyperfoil.tools.h5m.api.svc.UserServiceInterface;
 import io.hyperfoil.tools.h5m.entity.UserEntity;
 import io.hyperfoil.tools.h5m.entity.mapper.ApiMapper;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import java.util.List;
 
@@ -16,6 +18,23 @@ public class UserService implements UserServiceInterface {
 
     @Inject
     ApiMapper apiMapper;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Override
+    @Transactional
+    public User resolveUser() {
+        return apiMapper.toUser(resolveUserEntity());
+    }
+
+    @SuppressWarnings("SwitchStatementWithTooFewBranches")
+    private UserEntity resolveUserEntity() {
+        return switch (identity.getPrincipal()) {
+            case JsonWebToken jwt -> UserEntity.find("sub = ?1 and iss = ?2", jwt.getSubject(), jwt.getIssuer()).firstResult();
+            default -> UserEntity.find("username", identity.getPrincipal().getName()).firstResult();
+        };
+    }
 
     @Override
     @Transactional
@@ -40,7 +59,6 @@ public class UserService implements UserServiceInterface {
         return apiMapper.toUser(entity);
     }
 
-    @Override
     @Transactional
     public User bySub(String sub, String iss) {
         UserEntity entity = UserEntity.find("sub = ?1 and iss = ?2", sub, iss).firstResult();
@@ -52,6 +70,13 @@ public class UserService implements UserServiceInterface {
     public List<User> list() {
         List<UserEntity> entities = UserEntity.listAll();
         return entities.stream().map(apiMapper::toUser).toList();
+    }
+
+    @Override
+    @Transactional
+    public boolean isMemberOf(long teamId) {
+        UserEntity entity = resolveUserEntity();
+        return entity != null && entity.teams.stream().anyMatch(team -> team.id.equals(teamId));
     }
 
     @Override

--- a/src/main/webui/src/app/App.css
+++ b/src/main/webui/src/app/App.css
@@ -6,6 +6,11 @@
   max-inline-size: 100%;
 }
 
+.page-grid.cds--grid {
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .notification-container {
   position: fixed;
   top: 3rem;

--- a/src/main/webui/src/app/components/team/TeamMembersPanel.tsx
+++ b/src/main/webui/src/app/components/team/TeamMembersPanel.tsx
@@ -1,0 +1,167 @@
+import type { Team } from '@client/types.gen.ts';
+
+import { useNotification } from '@app/context/useNotification.tsx';
+import { useRoles } from '@app/context/useRoles.tsx';
+import { useTeams } from '@app/context/useTeams.tsx';
+import { Add, Subtract } from '@carbon/icons-react';
+import { ContainedList, ContainedListItem, ExpandableSearch, IconButton, InlineNotification, Modal, Stack } from '@carbon/react';
+import {
+  addMemberMutation,
+  listMembersOptions,
+  listTeamsOptions,
+  listUsersOptions,
+  removeMemberMutation,
+  userTeamsOptions,
+} from '@client/@tanstack/react-query.gen.ts';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export const TeamMembersPanel = ({ team }: { team: Team }) => {
+  const { isAdmin, userId } = useRoles();
+  const userTeams = useTeams();
+  const canEdit = isAdmin || userTeams.some((t) => t.id === team.id);
+  const queryClient = useQueryClient();
+  const notifications = useNotification();
+  const teamId = team.id ?? 0;
+  const [filter, setFilter] = useState('');
+  const [confirmSelfRemove, setConfirmSelfRemove] = useState(false);
+
+  const { data: members } = useSuspenseQuery(listMembersOptions({ path: { id: teamId } }));
+  const { data: allUsers } = useSuspenseQuery(listUsersOptions());
+
+  const membersQueryKey = listMembersOptions({ path: { id: teamId } }).queryKey;
+  const teamsQueryKey = listTeamsOptions().queryKey;
+  const userTeamsQueryKey = userTeamsOptions().queryKey;
+
+  const updateTeamMemberCount = (count: number) => {
+    queryClient.setQueryData(teamsQueryKey, (teams: Team[] | undefined) => teams?.map((t) => (t.id === teamId ? { ...t, memberCount: count } : t)));
+  };
+
+  const addMember = useMutation({
+    ...addMemberMutation(),
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(membersQueryKey, data);
+      updateTeamMemberCount(data.length);
+      if (variables.path.userId === userId) {
+        queryClient.setQueryData(userTeamsQueryKey, (teams: Team[] | undefined) => [...(teams ?? []), { ...team, memberCount: data.length }]);
+      }
+    },
+    onError: (e) => {
+      notifications.handleError('Failed to add Member', e);
+    },
+  });
+
+  const removeMember = useMutation({
+    ...removeMemberMutation(),
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(membersQueryKey, data);
+      updateTeamMemberCount(data.length);
+      if (variables.path.userId === userId) {
+        queryClient.setQueryData(userTeamsQueryKey, (teams: Team[] | undefined) => teams?.filter((t) => t.id !== teamId));
+      }
+    },
+    onError: (e) => {
+      notifications.handleError('Failed to remove Member', e);
+    },
+  });
+
+  const handleRemove = (memberId: number) => {
+    if (memberId === userId && !isAdmin) {
+      setConfirmSelfRemove(true);
+    } else {
+      removeMember.mutate({ path: { id: teamId, userId: memberId } });
+    }
+  };
+
+  const memberIds = new Set(members.map((m) => m.id));
+  const nonMembers = filter ? allUsers.filter((u) => !memberIds.has(u.id) && (u.username ?? '').toLowerCase().includes(filter.toLowerCase())) : [];
+
+  return (
+    <Stack gap={2}>
+      <ContainedList label={`Members of ${team.name}`} kind="on-page">
+        {members.map((user) => (
+          <ContainedListItem
+            key={user.id}
+            action={
+              canEdit && (
+                <IconButton
+                  label="Remove from Team"
+                  kind={'danger--ghost' as 'ghost'}
+                  onClick={() => {
+                    handleRemove(user.id ?? 0);
+                  }}
+                >
+                  <Subtract />
+                </IconButton>
+              )
+            }
+          >
+            {user.username ?? ''}
+          </ContainedListItem>
+        ))}
+        {members.length === 0 && <InlineNotification kind="info" title="No members in this team" lowContrast hideCloseButton />}
+      </ContainedList>
+      {canEdit && (
+        <ContainedList
+          label="Add Users"
+          kind="on-page"
+          action={
+            <ExpandableSearch
+              id="member-search"
+              size="lg"
+              labelText="Search Users"
+              placeholder="Search Users"
+              value={filter}
+              onChange={(e) => {
+                setFilter(e.target.value);
+              }}
+              onClear={() => {
+                setFilter('');
+              }}
+            />
+          }
+        >
+          {nonMembers.map((user) => (
+            <ContainedListItem
+              key={user.id}
+              action={
+                <IconButton
+                  label="Add to Team"
+                  kind="ghost"
+                  onClick={() => {
+                    addMember.mutate({ path: { id: teamId, userId: user.id ?? 0 } });
+                  }}
+                >
+                  <Add />
+                </IconButton>
+              }
+            >
+              {user.username ?? ''}
+            </ContainedListItem>
+          ))}
+        </ContainedList>
+      )}
+
+      <Modal
+        open={confirmSelfRemove}
+        danger
+        modalLabel={'Leave Team'}
+        modalHeading={team.name}
+        primaryButtonText="Leave"
+        secondaryButtonText="Cancel"
+        onRequestClose={() => {
+          setConfirmSelfRemove(false);
+        }}
+        onSecondarySubmit={() => {
+          setConfirmSelfRemove(false);
+        }}
+        onRequestSubmit={() => {
+          removeMember.mutate({ path: { id: teamId, userId: userId } });
+          setConfirmSelfRemove(false);
+        }}
+      >
+        <p>You will no longer be able to manage this Team and its Folders. Are you sure?</p>
+      </Modal>
+    </Stack>
+  );
+};

--- a/src/main/webui/src/app/components/team/TeamNameModal.tsx
+++ b/src/main/webui/src/app/components/team/TeamNameModal.tsx
@@ -1,0 +1,107 @@
+import type { Team } from '@client/types.gen.ts';
+
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
+import { fieldError } from '@app/validation';
+import { Button, ComposedModal, Form, InlineNotification, ModalBody, ModalFooter, ModalHeader, TextInput } from '@carbon/react';
+import { createTeamMutation, listTeamsOptions, renameTeamMutation } from '@client/@tanstack/react-query.gen.ts';
+import { zCreateTeamBody } from '@client/zod.gen.ts';
+import { useForm } from '@tanstack/react-form';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export const TeamNameModal = ({ team, open, onClose }: { team: Team | null; open: boolean; onClose: () => void }) => {
+  const isRename = team !== null;
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const onSuccess = () => {
+    void queryClient.invalidateQueries({ queryKey: listTeamsOptions().queryKey });
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  };
+
+  const createTeam = useMutation({
+    ...createTeamMutation(),
+    onSuccess,
+    onError: (e) => {
+      setSubmitError(extractErrorMessage(e) ?? 'Failed to create team');
+    },
+  });
+
+  const renameTeam = useMutation({
+    ...renameTeamMutation(),
+    onSuccess,
+    onError: (e) => {
+      setSubmitError(extractErrorMessage(e) ?? 'Failed to rename team');
+    },
+  });
+
+  const mutation = isRename ? renameTeam : createTeam;
+
+  const form = useForm({
+    defaultValues: { name: team?.name ?? '' },
+    validators: {
+      onSubmit: zCreateTeamBody,
+    },
+    onSubmit: ({ value }) => {
+      setSubmitError(null);
+      if (isRename) {
+        renameTeam.mutate({ path: { id: team.id ?? 0 }, body: { name: value.name } });
+      } else {
+        createTeam.mutate({ body: { name: value.name } });
+      }
+    },
+  });
+
+  const handleClose = () => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  };
+
+  return (
+    <ComposedModal open={open} onClose={handleClose}>
+      <ModalHeader label={isRename ? `Rename Team` : undefined} title={isRename ? team.name : 'Create Team'} />
+      <ModalBody>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+          }}
+        >
+          <form.Field name="name">
+            {(field) => (
+              <TextInput
+                id="team-name"
+                labelText="Team name"
+                placeholder="e.g. performance"
+                value={field.state.value}
+                onChange={(e) => {
+                  field.handleChange(e.target.value);
+                }}
+                onBlur={field.handleBlur}
+                invalid={field.state.meta.errors.length > 0}
+                invalidText={fieldError(field.state.meta.errors)}
+              />
+            )}
+          </form.Field>
+          {submitError && <InlineNotification kind="error" title={submitError} lowContrast hideCloseButton />}
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button
+          kind="primary"
+          onClick={() => {
+            void form.handleSubmit();
+          }}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+};

--- a/src/main/webui/src/app/components/team/TeamsPanel.tsx
+++ b/src/main/webui/src/app/components/team/TeamsPanel.tsx
@@ -1,0 +1,169 @@
+import type { Team } from '@client/types.gen.ts';
+
+import { TeamNameModal } from '@app/components/team/TeamNameModal.tsx';
+import { useNotification } from '@app/context/useNotification.tsx';
+import { useRoles } from '@app/context/useRoles.tsx';
+import { Add, Edit, TrashCan } from '@carbon/icons-react';
+import { ContainedList, ContainedListItem, ExpandableSearch, InlineNotification, Modal, Tag, IconButton } from '@carbon/react';
+import { deleteTeamMutation, listTeamsOptions } from '@client/@tanstack/react-query.gen.ts';
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export const TeamsPanel = ({ onSelect }: { onSelect: (team: Team | null) => void }) => {
+  const { isAdmin } = useRoles();
+  const queryClient = useQueryClient();
+  const notifications = useNotification();
+  const { data: teams } = useSuspenseQuery(listTeamsOptions());
+
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [editTeam, setEditTeam] = useState<Team | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<Team | null>(null);
+  const [teamFilter, setTeamFilter] = useState('');
+
+  const deleteTeam = useMutation({
+    ...deleteTeamMutation(),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({ queryKey: listTeamsOptions().queryKey });
+      const deleted = teams.find((t) => t.id === variables.path.id);
+      notifications.success(`Team '${deleted?.name ?? ''}' deleted`);
+      if (selectedId === variables.path.id) {
+        setSelectedId(null);
+        onSelect(null);
+      }
+      setConfirmDelete(null);
+    },
+    onError: (_e, variables) => {
+      const deleted = teams.find((t) => t.id === variables.path.id);
+      notifications.handleError(`Failed to delete Team '${deleted?.name ?? ''}'`, _e);
+      setConfirmDelete(null);
+    },
+  });
+
+  const filteredTeams = teams.filter((t) => !teamFilter || t.name.toLowerCase().includes(teamFilter.toLowerCase()));
+
+  return (
+    <>
+      <ContainedList
+        label="Teams"
+        kind="on-page"
+        action={
+          <>
+            <ExpandableSearch
+              id="team-filter"
+              size="lg"
+              labelText="Filter Team"
+              placeholder="Filter Team"
+              value={teamFilter}
+              onChange={(e) => {
+                setTeamFilter(e.target.value);
+              }}
+              onClear={() => {
+                setTeamFilter('');
+              }}
+            />
+            {isAdmin && (
+              <IconButton
+                label="Create Team"
+                kind="ghost"
+                onClick={() => {
+                  setCreateOpen(true);
+                }}
+              >
+                <Add />
+              </IconButton>
+            )}
+          </>
+        }
+      >
+        {filteredTeams.map((team) => (
+          <ContainedListItem
+            key={team.id}
+            onClick={() => {
+              setSelectedId(team.id ?? null);
+              onSelect(team);
+            }}
+            action={
+              <>
+                <IconButton
+                  label={`${String(team.memberCount ?? 0)} members`}
+                  kind="ghost"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                  }}
+                  style={{ cursor: 'default' }}
+                >
+                  <Tag size="lg">{team.memberCount ?? 0}</Tag>
+                </IconButton>
+                {isAdmin && (
+                  <>
+                    <IconButton
+                      label="Rename Team"
+                      kind="ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditTeam(team);
+                      }}
+                    >
+                      <Edit />
+                    </IconButton>
+                    <IconButton
+                      label="Delete Team"
+                      kind={'danger--ghost' as 'ghost'}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setConfirmDelete(team);
+                      }}
+                    >
+                      <TrashCan />
+                    </IconButton>
+                  </>
+                )}
+              </>
+            }
+          >
+            {team.name}
+          </ContainedListItem>
+        ))}
+        {teams.length === 0 && <InlineNotification kind="info" title="Create a team to get started." lowContrast hideCloseButton />}
+        {teams.length !== 0 && filteredTeams.length === 0 && <InlineNotification kind="info" title="No teams found." lowContrast hideCloseButton />}
+      </ContainedList>
+
+      <TeamNameModal
+        team={null}
+        open={createOpen}
+        onClose={() => {
+          setCreateOpen(false);
+        }}
+      />
+
+      <TeamNameModal
+        team={editTeam}
+        open={editTeam !== null}
+        onClose={() => {
+          setEditTeam(null);
+        }}
+      />
+
+      <Modal
+        open={confirmDelete !== null}
+        danger
+        modalLabel={'Delete Team'}
+        modalHeading={confirmDelete?.name}
+        primaryButtonText="Delete"
+        secondaryButtonText="Cancel"
+        onRequestClose={() => {
+          setConfirmDelete(null);
+        }}
+        onSecondarySubmit={() => {
+          setConfirmDelete(null);
+        }}
+        onRequestSubmit={() => {
+          deleteTeam.mutate({ path: { id: confirmDelete?.id ?? 0 } });
+        }}
+      >
+        <p>Are you sure you want to delete this team? This action cannot be undone.</p>
+      </Modal>
+    </>
+  );
+};

--- a/src/main/webui/src/app/context/AuthorizationContext.tsx
+++ b/src/main/webui/src/app/context/AuthorizationContext.tsx
@@ -1,11 +1,17 @@
+import type { Team } from '@client/types.gen.ts';
+
 import { createContext } from 'react';
 
 export interface AuthorizationContextInterface {
   isAdmin: boolean;
   isAuthenticated: boolean;
+  teams: Team[];
+  userId: number;
 }
 
 export const AuthorizationContext = createContext<AuthorizationContextInterface>({
   isAdmin: false,
   isAuthenticated: false,
+  teams: [],
+  userId: 0,
 });

--- a/src/main/webui/src/app/context/AuthorizationProvider.tsx
+++ b/src/main/webui/src/app/context/AuthorizationProvider.tsx
@@ -1,5 +1,5 @@
 import { AuthorizationContext } from '@app/context/AuthorizationContext.tsx';
-import { roleOptions } from '@client/@tanstack/react-query.gen.ts';
+import { currentUserOptions, userTeamsOptions } from '@client/@tanstack/react-query.gen.ts';
 import { client } from '@client/client.gen.ts';
 import { useQuery } from '@tanstack/react-query';
 import { ReactNode, useEffect } from 'react';
@@ -15,8 +15,14 @@ export const AuthorizationProvider = ({ children }: { children: ReactNode }) => 
     client.setConfig({ auth: isAuthenticated ? token : undefined });
   }, [token, isAuthenticated]);
 
-  const { data: role } = useQuery({
-    ...roleOptions(),
+  const { data: currentUser } = useQuery({
+    ...currentUserOptions(),
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000,
+  });
+
+  const { data: teams } = useQuery({
+    ...userTeamsOptions(),
     enabled: isAuthenticated,
     staleTime: 60 * 1000,
   });
@@ -24,8 +30,10 @@ export const AuthorizationProvider = ({ children }: { children: ReactNode }) => 
   return (
     <AuthorizationContext.Provider
       value={{
-        isAdmin: isAuthenticated && role === 'ADMIN',
+        isAdmin: isAuthenticated && currentUser?.role === 'ADMIN',
         isAuthenticated,
+        teams: teams ?? [],
+        userId: currentUser?.id ?? 0,
       }}
     >
       {children}

--- a/src/main/webui/src/app/context/useTeams.tsx
+++ b/src/main/webui/src/app/context/useTeams.tsx
@@ -1,0 +1,4 @@
+import { AuthorizationContext } from '@app/context/AuthorizationContext.tsx';
+import { useContext } from 'react';
+
+export const useTeams = () => useContext(AuthorizationContext).teams;

--- a/src/main/webui/src/app/layout/AppHeader.tsx
+++ b/src/main/webui/src/app/layout/AppHeader.tsx
@@ -1,4 +1,5 @@
 import { AuthActions } from '@app/layout/AuthActions.tsx';
+import { DOCS_IFRAME_STYLE, docsIframeSrc } from '@app/pages/SitePage';
 import { Help } from '@carbon/icons-react';
 import {
   Content,
@@ -18,8 +19,8 @@ import {
 } from '@carbon/react';
 import { listFoldersOptions } from '@client/@tanstack/react-query.gen.ts';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { Suspense, useCallback, useState } from 'react';
-import { Link, Outlet, useNavigate, useParams } from 'react-router-dom';
+import { ReactNode, Suspense, useCallback, useState } from 'react';
+import { Link, Outlet, useParams } from 'react-router-dom';
 
 const NavFolders = () => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
@@ -35,11 +36,14 @@ const NavFolders = () => {
   );
 };
 
-export const AppHeader = () => {
-  const navigate = useNavigate();
+export const AppHeader = ({ children }: { children?: ReactNode }) => {
   const [sideNavOpen, setSideNavOpen] = useState(false);
+  const [docsOpen, setDocsOpen] = useState(false);
   const toggleSideNav = useCallback(() => {
     setSideNavOpen((prev) => !prev);
+  }, []);
+  const toggleDocs = useCallback(() => {
+    setDocsOpen((prev) => !prev);
   }, []);
   return (
     <>
@@ -51,7 +55,7 @@ export const AppHeader = () => {
             Horreum
           </HeaderName>
           <HeaderGlobalBar>
-            <HeaderGlobalAction aria-label="Documentation" onClick={() => void navigate('/help')} tooltipAlignment="end">
+            <HeaderGlobalAction aria-label="Documentation" onClick={toggleDocs} isActive={docsOpen} tooltipAlignment="end">
               <Help size={24} />
             </HeaderGlobalAction>
             <AuthActions />
@@ -77,9 +81,24 @@ export const AppHeader = () => {
           </ErrorBoundary>
         </SideNav>
       </Theme>
-      <Content style={{ padding: 0 }}>
-        <Outlet />
-      </Content>
+      {children ?? (
+        <>
+          <Content>
+            <Outlet />
+          </Content>
+          <iframe
+            src={docsIframeSrc()}
+            title="Documentation"
+            style={{
+              ...DOCS_IFRAME_STYLE,
+              display: docsOpen ? 'block' : 'none',
+              position: 'fixed',
+              top: '3rem',
+              zIndex: 8000,
+            }}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/main/webui/src/app/layout/AuthActions.tsx
+++ b/src/main/webui/src/app/layout/AuthActions.tsx
@@ -1,6 +1,8 @@
 import { setAppNavigator } from '@app/context/navigation.tsx';
 import { useNotification } from '@app/context/useNotification.tsx';
-import { Login, Logout, UserAvatar } from '@carbon/icons-react';
+import { useRoles } from '@app/context/useRoles.tsx';
+import { useTeams } from '@app/context/useTeams.tsx';
+import { GroupAccess, Login, Logout, UserAvatar } from '@carbon/icons-react';
 import { HeaderGlobalAction, HeaderPanel, SideNavDivider, SideNavItems, SideNavLink, SideNavMenuItem } from '@carbon/react';
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from 'react-oidc-context';
@@ -8,6 +10,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 export const AuthActions = () => {
   const auth = useAuth();
+  const { isAdmin } = useRoles();
+  const teams = useTeams();
   const location = useLocation();
   const navigate = useNavigate();
   const { warning, handleError } = useNotification();
@@ -78,10 +82,42 @@ export const AuthActions = () => {
       <HeaderPanel aria-label="User panel" expanded={panelOpen}>
         <SideNavItems>
           <SideNavMenuItem>{username}</SideNavMenuItem>
-          <SideNavDivider />
           <SideNavLink renderIcon={Logout} onClick={handleLogout}>
             Logout
           </SideNavLink>
+          {teams.length !== 0 && (
+            <>
+              <SideNavDivider />
+              <SideNavMenuItem>Team Management</SideNavMenuItem>
+              {teams.map((t) => (
+                <SideNavLink
+                  key={t.id}
+                  renderIcon={GroupAccess}
+                  onClick={() => {
+                    setPanelOpen(false);
+                    void navigate(`/team/${String(t.id)}`);
+                  }}
+                >
+                  {t.name}
+                </SideNavLink>
+              ))}
+            </>
+          )}
+          {isAdmin && (
+            <>
+              <SideNavDivider />
+              <SideNavMenuItem>Administration</SideNavMenuItem>
+              <SideNavLink
+                renderIcon={GroupAccess}
+                onClick={() => {
+                  setPanelOpen(false);
+                  void navigate('/teams');
+                }}
+              >
+                Teams
+              </SideNavLink>
+            </>
+          )}
         </SideNavItems>
       </HeaderPanel>
     </>

--- a/src/main/webui/src/app/pages/SitePage.tsx
+++ b/src/main/webui/src/app/pages/SitePage.tsx
@@ -1,0 +1,23 @@
+import { AppHeader } from '@app/layout/AppHeader';
+import { Content } from '@carbon/react';
+import { CSSProperties } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export const DOCS_IFRAME_STYLE: CSSProperties = { display: 'block', border: 'none', width: '100%', height: 'calc(100vh - 3rem)' };
+
+export const docsIframeSrc = (pathname = '', hash = '') => {
+  const path = pathname.replace(/^\/help\/?/, '');
+  const needsSlash = path && !path.endsWith('/') && !path.includes('.');
+  return `/site/docs/${path}${needsSlash ? '/' : ''}${hash}`;
+};
+
+export const SitePage = () => {
+  const { pathname, hash } = useLocation();
+  return (
+    <AppHeader>
+      <Content style={{ padding: 0 }}>
+        <iframe src={docsIframeSrc(pathname, hash)} title="Documentation" style={DOCS_IFRAME_STYLE} />
+      </Content>
+    </AppHeader>
+  );
+};

--- a/src/main/webui/src/app/pages/TeamManagementPage.tsx
+++ b/src/main/webui/src/app/pages/TeamManagementPage.tsx
@@ -1,0 +1,19 @@
+import { TeamMembersPanel } from '@app/components/team/TeamMembersPanel';
+import { ErrorBoundary, InlineLoading, SkeletonText } from '@carbon/react';
+import { listTeamsOptions } from '@client/@tanstack/react-query.gen.ts';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Suspense } from 'react';
+import { useParams } from 'react-router-dom';
+
+export const TeamManagementPage = () => {
+  const { teamId } = useParams();
+  const { data: teams } = useSuspenseQuery(listTeamsOptions());
+  const team = teams.find((t) => t.id === Number(teamId));
+  return (
+    <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load team" />}>
+      <Suspense fallback={<SkeletonText paragraph lineCount={5} />}>
+        {team ? <TeamMembersPanel team={team} /> : <InlineLoading status="error" description="Team not found" />}
+      </Suspense>
+    </ErrorBoundary>
+  );
+};

--- a/src/main/webui/src/app/pages/TeamsPage.tsx
+++ b/src/main/webui/src/app/pages/TeamsPage.tsx
@@ -1,0 +1,32 @@
+import type { Team } from '@client/types.gen.ts';
+
+import { TeamMembersPanel } from '@app/components/team/TeamMembersPanel.tsx';
+import { TeamsPanel } from '@app/components/team/TeamsPanel.tsx';
+import { Column, ErrorBoundary, Grid, InlineLoading, InlineNotification, SkeletonText } from '@carbon/react';
+import { Suspense, useState } from 'react';
+
+export const TeamsPage = () => {
+  const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+  return (
+    <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load teams" />}>
+      <Suspense fallback={<SkeletonText paragraph lineCount={5} />}>
+        <Grid fullWidth className="page-grid">
+          <Column lg={5} md={3} sm={4}>
+            <TeamsPanel onSelect={setSelectedTeam} />
+          </Column>
+          <Column lg={11} md={5} sm={4}>
+            {selectedTeam ? (
+              <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load members" />}>
+                <Suspense fallback={<SkeletonText paragraph lineCount={5} />}>
+                  <TeamMembersPanel key={selectedTeam.id} team={selectedTeam} />
+                </Suspense>
+              </ErrorBoundary>
+            ) : (
+              <InlineNotification kind="info" lowContrast hideCloseButton title="Select a team to manage members" />
+            )}
+          </Column>
+        </Grid>
+      </Suspense>
+    </ErrorBoundary>
+  );
+};

--- a/src/main/webui/src/app/routes.ts
+++ b/src/main/webui/src/app/routes.ts
@@ -1,10 +1,16 @@
 import { AppHeader } from '@app/layout/AppHeader';
 import { DashboardPage } from '@app/pages/DashboardPage';
 import { FolderPage } from '@app/pages/FolderPage';
-import { createElement } from 'react';
+import { SitePage } from '@app/pages/SitePage';
+import { TeamManagementPage } from '@app/pages/TeamManagementPage';
+import { TeamsPage } from '@app/pages/TeamsPage';
 import { createBrowserRouter } from 'react-router-dom';
 
 const router = createBrowserRouter([
+  {
+    Component: SitePage,
+    path: '/help/*',
+  },
   {
     Component: AppHeader,
     path: '/',
@@ -14,17 +20,16 @@ const router = createBrowserRouter([
         index: true,
       },
       {
-        Component: () =>
-          createElement('iframe', {
-            src: '/site/docs/',
-            title: 'Documentation',
-            style: { display: 'block', border: 'none', width: '100%', height: 'calc(100vh - 3rem)' },
-          }),
-        path: 'help',
-      },
-      {
         Component: FolderPage,
         path: 'folder/:folderId',
+      },
+      {
+        Component: TeamManagementPage,
+        path: 'team/:teamId',
+      },
+      {
+        Component: TeamsPage,
+        path: 'teams',
       },
     ],
   },

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/AuthorizationServiceTest.java
@@ -54,7 +54,7 @@ public class AuthorizationServiceTest extends FreshDb {
     @Test
     @Transactional
     void canModifyFolder_returns_true_for_team_member() {
-        long teamId = teamService.create("dev");
+        long teamId = teamService.create("dev").id();
         long userId = userService.create("alice", Role.USER);
         teamService.addMember(teamId, userId);
 
@@ -69,7 +69,7 @@ public class AuthorizationServiceTest extends FreshDb {
     @Test
     @Transactional
     void canModifyFolder_returns_false_for_non_member() {
-        long teamId = teamService.create("dev");
+        long teamId = teamService.create("dev").id();
         userService.create("outsider", Role.USER);
 
         FolderEntity folder = new FolderEntity();
@@ -83,7 +83,7 @@ public class AuthorizationServiceTest extends FreshDb {
     @Test
     @Transactional
     void canModifyFolder_returns_true_for_admin() {
-        long teamId = teamService.create("dev");
+        long teamId = teamService.create("dev").id();
         userService.create("boss", Role.ADMIN);
 
         FolderEntity folder = new FolderEntity();
@@ -109,7 +109,7 @@ public class AuthorizationServiceTest extends FreshDb {
     @Test
     @Transactional
     void requireFolderModify_throws_for_non_member() {
-        long teamId = teamService.create("dev");
+        long teamId = teamService.create("dev").id();
         userService.create("outsider", Role.USER);
 
         FolderEntity folder = new FolderEntity();

--- a/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
+++ b/src/test/java/io/hyperfoil/tools/h5m/svc/TeamServiceTest.java
@@ -24,7 +24,7 @@ public class TeamServiceTest extends FreshDb {
 
     @Test
     void create_team() {
-        long id = teamService.create("test-team");
+        long id = teamService.create("test-team").id();
         assertTrue(id > 0);
         Team team = teamService.find("test-team");
         assertNotNull(team);
@@ -41,7 +41,7 @@ public class TeamServiceTest extends FreshDb {
 
     @Test
     void delete_team() {
-        long id = teamService.create("to-delete");
+        long id = teamService.create("to-delete").id();
         assertNotNull(teamService.find("to-delete"));
         teamService.delete(id);
         assertNull(teamService.find("to-delete"));
@@ -50,20 +50,20 @@ public class TeamServiceTest extends FreshDb {
     @Test
     @Transactional
     void add_member() {
-        long teamId = teamService.create("dev-team");
+        long teamId = teamService.create("dev-team").id();
         long userId = userService.create("alice", Role.USER);
         teamService.addMember(teamId, userId);
 
         TeamEntity teamEntity = TeamEntity.findById(teamId);
         assertNotNull(teamEntity);
         assertEquals(1, teamEntity.members.size());
-        assertEquals("alice", teamEntity.members.get(0).username);
+        assertEquals("alice", teamEntity.members.iterator().next().username);
     }
 
     @Test
     @Transactional
     void remove_member() {
-        long teamId = teamService.create("dev-team");
+        long teamId = teamService.create("dev-team").id();
         long userId = userService.create("bob", Role.USER);
         teamService.addMember(teamId, userId);
 
@@ -78,7 +78,7 @@ public class TeamServiceTest extends FreshDb {
     @Test
     @Transactional
     void add_member_is_idempotent() {
-        long teamId = teamService.create("dev-team");
+        long teamId = teamService.create("dev-team").id();
         long userId = userService.create("carol", Role.USER);
         teamService.addMember(teamId, userId);
         teamService.addMember(teamId, userId);


### PR DESCRIPTION
Adds end-to-end team management — REST API, services, and web UI — letting admins create, rename, and delete teams and manage membership.

Backend
- `TeamResource` endpoints for team CRUD and member `add`/`remove`/`list`, backed by `TeamService`/`UserService`.
- Team-scoped authorization wiring.
- Use constants for the defined `Role` (like in `H5mRolesAugmentor`, `AuthorizationService`); tests updated.

Web UI
- `TeamsPanel`, `TeamMembersPanel`, and `TeamNameModal` for managing teams and members, wired into routing, header, and auth context.
- Small tweaks on how the documentation `iframe` is displayed. Allow for direct links to docs.
