### PR TITLE
Notification UI

### DIFF
--- a/src/main/webui/src/app/components/Notification/AddNotificationConfig.tsx
+++ b/src/main/webui/src/app/components/Notification/AddNotificationConfig.tsx
@@ -1,0 +1,106 @@
+import {
+  Button,
+  MenuButton,
+  MenuItem,
+  StructuredListBody,
+  StructuredListCell,
+  StructuredListHead,
+  StructuredListRow,
+  StructuredListWrapper,
+  Tag,
+} from '@carbon/react';
+import { useState } from 'react';
+import { listConfigsOptions } from '@client/@tanstack/react-query.gen';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import type { NotificationConfigResponse } from '@client/types.gen';
+import CreateNotificationModal from '@app/components/Notification/CreateNotificationModal';
+import DeleteNotiConfigModal from '@app/components/Notification/DeleteNotiConfigModal';
+import EditNotiConfigModal from '@app/components/Notification/EditNotiConfigModal';
+
+function getDestination(config: NotificationConfigResponse): string {
+  if (!config.data) return '';
+  try {
+    const parsed = JSON.parse(config.data);
+    switch (config.method) {
+      case 'WEBHOOK': return parsed.url ?? '';
+      case 'EMAIL': return parsed.to ?? '';
+      case 'SLACK': return parsed.channel ?? '';
+      case 'GITHUB_ISSUE': return `${parsed.owner ?? ''}/${parsed.repo ?? ''}`;
+      default: return '';
+    }
+  } catch {
+    return config.data;
+  }
+}
+
+export default function AddNotificationConfig({ folderId }: { folderId: number }){
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [configToDelete, setConfigToDelete] = useState<NotificationConfigResponse | null>(null);
+  const [configToEdit, setConfigToEdit] = useState<NotificationConfigResponse | null>(null);
+
+
+  const { data: configs } = useSuspenseQuery(listConfigsOptions({ query: { folderId } }));
+
+  return(
+      <>
+        <Button
+          kind="primary"
+          size="md"
+          onClick={() => setIsCreateOpen(true)}
+          className="create-notification-btn"
+          style={{ margin: 'var(--cds-spacing-05)' }}>
+          Create Notification Config
+          </Button>
+        <CreateNotificationModal
+          open={isCreateOpen}
+          onClose={() => setIsCreateOpen(false)}
+          folderId={folderId}
+        />
+         <DeleteNotiConfigModal
+          open={configToDelete !== null}
+          onClose={() => setConfigToDelete(null)}
+          config={configToDelete}
+         />
+         <EditNotiConfigModal
+          open={configToEdit !==null}
+          onClose={()=>setConfigToEdit(null)}
+          config={configToEdit}
+         />
+        {configs.length === 0 ? (
+          <p style={{ margin: 'var(--cds-spacing-05)' }}>No notifications configured</p>
+        ) : (
+        <StructuredListWrapper>
+          <StructuredListHead>
+            <StructuredListRow head>
+              <StructuredListCell head>Method</StructuredListCell>
+              <StructuredListCell head>Enabled</StructuredListCell>
+              <StructuredListCell head>Destination</StructuredListCell>
+              <StructuredListCell head />
+            </StructuredListRow>
+          </StructuredListHead>
+          <StructuredListBody>
+            {configs?.map((config: NotificationConfigResponse) => (
+              <StructuredListRow key={config.id}>
+                <StructuredListCell>
+                  <Tag size="sm">{config.method}</Tag>
+                </StructuredListCell>
+                <StructuredListCell>
+                  {config.enabled ? 'Yes' : 'No'}
+                </StructuredListCell>
+                <StructuredListCell>
+                  {getDestination(config)}
+                </StructuredListCell>
+                <StructuredListCell>
+                  <MenuButton label="Action" kind="ghost" size="sm" menuAlignment="bottom-end">
+                    <MenuItem label="Delete" kind="danger" onClick={() => setConfigToDelete(config) } />
+                    <MenuItem label="Edit" onClick={()=> setConfigToEdit(config) } />
+                  </MenuButton>
+                </StructuredListCell>
+              </StructuredListRow>
+            ))}
+          </StructuredListBody>
+        </StructuredListWrapper>
+        )}
+      </>
+    );
+  }

