### PR TITLE
move REST prefix to quarkus.rest.path property

### DIFF
--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ApiKeyResource.java
@@ -17,7 +17,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
-@Path("/api/apikey")
+@Path("/apikey")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "API Key", description = "Manage API keys for authentication")
 public class ApiKeyResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/FolderResource.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
 import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 import static java.nio.file.Files.readAllBytes;
 
-@Path("/api/folder")
+@Path("/folder")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Folder", description = "Manage folders for uploaded data")
 public class FolderResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeGroupResource.java
@@ -10,7 +10,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-@Path("/api/group")
+@Path("/group")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "NodeGroup", description = "Manage node groups (transformation pipelines)")
 public class NodeGroupResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NodeResource.java
@@ -34,7 +34,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import java.util.List;
 import java.util.Objects;
 
-@Path("/api/node")
+@Path("/node")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Node", description = "Manage transformation nodes in the DAG pipeline")
 public class NodeResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/NotificationResource.java
@@ -21,7 +21,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
-@Path("/api/notification")
+@Path("/notification")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Notification", description = "Manage notification configurations for change detection")
 public class NotificationResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ProcessingResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ProcessingResource.java
@@ -9,7 +9,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-@Path("/api/processing")
+@Path("/processing")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Processing", description = "Track processing status for uploads and recalculations")
 public class ProcessingResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/UserResource.java
@@ -15,7 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
-@Path("/api/user")
+@Path("/user")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "User", description = "User and role information")
 public class UserResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ValueResource.java
@@ -15,7 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
-@Path("/api/value")
+@Path("/value")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "Value", description = "Manage computed values produced by nodes")
 public class ValueResource {

--- a/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
+++ b/src/main/java/io/hyperfoil/tools/h5m/rest/ViewResource.java
@@ -15,7 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import java.util.List;
 
-@Path("/api/folder/{folderId}/view")
+@Path("/folder/{folderId}/view")
 @Produces(MediaType.APPLICATION_JSON)
 @Tag(name = "View", description = "Manage views for folder data presentation")
 public class ViewResource {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -72,9 +72,11 @@ quarkus.package.jar.type=fast-jar
 quarkus.smallrye-openapi.operation-id-strategy=method
 quarkus.smallrye-openapi.store-schema-directory=src/main/webui/
 
+# REST endpoints mounted under /api so the SPA fallback owns the root paths
+quarkus.rest.path=/api
+
 # quinoa
 quarkus.quinoa.enable-spa-routing=true
-quarkus.quinoa.ignored-path-prefixes=/api
 quarkus.quinoa.dev-server.direct-forwarding=true
 
 # aesh configuration: runtime for commands, console for REPL


### PR DESCRIPTION
## Root cause

The JAX-RS application was mounted at the HTTP root (`quarkus.rest.path` unset), so RESTEasy owned every path and answered `/folder/1` with its own `404` before Quinoa's (deliberately late-ordered) SPA fallback could reroute it to `index.html`. 

Dev masked this because `quarkus.quinoa.dev-server.direct-forwarding=true` forwards non-`/api` requests to the Vite dev server, which serves `index.html` for any route.
With REST now under `/api`, `direct-forwarding=true` is the correct setting: it gives consistent behavior across `%dev` and `%prod`. 
When `false`, Quinoa falls back to a heuristic to decide whether to handle or proxy each request: a heuristic that only exists in dev, so it introduced a dev/prod divergence.

## Fix

- Set `quarkus.rest.path=/api` so REST is confined to `/api/*`, leaving root paths to the SPA fallback.
- Stripped the now-redundant `/api` prefix from the REST resources `@Path` annotations.
- Removed `quarkus.quinoa.ignored-path-prefixes=/api` as Quinoa now auto-derives the ignore list (`/api`, `/q`) from `quarkus.rest.path`.

## Verification

- Generated `openapi.yaml` (path keys unchanged: `/api` folds into the paths, not `servers`, so the generated client is unaffected).
- Confirmed on a production build: `/folder/1` -> `200` (serves `index.html`), `/api/folder` -> `200`, `/q/health` -> `200`.

Note: `quarkus.rest.path` is build-time so requires a rebuild to take effect.