--- a/src/main/webui/src/app/components/Notification/CreateNotificationModal.tsx
+++ b/src/main/webui/src/app/components/Notification/CreateNotificationModal.tsx
@@ -1,0 +1,333 @@
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
+import { useNotification } from '@app/context/useNotification.tsx';
+import { fieldError } from '@app/validation.ts';
+import {
+  Button,
+  ComposedModal,
+  Form,
+  InlineNotification,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Select,
+  SelectItem,
+  Stack,
+  TextInput,
+} from '@carbon/react';
+import { createConfigMutation } from '@client/@tanstack/react-query.gen';
+import { zNotificationMethod } from '@client/zod.gen.ts';
+import { useForm, useSelector } from '@tanstack/react-form';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { NotificationMethod } from '@client/types.gen';
+import { useState } from 'react';
+import { z } from 'zod';
+
+interface CreateNotificationModalProps {
+  open: boolean;
+  onClose: () => void;
+  folderId: number;
+}
+
+interface FormValues {
+  method: string;
+  url: string;
+  auth: string;
+  recipients: string;
+  subject: string;
+  channel: string;
+  slackToken: string;
+  repo: string;
+  owner: string;
+  title: string;
+  label: string;
+  githubToken: string;
+}
+
+const DEFAULT_VALUES: FormValues = {
+  method: '',
+  url: '',
+  auth: '',
+  recipients: '',
+  subject: '',
+  channel: '',
+  slackToken: '',
+  repo: '',
+  owner: '',
+  title: '',
+  label: '',
+  githubToken: '',
+};
+
+const required = z.string().min(1, 'Required');
+
+export default function CreateNotificationModal({ open, onClose, folderId }: CreateNotificationModalProps) {
+  const notifications = useNotification();
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const createConfig = useMutation({
+    ...createConfigMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+      notifications.success('Notification Config created');
+      handleClose();
+    },
+    onError: (e) => {
+      setSubmitError(extractErrorMessage(e) ?? 'Failed to create Notification config');
+    },
+  });
+
+  const form = useForm({
+    defaultValues: DEFAULT_VALUES,
+    onSubmit: ({ value }) => {
+      setSubmitError(null);
+      let requestBody = {};
+      let secretData = '';
+
+      switch (value.method) {
+        case 'WEBHOOK':
+          requestBody = { url: value.url };
+          secretData = value.auth;
+          break;
+        case 'EMAIL':
+          requestBody = { to: value.recipients, subject: value.subject };
+          break;
+        case 'SLACK':
+          requestBody = { channel: value.channel };
+          secretData = value.slackToken;
+          break;
+        case 'GITHUB_ISSUE':
+          requestBody = { repo: value.repo, owner: value.owner, title: value.title, label: value.label };
+          secretData = value.githubToken;
+          break;
+      }
+
+      createConfig.mutate({
+        query: { folderId, method: value.method as NotificationMethod, name: undefined, secrets: secretData },
+        body: JSON.stringify(requestBody),
+      });
+    },
+  });
+
+  const method = useSelector(form.store, (s) => s.values.method);
+
+  const handleClose = () => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  };
+
+  return (
+    <ComposedModal open={open} onClose={handleClose}>
+      <ModalHeader title="Create Notification" closeModal={handleClose} />
+      <ModalBody>
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <Stack gap={6}>
+            <p style={{ marginBottom: '1rem' }}>Configure your new notification here.</p>
+
+            <form.Field name="method" validators={{ onSubmit: zNotificationMethod }}>
+              {(field) => (
+                <Select
+                  id="config"
+                  labelText="Method"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  invalid={field.state.meta.errors.length > 0}
+                  invalidText={fieldError(field.state.meta.errors)}
+                >
+                  <SelectItem value="" text="Choose an option" disabled hidden />
+                  <SelectItem value="WEBHOOK" text="Web Hook" />
+                  <SelectItem value="EMAIL" text="Email" />
+                  <SelectItem value="SLACK" text="Slack" />
+                  <SelectItem value="GITHUB_ISSUE" text="Github Issue" />
+                </Select>
+              )}
+            </form.Field>
+
+            {method === 'WEBHOOK' && (
+              <>
+                <form.Field name="url" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="url-name"
+                      type="url"
+                      labelText="Url (required)"
+                      placeholder="e.g. 'Http / Https '"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="auth">
+                  {(field) => (
+                    <TextInput
+                      id="Auth-name"
+                      labelText="Auth (optional)"
+                      placeholder="e.g. jascjsa"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+              </>
+            )}
+
+            {method === 'EMAIL' && (
+              <>
+                <form.Field name="recipients" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="Recipients-name"
+                      type="email"
+                      labelText="Recipients (required)"
+                      placeholder="e.g. abcd@example.com"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="subject">
+                  {(field) => (
+                    <TextInput
+                      id="subject-name"
+                      labelText="Subject (optional)"
+                      placeholder="e.g. Regression detected for abcd node"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+              </>
+            )}
+
+            {method === 'SLACK' && (
+              <>
+                <form.Field name="channel" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="Channel-name"
+                      labelText="Channel (required)"
+                      placeholder="e.g. #alerts"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="slackToken" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="token-name"
+                      labelText="Secret (required)"
+                      placeholder="e.g. ***"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+              </>
+            )}
+
+            {method === 'GITHUB_ISSUE' && (
+              <>
+                <form.Field name="repo" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="Repo-name"
+                      labelText="Repo (required)"
+                      placeholder="e.g. test github repo"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="owner" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="owner-name"
+                      labelText="Owner (required)"
+                      placeholder="e.g. Owner name"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="title">
+                  {(field) => (
+                    <TextInput
+                      id="title-name"
+                      labelText="Title (optional)"
+                      placeholder="e.g. Regression detected"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="label">
+                  {(field) => (
+                    <TextInput
+                      id="Label-name"
+                      labelText="Label (optional)"
+                      placeholder="e.g. bug"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  )}
+                </form.Field>
+                <form.Field name="githubToken" validators={{ onSubmit: required, onBlur: required }}>
+                  {(field) => (
+                    <TextInput
+                      id="github-token-name"
+                      labelText="Token (required)"
+                      placeholder="e.g. ***"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      invalid={field.state.meta.errors.length > 0}
+                      invalidText={fieldError(field.state.meta.errors)}
+                    />
+                  )}
+                </form.Field>
+              </>
+            )}
+
+            {submitError && (
+              <InlineNotification
+                kind="error"
+                lowContrast
+                title="Failed to create notification"
+                subtitle={submitError}
+                onCloseButtonClick={() => setSubmitError(null)}
+              />
+            )}
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button kind="primary" disabled={createConfig.isPending} onClick={() => void form.handleSubmit()}>
+          {createConfig.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+}

--- a/src/main/webui/src/app/components/Notification/DeleteNotiConfigModal.tsx
+++ b/src/main/webui/src/app/components/Notification/DeleteNotiConfigModal.tsx
@@ -1,0 +1,66 @@
+import { Modal } from '@carbon/react';
+import { deleteConfigMutation } from '@client/@tanstack/react-query.gen.ts';
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
+import { useNotification } from '@app/context/useNotification.tsx';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { NotificationConfigResponse } from '@client/types.gen';
+import { useState } from 'react';
+
+interface DeleteNotiConfigModalProps {
+  open: boolean;
+  onClose: () => void;
+  config: NotificationConfigResponse | null;
+}
+
+export default function DeleteNotiConfigModal({ open, onClose, config }: DeleteNotiConfigModalProps){
+  const queryClient = useQueryClient();
+  const notifications = useNotification();
+  const [error, setError] = useState<string | null>(null);
+
+   const deleteConfig = useMutation({
+      ...deleteConfigMutation(),
+      onSuccess: () => {
+        void queryClient.invalidateQueries();
+        notifications.success('Notification config deleted');
+        handleClose();
+      },
+      onError: (e) => {
+        notifications.error(extractErrorMessage(e) ?? 'Failed to delete notification config');
+      },
+    });
+  const handleDelete = ()=>{
+    if (!config?.id) return;
+    deleteConfig.mutate({ path: { id: config.id } })
+    }
+
+  const handleClose = ()=>{
+    setError('');
+    onClose();
+    };
+
+  return (
+    <Modal
+      open={open}
+      danger
+      modalHeading="Delete config"
+      modalLabel={config?.name ?? ''}
+      primaryButtonText={deleteConfig.isPending ? 'Deleting…' : 'Delete'}
+      secondaryButtonText="Cancel"
+      primaryButtonDisabled={deleteConfig.isPending}
+      onRequestSubmit={handleDelete}
+      onRequestClose={() => { setError(null); handleClose(); }}
+    >
+      <p>
+        Are you sure you want to delete <strong>{config?.name}</strong>?
+      </p>
+      <p style={{ marginTop: '0.75rem', color: 'var(--cds-text-secondary)' }}>
+         This action cannot be undone.
+      </p>
+      {error && (
+        <p style={{ marginTop: '0.75rem', color: 'var(--cds-support-error)' }}>
+          {error}
+        </p>
+      )}
+    </Modal>
+  );
+}

--- a/src/main/webui/src/app/components/Notification/EditNotiConfigModal.tsx
+++ b/src/main/webui/src/app/components/Notification/EditNotiConfigModal.tsx
@@ -1,0 +1,175 @@
+import { extractErrorMessage } from '@app/context/NotificationProvider.tsx';
+import { useNotification } from '@app/context/useNotification.tsx';
+import { fieldError } from '@app/validation.ts';
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  ComposedModal,
+  Form,
+  InlineNotification,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  Stack,
+  TextInput,
+  Toggle,
+} from '@carbon/react';
+import { updateConfigMutation } from '@client/@tanstack/react-query.gen';
+import { useForm } from '@tanstack/react-form';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { NotificationConfigResponse } from '@client/types.gen';
+import { z } from 'zod';
+
+interface EditNotiConfigModalProps {
+  open: boolean;
+  onClose: () => void;
+  config: NotificationConfigResponse | null;
+}
+
+interface FormValues {
+  enabled: boolean;
+  destination: string;
+}
+
+const DEFAULT_VALUES: FormValues = {
+  enabled: true,
+  destination: '',
+};
+
+const required = z.string().min(1, 'Required');
+
+function destinationKey(method?: string): string {
+  switch (method) {
+    case 'WEBHOOK': return 'url';
+    case 'EMAIL': return 'to';
+    case 'SLACK': return 'channel';
+    case 'GITHUB_ISSUE': return 'repo';
+    default: return 'to';
+  }
+}
+
+function destinationLabel(method?: string): string {
+  switch (method) {
+    case 'WEBHOOK': return 'URL (required)';
+    case 'EMAIL': return 'Recipients (required)';
+    case 'SLACK': return 'Channel (required)';
+    case 'GITHUB_ISSUE': return 'Repository (required)';
+    default: return 'Destination (required)';
+  }
+}
+
+export default function EditNotiConfigModal({ open, onClose, config }: EditNotiConfigModalProps) {
+  const notifications = useNotification();
+  const queryClient = useQueryClient();
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const editConfig = useMutation({
+    ...updateConfigMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries();
+      notifications.success('Notification config updated');
+      handleClose();
+    },
+    onError: (e) => {
+      setSubmitError(extractErrorMessage(e) ?? 'Failed to update notification config');
+    },
+  });
+
+  const form = useForm({
+    defaultValues: DEFAULT_VALUES,
+    onSubmit: ({ value }) => {
+      if (!config?.id) return;
+      setSubmitError(null);
+      const key = destinationKey(config.method);
+      let body: string;
+      try {
+        const parsed = JSON.parse(config.data ?? '{}');
+        parsed[key] = value.destination;
+        body = JSON.stringify(parsed);
+      } catch {
+        body = JSON.stringify({ [key]: value.destination });
+      }
+      editConfig.mutate({
+        path: { id: config.id },
+        query: { enabled: value.enabled },
+        body,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (open && config) {
+      form.setFieldValue('enabled', config.enabled ?? true);
+      try {
+        const parsed = JSON.parse(config.data ?? '');
+        const key = destinationKey(config.method);
+        form.setFieldValue('destination', parsed[key] ?? '');
+      } catch {
+        form.setFieldValue('destination', config.data ?? '');
+      }
+    }
+  }, [open, config]);
+
+  const handleClose = () => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  };
+
+  return (
+    <ComposedModal open={open} onClose={handleClose}>
+      <ModalHeader title="Edit Notification" />
+      <ModalBody>
+        <Form onSubmit={(e) => e.preventDefault()}>
+          <Stack gap={6}>
+            <form.Field name="enabled">
+              {(field) => (
+                <Toggle
+                  id="edit-enabled-toggle"
+                  labelA="Off"
+                  labelB="On"
+                  labelText="Enabled"
+                  toggled={field.state.value}
+                  onToggle={(checked) => field.handleChange(checked)}
+                />
+              )}
+            </form.Field>
+
+            <form.Field name="destination" validators={{ onSubmit: required, onBlur: required }}>
+              {(field) => (
+                <TextInput
+                  id="edit-destination-name"
+                  type={config?.method === 'WEBHOOK' ? 'url' : config?.method === 'EMAIL' ? 'email' : 'text'}
+                  labelText={destinationLabel(config?.method)}
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                  invalid={field.state.meta.errors.length > 0}
+                  invalidText={fieldError(field.state.meta.errors)}
+                />
+              )}
+            </form.Field>
+
+            {submitError && (
+              <InlineNotification
+                kind="error"
+                lowContrast
+                title="Failed to update notification"
+                subtitle={submitError}
+                onCloseButtonClick={() => setSubmitError(null)}
+              />
+            )}
+          </Stack>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button kind="secondary" onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button kind="primary" disabled={editConfig.isPending} onClick={() => void form.handleSubmit()}>
+          {editConfig.isPending ? 'Saving...' : 'Save'}
+        </Button>
+      </ModalFooter>
+    </ComposedModal>
+  );
+}

--- a/src/main/webui/src/app/pages/FolderPage.tsx
+++ b/src/main/webui/src/app/pages/FolderPage.tsx
@@ -31,6 +31,7 @@ import '@app/pages/DashboardPage.css';
 import { CreateNodeModal } from '@app/components/CreateNodeModal';
 import { DeleteNodeModal } from '@app/components/DeleteNodeModal';
 import { EditNodeModal } from '@app/components/EditNodeModal';
+import  AddNotificationConfig  from '@app/components/Notification/AddNotificationConfig';
 
 const NodesTab = ({ groupId }: { groupId: number }) => {
   const { data: nodeGroup } = useSuspenseQuery(byIdOptions({ path: { id: groupId } }));
@@ -148,7 +149,7 @@ const GraphVisualizer = ({ groupId }: { groupId: number }) => {
   );
 };
 
-const TAB_ANCHORS = ['data', 'nodes', 'graph'];
+const TAB_ANCHORS = ['data', 'nodes', 'graph','Notification'];
 
 const FolderContent = ({ folderId }: { folderId: number }) => {
   const { data: folders } = useSuspenseQuery(listFoldersOptions());
@@ -168,6 +169,7 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
         <Tab>Data</Tab>
         <Tab>Nodes</Tab>
         <Tab>Graph</Tab>
+        <Tab>Notification</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>
@@ -199,6 +201,17 @@ const FolderContent = ({ folderId }: { folderId: number }) => {
             <p>No node group associated with this folder</p>
           )}
         </TabPanel>
+       <TabPanel>
+         {folder.id != null ? (
+           <ErrorBoundary fallback={<InlineLoading status="error" description="Failed to load Notifications" />}>
+            <Suspense fallback={<SkeletonText paragraph={true} lineCount={5} />}>
+              <AddNotificationConfig folderId={folder.id} />
+                </Suspense>
+           </ErrorBoundary>
+                 ) : (
+                   <p>No notification config associated with this folder</p>
+                 )}
+               </TabPanel>
       </TabPanels>
     </Tabs>
   );


### PR DESCRIPTION
Add notification config UI — create, edit, and delete notification configurations

Adds a Notification Config tab to the folder page with CRUD modals for managing notification configs (Webhook, Email, Slack, GitHub Issue). 